### PR TITLE
Add Autobahn TestSuite and make it pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ bandit-*.tar
 
 # Ignore dialyzer caches
 /priv/plts/
+
+test/support/autobahn_reports

--- a/lib/bandit/http2/flow_control.ex
+++ b/lib/bandit/http2/flow_control.ex
@@ -2,7 +2,7 @@ defmodule Bandit.HTTP2.FlowControl do
   @moduledoc false
   # Helpers for working with flow control window calculations
 
-  use Bitwise
+  import Bitwise
 
   @max_window_increment (1 <<< 31) - 1
   @max_window_size (1 <<< 31) - 1

--- a/lib/bandit/websocket/connection.ex
+++ b/lib/bandit/websocket/connection.ex
@@ -24,6 +24,7 @@ defmodule Bandit.WebSocket.Connection do
     %__MODULE__{sock: sock, sock_state: sock_state}
   end
 
+  # credo:disable-for-this-file Credo.Check.Refactor.CyclomaticComplexity
   def handle_connection(conn, socket, connection) do
     case connection.sock.negotiate(conn, connection.sock_state) do
       {:accept, conn, sock_state} ->

--- a/lib/bandit/websocket/connection.ex
+++ b/lib/bandit/websocket/connection.ex
@@ -38,8 +38,13 @@ defmodule Bandit.WebSocket.Connection do
   def handle_frame(frame, socket, %{buffer: []} = connection) do
     case frame do
       %Frame.Text{fin: true} = frame ->
-        connection.sock.handle_text_frame(frame.data, socket, connection.sock_state)
-        |> handle_continutation(socket, connection)
+        if String.valid?(frame.data) do
+          connection.sock.handle_text_frame(frame.data, socket, connection.sock_state)
+          |> handle_continutation(socket, connection)
+        else
+          do_connection_close(1007, socket, connection)
+          {:close, connection}
+        end
 
       %Frame.Text{fin: false} = frame ->
         {:continue, %{connection | buffer: [frame | connection.buffer]}}

--- a/lib/bandit/websocket/frame.ex
+++ b/lib/bandit/websocket/frame.ex
@@ -94,7 +94,9 @@ defmodule Bandit.WebSocket.Frame do
 
   # Note that masking is an involution, so we don't need a separate unmask function
   def mask(payload, mask) when is_integer(mask), do: mask(payload, <<mask::32>>)
-  def mask(payload, mask) when is_bitstring(mask), do: do_mask(payload, mask, <<>>)
+  def mask(payload, mask) when is_bitstring(mask) do
+    do_mask(payload, mask, <<>>)
+  end
 
   defp do_mask(<<>>, _mask, msg), do: msg
 

--- a/lib/bandit/websocket/frame.ex
+++ b/lib/bandit/websocket/frame.ex
@@ -94,6 +94,7 @@ defmodule Bandit.WebSocket.Frame do
 
   # Note that masking is an involution, so we don't need a separate unmask function
   def mask(payload, mask) when is_integer(mask), do: mask(payload, <<mask::32>>)
+
   def mask(payload, mask) when is_bitstring(mask) do
     do_mask(payload, mask, <<>>)
   end

--- a/lib/bandit/websocket/handler.ex
+++ b/lib/bandit/websocket/handler.ex
@@ -48,7 +48,7 @@ defmodule Bandit.WebSocket.Handler do
         {:halt, {:error, reason, %{state | buffer: <<>>}}}
 
       {:more, rest}, {:continue, state} ->
-        {:halt, {:continue, %{state | buffer: state.buffer <> rest}}}
+        {:halt, {:continue, %{state | buffer: rest}}}
     end)
   end
 

--- a/lib/bandit/websocket/handler.ex
+++ b/lib/bandit/websocket/handler.ex
@@ -44,6 +44,9 @@ defmodule Bandit.WebSocket.Handler do
             {:halt, {:error, reason, %{state | connection: connection, buffer: <<>>}}}
         end
 
