### PR TITLE
Explicitly handle HTTP1 ALPN

### DIFF
--- a/lib/bandit/initial_handler.ex
+++ b/lib/bandit/initial_handler.ex
@@ -23,6 +23,9 @@ defmodule Bandit.InitialHandler do
       {Bandit.HTTP2.Handler, Bandit.HTTP2.Handler} ->
         {:ok, Bandit.HTTP2.Handler, <<>>}
 
+      {Bandit.HTTP1.Handler, {:no_match, data}} ->
+        {:ok, Bandit.HTTP1.Handler, data}
+
       {:no_match, Bandit.HTTP2.Handler} ->
         {:ok, Bandit.HTTP2.Handler, <<>>}
 
@@ -39,6 +42,12 @@ defmodule Bandit.InitialHandler do
     case ThousandIsland.Socket.negotiated_protocol(socket) do
       {:ok, "h2"} ->
         Bandit.HTTP2.Handler
+
+      {:ok, "http/1.1"} ->
+        Bandit.HTTP1.Handler
+
+      {:ok, "http/1.0"} ->
+        Bandit.HTTP1.Handler
 
       _ ->
         :no_match

--- a/lib/bandit/initial_handler.ex
+++ b/lib/bandit/initial_handler.ex
@@ -46,9 +46,6 @@ defmodule Bandit.InitialHandler do
       {:ok, "http/1.1"} ->
         Bandit.HTTP1.Handler
 
-      {:ok, "http/1.0"} ->
-        Bandit.HTTP1.Handler
-
       _ ->
         :no_match
     end

--- a/test/bandit/initial_handler_test.exs
+++ b/test/bandit/initial_handler_test.exs
@@ -60,5 +60,11 @@ defmodule InitialHandlerTest do
       assert response.status == 200
       assert response.body == "HTTP/2 https"
     end
+
+    test "closes with an error if HTTP2 is attempted over a HTTP/1.1 connection", context do
+      socket = ClientHelpers.tls_client(context, ["http/1.1"])
+      :ssl.send(socket, "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
+      assert :ssl.recv(socket, 0) == {:error, :closed}
+    end
   end
 end

--- a/test/support/client_helpers.ex
+++ b/test/support/client_helpers.ex
@@ -1,0 +1,16 @@
+defmodule ClientHelpers do
+  @moduledoc false
+
+  def tls_client(context, protocols) do
+    {:ok, socket} =
+      :ssl.connect('localhost', context[:port],
+        active: false,
+        mode: :binary,
+        verify: :verify_peer,
+        cacertfile: Path.join(__DIR__, "../support/ca.pem"),
+        alpn_advertised_protocols: protocols
+      )
+
+    socket
+  end
+end

--- a/test/support/simple_h2_client.ex
+++ b/test/support/simple_h2_client.ex
@@ -3,18 +3,7 @@ defmodule SimpleH2Client do
 
   import Bitwise
 
-  def tls_client(context) do
-    {:ok, socket} =
-      :ssl.connect('localhost', context[:port],
-        active: false,
-        mode: :binary,
-        verify: :verify_peer,
-        cacertfile: Path.join(__DIR__, "../support/ca.pem"),
-        alpn_advertised_protocols: ["h2"]
-      )
-
-    socket
-  end
+  def tls_client(context), do: ClientHelpers.tls_client(context, ["h2"])
 
   def setup_connection(context) do
     socket = tls_client(context)


### PR DESCRIPTION
Explicitly handle the `http/1.1` and `http/1.0` ALPN from the client.