### PR TITLE
Inline masking

### DIFF
--- a/lib/bandit/websocket/frame.ex
+++ b/lib/bandit/websocket/frame.ex
@@ -95,6 +95,7 @@ defmodule Bandit.WebSocket.Frame do
   defp mask_and_length(length) when length <= 65_535, do: <<0::1, 126::7, length::16>>
   defp mask_and_length(length), do: <<0::1, 127::7, length::64>>
 
+  @compile {:inline, mask: 2, do_mask: 3}
   # Masking is done @mask_size bits at a time until there is less than that number of bits left.
   # We then go 32 bits at a time until there is less than 32 bits left. We then go 8 bits at
   # a time. This yields some significant perforamnce gains for only marginally more complexity


### PR DESCRIPTION
Inlining the mask function seems to yield some more performance benefits.

<details>
<summary>Benchmark</summary>

```elixir
Operating System: macOS
CPU Information: Apple M1 Pro
Number of Available Cores: 10
Available memory: 32 GB
Elixir 1.15.0-dev
Erlang 25.2.1

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 10 s
memory time: 2 s
reduction time: 0 ns
parallel: 1
inputs: huge, large, medium, micro, small, tiny
Estimated total run time: 2.80 min

Benchmarking current with input huge ...
Benchmarking current with input large ...
Benchmarking current with input medium ...
Benchmarking current with input micro ...
Benchmarking current with input small ...
Benchmarking current with input tiny ...
Benchmarking current_inlined with input huge ...
Benchmarking current_inlined with input large ...
Benchmarking current_inlined with input medium ...
Benchmarking current_inlined with input micro ...
Benchmarking current_inlined with input small ...
Benchmarking current_inlined with input tiny ...

##### With input huge #####
Name                      ips        average  deviation         median         99th %
current_inlined        377.47        2.65 ms    ±46.17%        2.34 ms        8.56 ms
current                315.21        3.17 ms    ±52.98%        2.71 ms       11.99 ms

Comparison:
current_inlined        377.47
current                315.21 - 1.20x slower +0.52 ms

Memory usage statistics:

Name               Memory usage
current_inlined         4.11 MB
current                 4.41 MB - 1.07x memory usage +0.30 MB

**All measurements for memory usage were the same**

##### With input large #####
Name                      ips        average  deviation         median         99th %
current_inlined        3.47 K      287.88 μs    ±62.34%      277.08 μs      555.56 μs
current                3.11 K      321.55 μs   ±118.10%      294.75 μs      862.33 μs

Comparison:
current_inlined        3.47 K
current                3.11 K - 1.12x slower +33.67 μs

Memory usage statistics:

Name               Memory usage
current_inlined       422.02 KB
current               452.69 KB - 1.07x memory usage +30.66 KB

**All measurements for memory usage were the same**

##### With input medium #####
Name                      ips        average  deviation         median         99th %
current_inlined       26.36 K       37.93 μs   ±326.09%       19.38 μs      614.08 μs
current               23.46 K       42.63 μs   ±464.79%       20.25 μs      608.37 μs

Comparison:
current_inlined       26.36 K
current               23.46 K - 1.12x slower +4.70 μs

Memory usage statistics:

Name               Memory usage
current_inlined        42.77 KB
current                45.89 KB - 1.07x memory usage +3.13 KB

**All measurements for memory usage were the same**

##### With input micro #####
Name                      ips        average  deviation         median         99th %
current_inlined        1.21 M      824.34 ns ±13368.33%         208 ns        1250 ns
current                1.13 M      881.30 ns ±12486.04%         208 ns        1292 ns

Comparison:
current_inlined        1.21 M
current                1.13 M - 1.07x slower +56.95 ns

Memory usage statistics:

Name               Memory usage
current_inlined           488 B
current                   528 B - 1.08x memory usage +40 B

**All measurements for memory usage were the same**

##### With input small #####
Name                      ips        average  deviation         median         99th %
current_inlined      189.49 K        5.28 μs  ±1578.45%        2.50 μs        7.50 μs
current              167.15 K        5.98 μs  ±1661.28%        2.54 μs        7.63 μs

Comparison:
current_inlined      189.49 K
current              167.15 K - 1.13x slower +0.71 μs

Memory usage statistics:

Name               Memory usage
current_inlined         5.23 KB
current                 5.70 KB - 1.09x memory usage +0.47 KB

**All measurements for memory usage were the same**

##### With input tiny #####
Name                      ips        average  deviation         median         99th %
current_inlined      489.05 K        2.04 μs  ±5209.21%        0.71 μs        2.08 μs
current              397.25 K        2.52 μs  ±5079.90%        0.71 μs        2.08 μs

Comparison:
current_inlined      489.05 K
current              397.25 K - 1.23x slower +0.47 μs

Memory usage statistics:

Name               Memory usage
current_inlined         1.36 KB
current                 1.55 KB - 1.14x memory usage +0.195 KB

**All measurements for memory usage were the same**
```
</details>