### PR TITLE
Only fetch connection header once

### DIFF
--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -30,7 +30,7 @@ defmodule Bandit.HTTP1.Adapter do
         body_size = get_header(headers, "content-length")
         body_encoding = get_header(headers, "transfer-encoding")
         connection = get_header(headers, "connection")
-        keepalive = should_keepalive?(version, headers)
+        keepalive = should_keepalive?(version, connection)
 
         case {body_size, body_encoding} do
           {nil, nil} ->
@@ -102,11 +102,11 @@ defmodule Bandit.HTTP1.Adapter do
     end
   end
 
-  defp should_keepalive?(version, headers) do
+  defp should_keepalive?(version, connection_header) do
     cond do
-      get_header(headers, "connection") |> is_nil -> version == :"HTTP/1.1"
-      get_header(headers, "connection") |> String.match?(~r/^keep-alive$/i) -> true
-      get_header(headers, "connection") |> String.match?(~r/^close$/i) -> false
+      is_nil(connection_header) -> version == :"HTTP/1.1"
+      String.match?(connection_header, ~r/^keep-alive$/i) -> true
+      String.match?(connection_header, ~r/^close$/i) -> false
       version == :"HTTP/1.1" -> true
       true -> false
     end


### PR DESCRIPTION
Hi! Thanks a lot for this very interesting project (and video)! :heart:

As I was reading the code, I noticed the `connection` header was being fetched 4 times, but it seems it can be reused after being fetched the first time.

It probably doesn't have much performance impact, but I thought I could still suggest it. What do you think?