### PR TITLE
Use references as unique process identifiers to support multiple Bandits

### DIFF
--- a/lib/bandit.ex
+++ b/lib/bandit.ex
@@ -142,7 +142,7 @@ defmodule Bandit do
 
   @spec child_spec(keyword()) :: Supervisor.child_spec()
   def child_spec(arg) do
-    %{id: Bandit, start: {__MODULE__, :start_link, [arg]}}
+    %{id: make_ref(), start: {__MODULE__, :start_link, [arg]}}
   end
 
   @doc """

--- a/test/bandit/server_test.exs
+++ b/test/bandit/server_test.exs
@@ -1,8 +1,11 @@
 defmodule ServerTest do
   use ExUnit.Case, async: true
   use ServerHelpers
+  use FinchHelpers
 
   import ExUnit.CaptureLog
+
+  setup :finch_http1_client
 
   test "server logs connection details at startup" do
     logs =
@@ -17,5 +20,28 @@ defmodule ServerTest do
 
     assert logs =~
              "Running ServerTest with Bandit #{Application.spec(:bandit)[:vsn]} at 127.0.0.1"
+  end
+
+  test "can run multiple instances of Bandit", context do
+    start_supervised({Bandit, scheme: :http, plug: __MODULE__, options: [port: 4000]})
+    start_supervised({Bandit, scheme: :http, plug: __MODULE__, options: [port: 4001]})
+
+    {:ok, response} =
+      Finch.build(:get, "http://localhost:4000/hello")
+      |> Finch.request(context[:finch_name])
+
+    assert response.status == 200
+    assert response.body == "OK"
+
+    {:ok, response} =
+      Finch.build(:get, "http://localhost:4001/hello")
+      |> Finch.request(context[:finch_name])
+
+    assert response.status == 200
+    assert response.body == "OK"
+  end
+
+  def hello(conn) do
+    conn |> send_resp(200, "OK")
   end
 end


### PR DESCRIPTION
Fixes #75 