### PR TITLE
Make header field handling case-insensitive

### DIFF
--- a/lib/bandit/websocket/handshake.ex
+++ b/lib/bandit/websocket/handshake.ex
@@ -10,8 +10,8 @@ defmodule Bandit.WebSocket.Handshake do
         # Cases from RFC6455§4.2.1
         conn.method == "GET" &&
           get_req_header(conn, "host") != [] &&
-          "websocket" in get_req_header(conn, "upgrade") &&
-          "Upgrade" in get_req_header(conn, "connection") &&
+          header_contains?(conn, "upgrade", "websocket") &&
+          header_contains?(conn, "connection", "upgrade") &&
           match?([<<_::binary>>], get_req_header(conn, "sec-websocket-key")) &&
           get_req_header(conn, "sec-websocket-version") == ["13"]
 
@@ -34,5 +34,11 @@ defmodule Bandit.WebSocket.Handshake do
     |> put_resp_header("connection", "Upgrade")
     |> put_resp_header("sec-websocket-accept", server_key)
     |> send_resp()
+  end
+
+  defp header_contains?(conn, field, value) do
+    get_req_header(conn, field)
+    |> Enum.map(&String.downcase/1)
+    |> Enum.member?(String.downcase(value))
   end
 end

--- a/test/bandit/websocket/http1_handshake_test.exs
+++ b/test/bandit/websocket/http1_handshake_test.exs
@@ -10,8 +10,8 @@ defmodule WebSocketHTTP1HandshakeTest do
       :gen_tcp.send(client, """
       GET /websocket_test HTTP/1.1\r
       Host: server.example.com\r
-      Upgrade: websocket\r
-      Connection: Upgrade\r
+      Upgrade: WeBsOcKeT\r
+      Connection: UpGrAdE\r
       Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r
       Sec-WebSocket-Version: 13\r
       \r


### PR DESCRIPTION
Since header fields are case-insensitive, I added a helper which downcases the fields before comparison.

This is needed, so the Autobahn tests work, since Autobahn uses:
```
Upgrade: WebSocket
Connection: Upgrade
```
in headers