### PR TITLE
fix: chunk callback expects iodata in second argument

### DIFF
--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -295,7 +295,7 @@ defmodule Bandit.HTTP1.Adapter do
 
   @impl Plug.Conn.Adapter
   def chunk(%__MODULE__{socket: socket}, chunk) do
-    byte_size = chunk |> byte_size() |> Integer.to_string(16)
+    byte_size = chunk |> IO.iodata_length() |> Integer.to_string(16)
     Socket.send(socket, [byte_size, "\r\n", chunk, "\r\n"])
     :ok
   end


### PR DESCRIPTION
byte_size/1 only accepts bitstrings,
Whereas IO.iodata_length accepts iodata.

Implements fix mentioned in #63 