### PR TITLE
Faster masking

### DIFF
--- a/lib/bandit/websocket/frame.ex
+++ b/lib/bandit/websocket/frame.ex
@@ -98,6 +98,10 @@ defmodule Bandit.WebSocket.Frame do
 
   def mask(payload, mask, acc) when is_integer(mask), do: mask(payload, <<mask::32>>, acc)
 
+  def mask(<<h::32, rest::binary>>, <<mask::32>>, acc) do
+    mask(rest, mask, acc <> <<Bitwise.bxor(h, mask)::32>>)
+  end
+
   def mask(<<h::8, rest::binary>>, <<current::8, mask::24>>, acc) do
     mask(rest, <<mask::24, current::8>>, acc <> <<Bitwise.bxor(h, current)::8>>)
   end


### PR DESCRIPTION
Improve masking.
This is about 3x (for small inputs) - 10x (for large inputs) faster (also uses less memory): [Benchmark](https://gist.github.com/moogle19/cd58b4618cac33a44fc7d8561eb99455)

Limits/Performance section of Autobahn with the current version (left) and the `fast_mask` version (right): 
![fast_mask](https://user-images.githubusercontent.com/792046/193629894-0b90e8a0-f014-4fb4-9ebd-f031ef6e6aff.png)
