### PR TITLE
Implement no-op support for Plug.Conn.Adapter.upgrade/3

### DIFF
--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -309,6 +309,9 @@ defmodule Bandit.HTTP1.Adapter do
   def inform(_req, _status, _headers), do: {:error, :not_supported}
 
   @impl Plug.Conn.Adapter
+  def upgrade(_req, _upgrade, _opts), do: {:error, :not_supported}
+
+  @impl Plug.Conn.Adapter
   def push(_req, _path, _headers), do: {:error, :not_supported}
 
   @impl Plug.Conn.Adapter

--- a/lib/bandit/http2/adapter.ex
+++ b/lib/bandit/http2/adapter.ex
@@ -129,6 +129,9 @@ defmodule Bandit.HTTP2.Adapter do
   end
 
   @impl Plug.Conn.Adapter
+  def upgrade(_req, _upgrade, _opts), do: {:error, :not_supported}
+
+  @impl Plug.Conn.Adapter
   def push(_adapter, _path, _headers), do: {:error, :not_supported}
 
   @impl Plug.Conn.Adapter

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -297,6 +297,23 @@ defmodule HTTP1RequestTest do
     end
   end
 
+  describe "upgrade handling" do
+    test "does not update the conn or send any data on unsupported upgrades", context do
+      {:ok, response} =
+        Finch.build(:get, context[:base] <> "/upgrade_unsupported", [{"connection", "close"}])
+        |> Finch.request(context[:finch_name])
+
+      assert response.status == 200
+      assert response.body == "Not supported"
+    end
+
+    def upgrade_unsupported(conn) do
+      conn
+      |> upgrade_adapter(:unsupported, [])
+      |> send_resp(200, "Not supported")
+    end
+  end
+
   test "does not do anything special with EXIT messages from abnormally terminating spwaned processes",
        context do
     errors =

--- a/test/bandit/http2/plug_test.exs
+++ b/test/bandit/http2/plug_test.exs
@@ -208,6 +208,23 @@ defmodule HTTP2PlugTest do
     |> elem(1)
   end
 
+  describe "upgrade handling" do
+    test "does not update the conn or send any data on unsupported upgrades", context do
+      {:ok, response} =
+        Finch.build(:get, context[:base] <> "/upgrade_unsupported")
+        |> Finch.request(context[:finch_name])
+
+      assert response.status == 200
+      assert response.body == "Not supported"
+    end
+
+    def upgrade_unsupported(conn) do
+      conn
+      |> upgrade_adapter(:unsupported, [])
+      |> send_resp(200, "Not supported")
+    end
+  end
+
   test "raises a Plug.Conn.NotSentError if nothing was set in the conn", context do
     errors =
       capture_log(fn ->


### PR DESCRIPTION
This work does not provide any concrete support for any protocols, it merely satisfies the plumbing requirements introduced in Plug by https://github.com/elixir-plug/plug/pull/1119

See https://github.com/phoenixframework/phoenix/issues/5003 for an omnibus overview.

Doing a no-op implementation here allows for the changes required in Plug to be isolated to a small set of PRs (namely this one and https://github.com/elixir-plug/plug_cowboy/pull/88), while not breaking anything in the process.

Note that this PR is not entirely complete yet; it will need to have its dependency on Plug updated to a version which incorporates https://github.com/elixir-plug/plug/pull/1119.