### PR TITLE
Remove un-necessary Enum.map/2

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ there looks like this following:
 
 ## Using Bandit With Phoenix
 
-As of the 0.5.x branch Bandit supports Phoenix. Phoenix applications which use WebSockets for 
+As of the 0.5.x branch Bandit supports Phoenix. Phoenix applications which use WebSockets for
 features such as Channels or LiveView require a recent version of Phoenix with Sock support enabled (the PR for this work is [here](https://github.com/phoenixframework/phoenix/pull/4973)).
 
 Using Bandit to host your Phoenix application couldn't be simpler:
 
 1. Add Bandit as a dependency in your Phoenix application's `mix.exs`:
-    
+
     ```elixir
     {:bandit, ">= 0.5.6"}
     ```
@@ -126,7 +126,7 @@ Bandit takes a number of options at startup, which are described in detail in th
 For less formal usage, you can also start Bandit using the same configuration
 options via the `Bandit.start_link/1` function:
 
-```
+```elixir
 # Start an http server on the default port 4000, serving MyApp.MyPlug
 Bandit.start_link(plug: MyApp.MyPlug)
 ```

--- a/lib/bandit/http2/stream_collection.ex
+++ b/lib/bandit/http2/stream_collection.ex
@@ -35,13 +35,15 @@ defmodule Bandit.HTTP2.StreamCollection do
     delta = initial_send_window_size - collection.initial_send_window_size
 
     streams =
-      Map.new(collection.streams, fn
+      collection.streams
+      |> Enum.map(fn
         {id, %Stream{state: state} = stream} when state in [:open, :remote_closed] ->
           {id, %{stream | send_window_size: stream.send_window_size + delta}}
 
         {id, stream} ->
           {id, stream}
       end)
+      |> Map.new()
 
     %{collection | streams: streams, initial_send_window_size: initial_send_window_size}
   end

--- a/lib/bandit/http2/stream_collection.ex
+++ b/lib/bandit/http2/stream_collection.ex
@@ -35,15 +35,13 @@ defmodule Bandit.HTTP2.StreamCollection do
     delta = initial_send_window_size - collection.initial_send_window_size
 
     streams =
-      collection.streams
-      |> Enum.map(fn
+      Map.new(collection.streams, fn
         {id, %Stream{state: state} = stream} when state in [:open, :remote_closed] ->
           {id, %{stream | send_window_size: stream.send_window_size + delta}}
 
         {id, stream} ->
           {id, stream}
       end)
-      |> Map.new()
 
     %{collection | streams: streams, initial_send_window_size: initial_send_window_size}
   end

--- a/lib/bandit/websocket/handshake.ex
+++ b/lib/bandit/websocket/handshake.ex
@@ -37,9 +37,10 @@ defmodule Bandit.WebSocket.Handshake do
   end
 
   defp header_contains?(conn, field, value) do
+    value = String.downcase(value, :ascii)
+
     conn
     |> get_req_header(field)
-    |> Enum.map(&String.downcase(&1, :ascii))
-    |> Enum.member?(String.downcase(value, :ascii))
+    |> Enum.any?(&(String.downcase(&1, :ascii) == value))
   end
 end


### PR DESCRIPTION
Hi,

This is a small suggestion to remove some calls to `Enum.map/2` to avoid intermediate structures when there is a way of doing it in one pass.
While it most probably won't result in a noticeable speedup, it also simplifies the code.

The second unrelated commit just adds syntax highlighting to some code in the readme.