### PR TITLE
Fix header parsing in Websocket upgrade

### DIFF
--- a/lib/bandit/websocket/handshake.ex
+++ b/lib/bandit/websocket/handshake.ex
@@ -116,6 +116,7 @@ defmodule Bandit.WebSocket.Handshake do
 
     conn
     |> get_req_header(field)
+    |> Enum.flat_map(&Plug.Conn.Utils.list/1)
     |> Enum.any?(&(String.downcase(&1, :ascii) == value))
   end
 end

--- a/test/support/simple_websocket_client.ex
+++ b/test/support/simple_websocket_client.ex
@@ -14,7 +14,7 @@ defmodule SimpleWebSocketClient do
     GET /?#{URI.encode_query(params)} HTTP/1.1\r
     Host: server.example.com\r
     Upgrade: websocket\r
-    Connection: Upgrade\r
+    Connection: keep-alive, Upgrade\r
     Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r
     Sec-WebSocket-Version: 13\r
     #{extensions}


### PR DESCRIPTION
The Websocket upgrade was failing, when the connection header had more than 1 value (e.g `Connection: keep-alive, Upgrade` which is used by the Phoenix live_reload socket). 
I updated the `header_contains?/3` to handle these cases.