+      {:error, reason}, {:continue, state} ->
+        {:halt, {:error, reason, %{state | buffer: <<>>}}}
+
       {:more, rest}, {:continue, state} ->
         {:halt, {:continue, %{state | buffer: rest}}}
     end)

--- a/lib/bandit/websocket/handler.ex
+++ b/lib/bandit/websocket/handler.ex
@@ -48,7 +48,7 @@ defmodule Bandit.WebSocket.Handler do
         {:halt, {:error, reason, %{state | buffer: <<>>}}}
 
       {:more, rest}, {:continue, state} ->
-        {:halt, {:continue, %{state | buffer: rest}}}
+        {:halt, {:continue, %{state | buffer: state.buffer <> rest}}}
     end)
   end
 

--- a/lib/bandit/websocket/handshake.ex
+++ b/lib/bandit/websocket/handshake.ex
@@ -10,8 +10,8 @@ defmodule Bandit.WebSocket.Handshake do
         # Cases from RFC6455§4.2.1
         conn.method == "GET" &&
           get_req_header(conn, "host") != [] &&
-          "websocket" in get_req_header(conn, "upgrade") &&
-          "Upgrade" in get_req_header(conn, "connection") &&
+          "websocket" in String.downcase(get_req_header(conn, "upgrade")) &&
+          "upgrade" in String.downcase(get_req_header(conn, "connection")) &&
           match?([<<_::binary>>], get_req_header(conn, "sec-websocket-key")) &&
           get_req_header(conn, "sec-websocket-version") == ["13"]
 

--- a/lib/bandit/websocket/handshake.ex
+++ b/lib/bandit/websocket/handshake.ex
@@ -10,8 +10,8 @@ defmodule Bandit.WebSocket.Handshake do
         # Cases from RFC6455§4.2.1
         conn.method == "GET" &&
           get_req_header(conn, "host") != [] &&
-          "websocket" in String.downcase(get_req_header(conn, "upgrade")) &&
-          "upgrade" in String.downcase(get_req_header(conn, "connection")) &&
+          header_contains?(conn, "upgrade", "websocket") &&
+          header_contains?(conn, "connection", "upgrade") &&
           match?([<<_::binary>>], get_req_header(conn, "sec-websocket-key")) &&
           get_req_header(conn, "sec-websocket-version") == ["13"]
 
@@ -34,5 +34,11 @@ defmodule Bandit.WebSocket.Handshake do
     |> put_resp_header("connection", "Upgrade")
     |> put_resp_header("sec-websocket-accept", server_key)
     |> send_resp()
+  end
+
+  defp header_contains?(conn, header, value) do
+    get_req_header(conn, header)
+    |> Enum.map(&String.downcase/1)
+    |> Enum.member?(String.downcase(value))
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -12,6 +12,8 @@ defmodule Bandit.MixProject do
       name: "Bandit",
       description: "A pure-Elixir HTTP server built for Plug apps",
       source_url: "https://github.com/mtrudel/bandit",
