### PR TITLE
Fix Elixir 1.15 deprecations / warnings

### DIFF
--- a/lib/bandit/http2/connection.ex
+++ b/lib/bandit/http2/connection.ex
@@ -286,7 +286,7 @@ defmodule Bandit.HTTP2.Connection do
   # Catch-all handler for unknown frame types
 
   def handle_frame(%Frame.Unknown{} = frame, _socket, connection) do
-    Logger.warn("Unknown frame (#{inspect(Map.from_struct(frame))})")
+    Logger.warning("Unknown frame (#{inspect(Map.from_struct(frame))})")
 
     {:continue, connection}
   end

--- a/lib/bandit/http2/stream.ex
+++ b/lib/bandit/http2/stream.ex
@@ -50,7 +50,7 @@ defmodule Bandit.HTTP2.Stream do
       when state in [:open, :local_closed] do
     with :ok <- no_pseudo_headers(trailers, stream.stream_id) do
       # These are actually trailers, which Plug doesn't support. Log and ignore
-      Logger.warn("Ignoring trailers on stream #{stream.stream_id}: #{inspect(trailers)}")
+      Logger.warning("Ignoring trailers on stream #{stream.stream_id}: #{inspect(trailers)}")
 
       {:ok, stream}
     end
@@ -348,13 +348,13 @@ defmodule Bandit.HTTP2.Stream do
   end
 
   def stream_terminated(%__MODULE__{} = stream, {:bandit, reason}) do
-    Logger.warn("Stream #{stream.stream_id} was killed by bandit (#{reason})")
+    Logger.warning("Stream #{stream.stream_id} was killed by bandit (#{reason})")
 
     {:ok, %{stream | state: :closed, pid: nil}, nil}
   end
 
   def stream_terminated(%__MODULE__{} = stream, :normal) do
-    Logger.warn("Stream #{stream.stream_id} completed in unexpected state #{stream.state}")
+    Logger.warning("Stream #{stream.stream_id} completed in unexpected state #{stream.state}")
 
     {:ok, %{stream | state: :closed, pid: nil}, Errors.no_error()}
   end

--- a/test/bandit/http2/protocol_test.exs
+++ b/test/bandit/http2/protocol_test.exs
@@ -269,7 +269,7 @@ defmodule HTTP2ProtocolTest do
 
       SimpleH2Client.send_simple_headers(socket, 1, :post, "/large_headers", context.port)
 
-      random_string = for _ <- 1..60_000, into: "", do: <<Enum.random('0123456789abcdef')>>
+      random_string = for _ <- 1..60_000, into: "", do: <<Enum.random(~c"0123456789abcdef")>>
       <<to_send::binary-size(16_384), rest::binary>> = random_string
       SimpleH2Client.send_body(socket, 1, false, to_send)
 

--- a/test/support/client_helpers.ex
+++ b/test/support/client_helpers.ex
@@ -2,14 +2,14 @@ defmodule ClientHelpers do
   @moduledoc false
 
   def tcp_client(context) do
-    {:ok, socket} = :gen_tcp.connect('localhost', context[:port], active: false, mode: :binary)
+    {:ok, socket} = :gen_tcp.connect(~c"localhost", context[:port], active: false, mode: :binary)
 
     socket
   end
 
   def tls_client(context, protocols) do
     {:ok, socket} =
-      :ssl.connect('localhost', context[:port],
+      :ssl.connect(~c"localhost", context[:port],
         active: false,
         mode: :binary,
         verify: :verify_peer,

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -3,4 +3,4 @@ ExUnit.start()
 
 # Capture all logs so we're able to assert on logging done at info level in tests
 Logger.configure(level: :debug)
-Logger.configure_backend(:console, level: :warn)
+Logger.configure_backend(:console, level: :warning)


### PR DESCRIPTION
While test-driving 1.15 I noticed some warnings.

`Logger.warn/2` will be deprecated in favor of `Logger.warning/2`. 
As it is available since `1.11` and Bandit defines `~> 1.11` as elixir version this shouldn't be a problem.

And `mix format` defaults to `~c` for charlist now.