### PR TITLE
Use Plug.Conn.Status.reason_phrase/1

### DIFF
--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -302,7 +302,7 @@ defmodule Bandit.HTTP1.Adapter do
       " ",
       to_string(status),
       " ",
-      reason_for_status(status),
+      Plug.Conn.Status.reason_phrase(status),
       "\r\n",
       Enum.map(headers, fn {k, v} -> [k, ": ", v, "\r\n"] end),
       "\r\n"
@@ -331,53 +331,4 @@ defmodule Bandit.HTTP1.Adapter do
   def get_http_protocol(%__MODULE__{version: version}), do: version
 
   def keepalive?(%__MODULE__{keepalive: keepalive}), do: keepalive
-
-  response_reasons = %{
-    100 => "Continue",
-    101 => "Switching Protocols",
-    200 => "OK",
-    201 => "Created",
-    202 => "Accepted",
-    203 => "Non-Authoritative Information",
-    204 => "No Content",
-    205 => "Reset Content",
-    206 => "Partial Content",
-    300 => "Multiple Choices",
-    301 => "Moved Permanently",
-    302 => "Found",
-    303 => "See Other",
-    304 => "Not Modified",
-    305 => "Use Proxy",
-    307 => "Temporary Redirect",
-    400 => "Bad Request",
-    401 => "Unauthorized",
-    402 => "Payment Required",
-    403 => "Forbidden",
-    404 => "Not Found",
-    405 => "Method Not Allowed",
-    406 => "Not Acceptable",
-    407 => "Proxy Authentication Required",
-    408 => "Request Time-out",
-    409 => "Conflict",
-    410 => "Gone",
-    411 => "Length Required",
-    412 => "Precondition Failed",
-    413 => "Request Entity Too Large",
-    414 => "Request-URI Too Large",
-    415 => "Unsupported Media Type",
-    416 => "Requested range not satisfiable",
-    417 => "Expectation Failed",
-    500 => "Internal Server Error",
-    501 => "Not Implemented",
-    502 => "Bad Gateway",
-    503 => "Service Unavailable",
-    504 => "Gateway Time-out",
-    505 => "HTTP Version not supported"
-  }
-
-  for {code, reason} <- response_reasons do
-    defp reason_for_status(unquote(code)), do: unquote(reason)
-  end
-
-  defp reason_for_status(_), do: "Unknown Status Code"
 end


### PR DESCRIPTION
As an alternative to [Add some common HTTP status codes #94](https://github.com/mtrudel/bandit/pull/94), this PR removes Bandit's logic for generating status text from HTTP status codes and replaces it with [`Plug.Conn.Status.reason_phrase/1`](https://github.com/elixir-plug/plug/blob/d7940552e365e0d3245bb78ca99429ea5c324f7d/lib/plug/conn/status.ex#L146-L174).

Thanks to @moogle19 for [suggesting this](https://github.com/mtrudel/bandit/issues/93#issuecomment-1420385066).

The [status code list from Plug](https://github.com/elixir-plug/plug/blob/d7940552e365e0d3245bb78ca99429ea5c324f7d/lib/plug/conn/status.ex#L8-L72) matches the existing Bandit list, plus what was added in #94, plus HTTP 306 Switch Proxy, a deprecated status code in reserved space that some servers may return when presumably communicating with very old clients.

Currently, this PR is a breaking change to Bandit, because Plug's default behavior is to [raise when an unknown status code is encountered](https://github.com/elixir-plug/plug/blob/d7940552e365e0d3245bb78ca99429ea5c324f7d/lib/plug/conn/status.ex#L153-L174). However, non-standard HTTP status codes can still be registered via configuration: `config :plug, :statuses, %{998 => "Not An RFC Status Code"}`.

Overall, I think this is an improvement to Bandit and favorable over #94:

- Removes a divergence between Bandit and Plug.
- Provides an escape hatch for non-standard HTTP status codes.
- Removes the burden on Bandit maintainers of having to decide which status codes to include.

If we wanted to land this change in a non-breaking manner (assuming that the change from "Unknown Status Code" to the newly included status texts is not breaking), we could instead apply this patch to this PR and land the breaking version later:

```patch
diff --git c/lib/bandit/http1/adapter.ex w/lib/bandit/http1/adapter.ex
index 1ea4525..3f1ba2c 100644
--- c/lib/bandit/http1/adapter.ex
+++ w/lib/bandit/http1/adapter.ex
@@ -1,6 +1,8 @@
 defmodule Bandit.HTTP1.Adapter do
   @moduledoc false
 
+  require Logger
+
   @type state :: :new | :headers_read | :no_body | :body_read | :sent | :chunking_out
 
   @behaviour Plug.Conn.Adapter
@@ -302,7 +304,7 @@ defmodule Bandit.HTTP1.Adapter do
       " ",
       to_string(status),
       " ",
-      Plug.Conn.Status.reason_phrase(status),
+      reason_phrase(status),
       "\r\n",
       Enum.map(headers, fn {k, v} -> [k, ": ", v, "\r\n"] end),
       "\r\n"
@@ -331,4 +333,15 @@ defmodule Bandit.HTTP1.Adapter do
   def get_http_protocol(%__MODULE__{version: version}), do: version
 
   def keepalive?(%__MODULE__{keepalive: keepalive}), do: keepalive
+
+  defp reason_phrase(status) do
+    Plug.Conn.Status.reason_phrase(status)
+  rescue
+    e in ArgumentError ->
+      # Raising ArgumentError would be breaking, so we rescue until the next
+      # major version. Log the error as a debug message so users are notified
+      # they can provide configuration for non-standard codes.
+      Logger.debug(e.message)
+      "Unknown Status Code"
+  end
 end
```

Closes #93 