+      aliases: aliases(),
+      preferred_cli_env: ["test.autobahn": :test],
       package: [
         files: ["lib", "test", "mix.exs", "README*", "LICENSE*"],
         maintainers: ["Mat Trudel"],
@@ -46,5 +48,9 @@ defmodule Bandit.MixProject do
 
   defp docs do
     [main: "Bandit"]
+  end
+
+  defp aliases do
+    ["test.autobahn": "test test/bandit/websocket/autobahn_test.exs --include autobahn:true"]
   end
 end

--- a/test/bandit/http2/protocol_test.exs
+++ b/test/bandit/http2/protocol_test.exs
@@ -1,7 +1,7 @@
 defmodule HTTP2ProtocolTest do
   use ExUnit.Case, async: true
 
-  use Bitwise
+  import Bitwise
   use ServerHelpers
 
   setup :https_server

--- a/test/bandit/websocket/autobahn_test.exs
+++ b/test/bandit/websocket/autobahn_test.exs
@@ -38,7 +38,7 @@ defmodule WebsocketAutobahnTest do
       end
 
       @impl Sock
-      def handle_ping_frame(ping, socket, state) do
+      def handle_ping_frame(_ping, _socket, state) do
         {:continue, state}
       end
 
@@ -53,14 +53,12 @@ defmodule WebsocketAutobahnTest do
       end
 
       @impl Sock
-      def handle_error(error, _socket, _state) do
-        IO.inspect(error)
+      def handle_error(_error, _socket, _state) do
         :ok
       end
 
       @impl Sock
       def handle_timeout(_socket, _state) do
-        IO.inspect("timeout")
         :ok
       end
 

--- a/test/bandit/websocket/autobahn_test.exs
+++ b/test/bandit/websocket/autobahn_test.exs
@@ -1,0 +1,111 @@
+defmodule WebsocketAutobahnTest do
+  use ExUnit.Case, async: false
+
+  @tag timeout: :infinity
+  @tag :autobahn
+  test "autobahn test suite" do
+    defmodule EchoSock do
+      @behaviour Sock
+
+      import Sock.Socket
+      import Plug.Conn
+
+      @impl Sock
+      def init(_args) do
+        []
+      end
+
+      @impl Sock
+      def negotiate(conn, state) do
+        {:accept, conn, state}
+      end
+
+      @impl Sock
+      def handle_connection(_socket, state) do
+        {:continue, state}
+      end
+
+      @impl Sock
+      def handle_text_frame(text, socket, state) do
+        send_text_frame(socket, text)
+        {:continue, state}
+      end
+
+      @impl Sock
+      def handle_binary_frame(binary, socket, state) do
+        send_binary_frame(socket, binary)
+        {:continue, state}
+      end
+
+      @impl Sock
+      def handle_ping_frame(ping, socket, state) do
+        {:continue, state}
+      end
+
+      @impl Sock
+      def handle_pong_frame(_pong, _socket, state) do
+        {:continue, state}
+      end
+
+      @impl Sock
+      def handle_close(_status_code, _socket, _state) do
+        :ok
+      end
+
+      @impl Sock
+      def handle_error(error, _socket, _state) do
+        IO.inspect(error)
+        :ok
+      end
+
+      @impl Sock
+      def handle_timeout(_socket, _state) do
+        IO.inspect("timeout")
+        :ok
+      end
+
+      def call(conn, _) do
+        conn
+        |> put_resp_content_type("text/plain")
+        |> send_resp(200, "Hello world")
+      end
+    end
+
+    Bandit.child_spec(
+      sock: EchoSock,
+      plug: EchoSock
+    )
+    |> start_supervised!()
+
+    {_, 0} =
+      System.cmd("docker", [
+        "run",
+        "--rm",
+        "-v",
+        "#{Path.join(__DIR__, "../../support/autobahn_config.json")}:/fuzzingclient.json",
+        "-v",
+        "#{Path.join(__DIR__, "../../support/autobahn_reports")}:/reports",
+        "--name",
+        "fuzzingclient",
+        "crossbario/autobahn-testsuite",
+        "wstest",
+        "--mode",
+        "fuzzingclient"
+      ])
+
+    failures =
+      Path.join(__DIR__, "../../support/autobahn_reports/servers/index.json")
+      |> File.read!()
+      |> Jason.decode!()
+      |> Map.get("bandit")
+      |> Enum.map(fn {test_case, %{"behavior" => res, "behaviorClose" => res_close}} ->
+        {test_case, res, res_close}
+      end)
+      |> Enum.reject(fn {_, res, res_close} ->
+        (res == "OK" or res == "NON-STRICT" or res == "INFORMATIONAL") and
+          (res_close == "OK" or res_close == "INFORMATIONAL")
+      end)
+
+    assert failures == []
+  end
+end

--- a/test/support/autobahn_config.json
+++ b/test/support/autobahn_config.json
@@ -4,7 +4,7 @@
 
 	"servers": [{"agent": "bandit", "url": "ws://host.docker.internal:4000", "options": {"version": 18}}],
 
-	"cases": ["*"],
+	"cases": ["6.*"],
 	"exclude-cases": [],
 	"exclude-agent-cases": {}
 }

