### PR TITLE
Avoid regex matching in `should_keepalive?/2`

### DIFF
--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -102,7 +102,7 @@ defmodule Bandit.HTTP1.Adapter do
     end
   end
 
-  # If we do not have a connection header, then keep alive if we're running on HTTP/1.1
+  # If we do not have a connection header, then keep alive iff we're running on HTTP/1.1
   defp should_keepalive?(version, nil), do: version == :"HTTP/1.1"
 
   defp should_keepalive?(version, connection_header) do

--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -102,8 +102,8 @@ defmodule Bandit.HTTP1.Adapter do
     end
   end
 
-  defp should_keepalive?(:"HTTP/1.1", nil), do: true
-  defp should_keepalive?(_, nil), do: false
+    # If we do not have a connection header, then keep alive iff we're running on HTTP/1.1
+    defp should_keepalive?(version, nil), do: version == :"HTTP/1.1"
 
   defp should_keepalive?(version, connection_header) do
     case String.downcase(connection_header) do

--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -102,13 +102,14 @@ defmodule Bandit.HTTP1.Adapter do
     end
   end
 
+  defp should_keepalive?(:"HTTP/1.1", nil), do: true
+  defp should_keepalive?(_, nil), do: false
+
   defp should_keepalive?(version, connection_header) do
-    cond do
-      is_nil(connection_header) -> version == :"HTTP/1.1"
-      String.match?(connection_header, ~r/^keep-alive$/i) -> true
-      String.match?(connection_header, ~r/^close$/i) -> false
-      version == :"HTTP/1.1" -> true
-      true -> false
+    case String.downcase(connection_header) do
+      "keep-alive" -> true
+      "close" -> false
+      _ -> version == :"HTTP/1.1"
     end
   end
 

--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -102,8 +102,8 @@ defmodule Bandit.HTTP1.Adapter do
     end
   end
 
-    # If we do not have a connection header, then keep alive iff we're running on HTTP/1.1
-    defp should_keepalive?(version, nil), do: version == :"HTTP/1.1"
+  # If we do not have a connection header, then keep alive if we're running on HTTP/1.1
+  defp should_keepalive?(version, nil), do: version == :"HTTP/1.1"
 
   defp should_keepalive?(version, connection_header) do
     case String.downcase(connection_header) do


### PR DESCRIPTION
I replaced the `Regex` matching with a pattern match for a `nil` connection header and otherwise `downcase` the `connection_header` and match it in a case.
This should (in theory) be faster.