### PR TITLE
Handle all path types

### DIFF
--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -129,7 +129,7 @@ defmodule Bandit.HTTP1.Adapter do
   defp resolve_path(_path),
     do:
       {:error,
-       "Not supported. Path must be an absolute path, an absolute URI or `*` for a global OPTIONS request."}
+       "Not supported. Path must be an absolute path, an absolute URI or `*` request."}
 
   ##############
   # Body Reading

--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -72,7 +72,7 @@ defmodule Bandit.HTTP1.Adapter do
 
       {:ok, {:http_request, method, path, version}, rest} ->
         with {:ok, version} <- get_version(version),
-             {:ok, path} <- resolve_path(path, method) do
+             {:ok, path} <- resolve_path(path) do
           do_read_headers(%{req | buffer: rest, version: version}, :httph, headers, method, path)
         end
 
@@ -119,14 +119,14 @@ defmodule Bandit.HTTP1.Adapter do
   end
 
   # Unwrap different path returned by :erlang.decode_packet/3
-  defp resolve_path({:abs_path, _path} = path, _method), do: {:ok, path}
-  defp resolve_path({:absoluteURI, _scheme, _host, _port, _path} = path, _method), do: {:ok, path}
-  defp resolve_path(:*, :OPTIONS), do: {:ok, {:options, :*}}
+  defp resolve_path({:abs_path, _path} = path), do: {:ok, path}
+  defp resolve_path({:absoluteURI, _scheme, _host, _port, _path} = path), do: {:ok, path}
+  defp resolve_path(:*), do: {:ok, :*}
 
-  defp resolve_path({:scheme, _scheme, _path}, 'CONNECT'),
-    do: {:error, "CONNECT is not supported"}
+  defp resolve_path({:scheme, _scheme, _path}),
+    do: {:error, "schemeURI is not supported"}
 
-  defp resolve_path(_path, _method),
+  defp resolve_path(_path),
     do:
       {:error,
        "Not supported. Path must be an absolute path, an absolute URI or `*` for a global OPTIONS request."}

--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -26,7 +26,8 @@ defmodule Bandit.HTTP1.Adapter do
   ################
 
   def read_headers(req) do
-    with {:ok, headers, method, path, %__MODULE__{version: version, buffer: buffer} = req} <-
+    with {:ok, headers, method, request_target,
+          %__MODULE__{version: version, buffer: buffer} = req} <-
            do_read_headers(req) do
       body_size = get_header(headers, "content-length")
       body_encoding = get_header(headers, "transfer-encoding")
@@ -35,11 +36,11 @@ defmodule Bandit.HTTP1.Adapter do
 
       case {body_size, body_encoding} do
         {nil, nil} ->