--- a/test/support/autobahn_config.json
+++ b/test/support/autobahn_config.json
@@ -4,7 +4,7 @@
 
 	"servers": [{"agent": "bandit", "url": "ws://host.docker.internal:4000", "options": {"version": 18}}],
 
-	"cases": ["7.*"],
-	"exclude-cases": [],
+	"cases": ["*"],
+	"exclude-cases": ["9.*", "12.*", "13.*"],
 	"exclude-agent-cases": {}
 }

--- a/test/support/autobahn_config.json
+++ b/test/support/autobahn_config.json
@@ -4,7 +4,7 @@
 
 	"servers": [{"agent": "bandit", "url": "ws://host.docker.internal:4000", "options": {"version": 18}}],
 
-	"cases": ["9.3.1"],
+	"cases": ["*"],
 	"exclude-cases": ["12.*", "13.*"],
 	"exclude-agent-cases": {}
 }

--- a/test/support/autobahn_config.json
+++ b/test/support/autobahn_config.json
@@ -4,7 +4,7 @@
 
 	"servers": [{"agent": "bandit", "url": "ws://host.docker.internal:4000", "options": {"version": 18}}],
 
-	"cases": ["*"],
-	"exclude-cases": ["9.*", "12.*", "13.*"],
+	"cases": ["9.3.1"],
+	"exclude-cases": ["12.*", "13.*"],
 	"exclude-agent-cases": {}
 }

--- a/test/support/autobahn_config.json
+++ b/test/support/autobahn_config.json
@@ -4,7 +4,7 @@
 
 	"servers": [{"agent": "bandit", "url": "ws://host.docker.internal:4000", "options": {"version": 18}}],
 
-	"cases": ["6.*"],
+	"cases": ["7.*"],
 	"exclude-cases": [],
 	"exclude-agent-cases": {}
 }

--- a/test/support/autobahn_config.json
+++ b/test/support/autobahn_config.json
@@ -1,0 +1,10 @@
+{
+	"options": {"failByDrop": false},
+	"outdir": "./reports/servers",
+
+	"servers": [{"agent": "bandit", "url": "ws://host.docker.internal:4000", "options": {"version": 18}}],
+
+	"cases": ["*"],
+	"exclude-cases": [],
+	"exclude-agent-cases": {}
+}

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,5 @@
 Path.wildcard(Path.join(__DIR__, "support/*.{ex,exs}")) |> Enum.each(&Code.require_file/1)
+ExUnit.configure(exclude: [autobahn: true])
 ExUnit.start()
 
 # Capture all logs so we're able to assert on logging done at info level in tests


### PR DESCRIPTION
Added a test case for the Autobahn WebSocket-TestSuite and fixed some problems which occurred during this tests:

- Make header check during Upgrade case-insensitive
- Check reserved bits and fail if not 0 (RFC: `MUST be 0 unless an extension is negotiated that defines meanings for non-zero values.`)
- Check close code for validity (not sure why Autobahn expects 1016-2999 to fail but allows 3001-3999 since both are `Unassigned`, see: [IANA](https://www.iana.org/assignments/websocket/websocket.xhtml))
- Check if TextFrame and CloseFrame contain valid UTF-8 string
- Fix masking algorithm
- Append ContinuationFrames to initial Frame (not quite happy with using the initial frame as a buffer for the message, but couldn't think of a better way yet)

With these changes the Autobahn-TestCases 1 - 10 are passed, which would mean the last thing which is missing, is compression.

To run the TestSuite you need Docker. I added the alias `mix test.autobahn` for convenience and don't run the Autobahn Suite by default. 

Please feel free to review the code and propose changes.