### PR TITLE
Faster content-length parsing

### DIFF
--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -133,6 +133,9 @@ defmodule Bandit.HTTP1.Adapter do
         rest
         |> Plug.Conn.Utils.list()
         |> enforce_unique_value(to_string(length), length)
+
+      :error ->
+        {:error, "invalid content-length header (RFC9112§6.3.5)"}
     end
   end
 

--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -124,7 +124,7 @@ defmodule Bandit.HTTP1.Adapter do
     end
   end
 
-  def parse_content_length(value) do
+  defp parse_content_length(value) do
     case Integer.parse(value) do
       {length, ""} ->
         {:ok, length}

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -381,6 +381,20 @@ defmodule HTTP1RequestTest do
       assert response.status == 400
     end
 
+    @tag capture_log: true
+    test "rejects a request with non-integer content length", context do
+      {:ok, response} =
+        Finch.build(
+          :post,
+          context[:base] <> "/expect_body_with_multiple_content_length",
+          [{"connection", "close"}, {"content-length", "foo"}],
+          String.duplicate("a", 8_000)
+        )
+        |> Finch.request(context[:finch_name])
+
+      assert response.status == 400
+    end
+
     test "reads a content-length encoded body properly when more of it arrives than we want to read",
          context do
       {:ok, response} =


### PR DESCRIPTION
I looked over the content-length parsing again and found a solution, which should be as fast as before for single content-length values (which should be the default case most of the time), but a bit slower for multiple values.

Benchmark:

```bash
##### With input multiple #####
Name              ips        average  deviation         median         99th %
current        1.77 M      565.85 ns  ±5890.01%         458 ns        1417 ns
fast           1.63 M      612.88 ns  ±4632.45%         500 ns         667 ns

Comparison: 
current        1.77 M
fast           1.63 M - 1.08x slower +47.04 ns

Memory usage statistics:

Name       Memory usage
current           736 B
fast              728 B - 0.99x memory usage -8 B

**All measurements for memory usage were the same**

##### With input single #####
Name              ips        average  deviation         median         99th %
fast           8.26 M      121.03 ns ±25411.46%          83 ns         125 ns
current        2.52 M      396.97 ns  ±5671.71%         375 ns         459 ns

Comparison: 
fast           8.26 M
current        2.52 M - 3.28x slower +275.94 ns

Memory usage statistics:

Name       Memory usage
fast              152 B
current           288 B - 1.89x memory usage +136 B

**All measurements for memory usage were the same**
```

Code: 

```elixir
defmodule Adapter do
  # Current implementation
  def enforce_unique_value([value]), do: {:ok, value}
  def enforce_unique_value([value | rest]), do: enforce_unique_value(rest, value)
  def enforce_unique_value([], value), do: {:ok, value}
  def enforce_unique_value([value | rest], value), do: enforce_unique_value(rest, value)

  def enforce_unique_value(_values, _value),
    do: {:error, "invalid content-length header (RFC9112§6.3.5)"}

  # New inmplementation
  def parse_content_length(str) do
    case Integer.parse(str) do
      {value, ""} -> {:ok, value}
      {value, rest} -> enforce_int(Plug.Conn.Utils.list(rest), to_string(value), value)
    end
  end

  def enforce_int([], _str, value), do: {:ok, value}
  def enforce_int([value | rest], value, int), do: enforce_int(rest, value, int)
  def enforce_int(_values, _value), do: {:error, "invalid content-length header (RFC9112§6.3.5)"}
end

Benchee.run(
  %{
    "current" => fn input ->
      {:ok, value} =
        input
        |> Plug.Conn.Utils.list()
        |> Adapter.enforce_unique_value()

      {_val, ""} = Integer.parse(value)
    end,
    "fast" => fn input ->
      {:ok, _val} = Adapter.parse_content_length(input)
    end,
  },
  time: 10,
  memory_time: 2,
  inputs: %{
    single: "8000",
    multiple: "8000,8000,8000,8000"
  }
)

```