-          {:ok, headers, method, path,
+          {:ok, headers, method, request_target,
            %{req | state: :no_body, connection: connection, keepalive: keepalive}}
 
         {body_size, nil} ->
-          {:ok, headers, method, path,
+          {:ok, headers, method, request_target,
            %{
              req
              | state: :headers_read,
@@ -49,7 +50,7 @@ defmodule Bandit.HTTP1.Adapter do
            }}
 
         {_, body_encoding} ->
-          {:ok, headers, method, path,
+          {:ok, headers, method, request_target,
            %{
              req
              | state: :headers_read,
@@ -61,32 +62,29 @@ defmodule Bandit.HTTP1.Adapter do
     end
   end
 
-  defp do_read_headers(req, type \\ :http, headers \\ [], method \\ nil, path \\ nil)
+  defp do_read_headers(req, type \\ :http, headers \\ [], method \\ nil, request_target \\ nil)
 
-  defp do_read_headers(%__MODULE__{buffer: buffer} = req, type, headers, method, path) do
+  defp do_read_headers(%__MODULE__{buffer: buffer} = req, type, headers, method, request_target) do
     case :erlang.decode_packet(type, buffer, []) do
       {:more, _len} ->
         with {:ok, req} <- grow_buffer(req, 0) do
-          do_read_headers(req, type, headers, method, path)
+          do_read_headers(req, type, headers, method, request_target)
         end
 
-      {:ok, {:http_request, method, path, version}, rest} ->
+      {:ok, {:http_request, method, request_target, version}, rest} ->
         with {:ok, version} <- get_version(version),
-             {:ok, path} <- resolve_path(path) do
-          do_read_headers(%{req | buffer: rest, version: version}, :httph, headers, method, path)
+             {:ok, request_target} <- resolve_request_target(request_target),
+             req <- %{req | buffer: rest, version: version} do
+          do_read_headers(req, :httph, headers, method, request_target)
         end
 
       {:ok, {:http_header, _, header, _, value}, rest} ->
-        do_read_headers(
-          %{req | buffer: rest},
-          :httph,
-          [{header |> to_string() |> String.downcase(:ascii), to_string(value)} | headers],
-          to_string(method),
-          path
-        )
+        req = %{req | buffer: rest}
+        headers = [{header |> to_string() |> String.downcase(:ascii), to_string(value)} | headers]
+        do_read_headers(req, :httph, headers, to_string(method), request_target)
 
       {:ok, :http_eoh, rest} ->
-        {:ok, headers, method, path, %{req | state: :headers_read, buffer: rest}}
+        {:ok, headers, method, request_target, %{req | state: :headers_read, buffer: rest}}
 
       {:ok, {:http_error, _reason}, _rest} ->
         {:error, :invalid_request}
@@ -118,16 +116,19 @@ defmodule Bandit.HTTP1.Adapter do
     end
   end
 
-  # Unwrap different path returned by :erlang.decode_packet/3
-  defp resolve_path({:abs_path, _path} = path), do: {:ok, path}
-  defp resolve_path({:absoluteURI, _scheme, _host, _port, _path} = path), do: {:ok, path}
-  defp resolve_path(:*), do: {:ok, :*}
+  # Unwrap different request_targets returned by :erlang.decode_packet/3
+  defp resolve_request_target({:abs_path, _path} = request_target), do: {:ok, request_target}
 
-  defp resolve_path({:scheme, _scheme, _path}),
+  defp resolve_request_target({:absoluteURI, _scheme, _host, _port, _path} = requeast_target),
+    do: {:ok, requeast_target}
+
+  defp resolve_request_target(:*), do: {:ok, :*}
+
+  defp resolve_request_target({:scheme, _scheme, _path}),
     do: {:error, "schemeURI is not supported"}
 
-  defp resolve_path(_path),
-    do: {:error, "Not supported. Path must be an absolute path, an absolute URI or `*` request."}
+  defp resolve_request_target(_request_target),
+    do: {:error, "Unsupported request target (RFC9112§3.2)"}
 
   ##############
   # Body Reading

--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -127,9 +127,7 @@ defmodule Bandit.HTTP1.Adapter do
     do: {:error, "schemeURI is not supported"}
 
   defp resolve_path(_path),
-    do:
-      {:error,
-       "Not supported. Path must be an absolute path, an absolute URI or `*` request."}
+    do: {:error, "Not supported. Path must be an absolute path, an absolute URI or `*` request."}
 
   ##############
   # Body Reading

--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -128,6 +128,7 @@ defmodule Bandit.HTTP1.Adapter do
   defp get_path({:abs_path, path}), do: path
   defp get_path({:absoluteURI, _scheme, _host, _port, path}), do: path
   defp get_path({:scheme, _scheme, path}), do: path
+  defp get_path(:*), do: '/*'
   defp get_path(path), do: path
 
   # If the path contains no '/' the URL construction will fail

--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -121,10 +121,7 @@ defmodule Bandit.HTTP1.Adapter do
   # Unwrap different path returned by :erlang.decode_packet/3
   defp resolve_path({:abs_path, _path} = path, _method), do: {:ok, path}
   defp resolve_path({:absoluteURI, _scheme, _host, _port, _path} = path, _method), do: {:ok, path}
-
-  # Normally an OPTIONS request with `*` as path translates to an URL without any path or trailing slash
-  # Since Plug.Router matching MUST HAVE a path, we map it to `/*`
-  defp resolve_path(:*, 'OPTIONS'), do: {:ok, {:abs_path, '/*'}}
+  defp resolve_path(:*, :OPTIONS), do: {:ok, {:options, :*}}
 
   defp resolve_path({:scheme, _scheme, _path}, 'CONNECT'),
     do: {:error, "CONNECT is not supported"}

--- a/lib/bandit/http1/handler.ex
+++ b/lib/bandit/http1/handler.ex
@@ -64,7 +64,7 @@ defmodule Bandit.HTTP1.Handler do
   defp build_uri(_scheme, _host, {:absoluteURI, scheme, host, port, path}),
     do: URI.parse("#{scheme}://#{host}:#{port}#{path}")
 
-  defp build_uri(scheme, host, {:options, :*}) do
+  defp build_uri(scheme, host, :*) do
     URI.parse("#{scheme}://#{host}/*")
     |> Map.put(:path, "*")
   end

--- a/lib/bandit/http1/handler.ex
+++ b/lib/bandit/http1/handler.ex
@@ -64,6 +64,11 @@ defmodule Bandit.HTTP1.Handler do
   defp build_uri(_scheme, _host, {:absoluteURI, scheme, host, port, path}),
     do: URI.parse("#{scheme}://#{host}:#{port}#{path}")
 
+  defp build_uri(scheme, host, {:options, :*}) do
+    URI.parse("#{scheme}://#{host}/*")
+    |> Map.put(:path, "*")
+  end
+
   defp call_plug(%Plug.Conn{adapter: {Adapter, req}} = conn, {plug, plug_opts}) do
     {:ok, plug.call(conn, plug_opts)}
   rescue

--- a/lib/bandit/http1/handler.ex
+++ b/lib/bandit/http1/handler.ex
@@ -30,7 +30,7 @@ defmodule Bandit.HTTP1.Handler do
 
   defp build_conn(req) do
     case Adapter.read_headers(req) do
-      {:ok, headers, method, path, req} ->
+      {:ok, headers, method, request_target, req} ->
         %{address: remote_ip} = Adapter.get_peer_data(req)
 
         # Parse a string to build a URI struct. This is quite a hack. In general, canonicalizing
@@ -40,7 +40,7 @@ defmodule Bandit.HTTP1.Handler do
         {"host", host} = List.keyfind(headers, "host", 0, {"host", nil})
         scheme = if Adapter.secure?(req), do: :https, else: :http
 
-        uri = build_uri(scheme, host, path)
+        uri = build_uri(scheme, host, request_target)
 
         {:ok, Plug.Conn.Adapter.conn({Adapter, req}, method, uri, remote_ip, headers)}
 
@@ -54,7 +54,7 @@ defmodule Bandit.HTTP1.Handler do
     end
   end
 
-  # Build URI dependent on path type
+  # Build URI dependent on request target type
   defp build_uri(scheme, host, {:abs_path, path}),
     do: URI.parse("#{scheme}://#{host}#{path}")
 

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -230,7 +230,7 @@ defmodule HTTP1RequestTest do
       assert valid_date_header?(date)
     end
 
-    def global_options(conn) do
+    def unquote(:*)(conn) do
       assert conn.request_path == "*"
       assert conn.path_info == ["*"]
       send_resp(conn, 200, "")

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -144,6 +144,86 @@ defmodule HTTP1RequestTest do
 
       assert valid_date_header?(date)
     end
+
+    test "handles non-absolute path correctly", context do
+      client = ClientHelpers.tcp_client(context)
+
+      :gen_tcp.send(client, "GET ./..//non_absolute_path HTTP/1.0\r\n\r\n")
+      {:ok, response} = :gen_tcp.recv(client, 0)
+
+      assert [
+               "HTTP/1.0 200 OK",
+               "date: " <> date,
+               "content-length: 0"
+               | _rest
+             ] = String.split(response, "\r\n")
+
+      assert valid_date_header?(date)
+    end
+
+    def non_absolute_path(conn) do
+      send_resp(conn, 200, "")
+    end
+
+    test "handles path without a leading slash correctly", context do
+      client = ClientHelpers.tcp_client(context)
+
+      :gen_tcp.send(client, "GET path_without_leading_slash HTTP/1.0\r\n\r\n")
+      {:ok, response} = :gen_tcp.recv(client, 0)
+
+      assert [
+               "HTTP/1.0 200 OK",
+               "date: " <> date,
+               "content-length: 0"
+               | _rest
+             ] = String.split(response, "\r\n")
+
+      assert valid_date_header?(date)
+    end
+
+    def path_without_leading_slash(conn) do
+      send_resp(conn, 200, "")
+    end
+
+    test "handle absoluteURI as path correctly", context do
+      client = ClientHelpers.tcp_client(context)
+
+      :gen_tcp.send(client, "GET #{context[:base]}/absolute_url_path HTTP/1.0\r\n\r\n")
+      {:ok, response} = :gen_tcp.recv(client, 0)
+
+      assert [
+               "HTTP/1.0 200 OK",
+               "date: " <> date,
+               "content-length: 0"
+               | _rest
+             ] = String.split(response, "\r\n")
+
+      assert valid_date_header?(date)
+    end
+
+    def absolute_url_path(conn) do
+      send_resp(conn, 200, "")
+    end
+
+    test "handle schemeURI as path correctly", context do
+      client = ClientHelpers.tcp_client(context)
+
+      :gen_tcp.send(client, "GET http:scheme_url_path HTTP/1.0\r\n\r\n")
+      {:ok, response} = :gen_tcp.recv(client, 0)
+
+      assert [
+               "HTTP/1.0 200 OK",
+               "date: " <> date,
+               "content-length: 0"
+               | _rest
+             ] = String.split(response, "\r\n")
+
+      assert valid_date_header?(date)
+    end
+
+    def scheme_url_path(conn) do
+      send_resp(conn, 200, "")
+    end
   end
 
   describe "response handling" do

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -210,6 +210,33 @@ defmodule HTTP1RequestTest do
     end
 
     @tag capture_log: true
+    test "handle global OPTIONS request correctly", context do
+      client = ClientHelpers.tcp_client(context)
+
+      :gen_tcp.send(
+        client,
+        "OPTIONS * HTTP/1.0\r\nHost: localhost\r\n\r\n"
+      )
+
+      {:ok, response} = :gen_tcp.recv(client, 0)
+
+      assert [
+               "HTTP/1.0 200 OK",
+               "date: " <> date,
+               "content-length: 0"
+               | _rest
+             ] = String.split(response, "\r\n")
+
+      assert valid_date_header?(date)
+    end
+
+    def global_options(conn) do
+      assert conn.request_path == "*"
+      assert conn.path_info == ["*"]
+      send_resp(conn, 200, "")
+    end
+
+    @tag capture_log: true
     test "returns 400 for authority-form / CONNECT requests", context do
       client = ClientHelpers.tcp_client(context)
 

--- a/test/support/server_helpers.ex
+++ b/test/support/server_helpers.ex
@@ -46,12 +46,13 @@ defmodule ServerHelpers do
 
       def call(conn, []) do
         function =
-          conn.path_info
-          |> Enum.filter(fn path ->
-            path != ".." and path != "." and not String.starts_with?(path, "localhost:")
-          end)
-          |> List.first()
-          |> String.to_existing_atom()
+          if conn.path_info == ["*"] do
+            :global_options
+          else
+            conn.path_info
+            |> List.first()
+            |> String.to_existing_atom()
+          end
 
         apply(__MODULE__, function, [conn])
       end

--- a/test/support/server_helpers.ex
+++ b/test/support/server_helpers.ex
@@ -45,15 +45,7 @@ defmodule ServerHelpers do
       end
 
       def call(conn, []) do
-        function =
-          if conn.path_info == ["*"] do
-            :global_options
-          else
-            conn.path_info
-            |> List.first()
-            |> String.to_existing_atom()
-          end
-
+        function = String.to_atom(List.first(conn.path_info))
         apply(__MODULE__, function, [conn])
       end
 

--- a/test/support/server_helpers.ex
+++ b/test/support/server_helpers.ex
@@ -45,7 +45,14 @@ defmodule ServerHelpers do
       end
 
       def call(conn, []) do
-        function = String.to_atom(List.first(conn.path_info))
+        function =
+          conn.path_info
+          |> Enum.filter(fn path ->
+            path != ".." and path != "." and not String.starts_with?(path, "localhost:")
+          end)
+          |> List.first()
+          |> String.to_existing_atom()
+
         apply(__MODULE__, function, [conn])
       end
 


### PR DESCRIPTION
Currently only the `:abs_path` returned by `:erlang.decode_packet/3` are handled.
This adds support for the other types by extracting the `path` component of the [HttpUri](https://www.erlang.org/doc/man/erlang.html#decode_packet-3) returned by `decode_packet/3`.

Because of the URL construction [here](https://github.com/mtrudel/bandit/blob/f01d156b9b10cf51b74eaea4938361097d50f9f4/lib/bandit/http1/handler.ex#L42), the path **must** start with a slash, otherwise that will fail, therefore a slash is added to the start of the path if it is not present.

I am not sure if this is the correct or best way to handle the paths, so feedback would be appreciated!
