### PR TITLE
Fix host header consumption for ipv6 hostnames

### DIFF
--- a/lib/bandit/headers.ex
+++ b/lib/bandit/headers.ex
@@ -11,6 +11,22 @@ defmodule Bandit.Headers do
     end
   end
 
+  # covers ipv6 addresses, which look like this: `[::1]:4000` as defined in RFC2732
+  def parse_hostlike_header("[" <> _ = host_header) do
+    host_header
+    |> :binary.split("]:")
+    |> case do
+      [host, port] ->
+        case Integer.parse(port) do
+          {port, ""} when port > 0 -> {:ok, host <> "]", port}
+          _ -> {:error, "Header contains invalid port"}
+        end
+
+      [host] ->
+        {:ok, host, nil}
+    end
+  end
+
   def parse_hostlike_header(host_header) do
     host_header
     |> :binary.split(":")

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -186,6 +186,7 @@ defmodule HTTP1RequestTest do
       assert Jason.decode!(body)["host"] == "banana"
     end
 
+    @tag :skip
     test "derives ipv6 host from the URI, even if it differs from host header", context do
       client = SimpleHTTP1Client.tcp_client(context)
 

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -61,6 +61,14 @@ defmodule HTTP1RequestTest do
       assert Jason.decode!(body)["port"] == 1234
     end
 
+    test "derives host and port from host header with ipv6 host", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+      SimpleHTTP1Client.send(client, "GET", "/echo_components", ["host: [::1]:1234"])
+      assert {:ok, "200 OK", _headers, body} = SimpleHTTP1Client.recv_reply(client)
+      assert Jason.decode!(body)["host"] == "[::1]"
+      assert Jason.decode!(body)["port"] == 1234
+    end
+
     @tag capture_log: true
     test "returns 400 if port cannot be parsed from host header", context do
       client = SimpleHTTP1Client.tcp_client(context)

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -186,6 +186,7 @@ defmodule HTTP1RequestTest do
       assert Jason.decode!(body)["host"] == "banana"
     end
 
+    # Skip this test since there is a bug in :erlang.decode_packet. See https://github.com/mtrudel/bandit/pull/97
     @tag :skip
     test "derives ipv6 host from the URI, even if it differs from host header", context do
       client = SimpleHTTP1Client.tcp_client(context)


### PR DESCRIPTION
Good morning!

Last time I found something, I missed my chance to get a PR in, so I'm hoping to rectify that this time ;)

I was seeing errors when accessing my local server using its IPv6 address as hostname (some HTTP clients unfortunately convert localhost to `[::1]` automatically). So I did some digging and discovered that bandit just didn't cover this case at all.

I think this PR should just about cover it. Let me know if you'd prefer to see something changed in here.

Also I have to say, the more I read the code the more impressed I am with bandit / thousand island. It isn't a trivial task to make code that is this clear, let alone an http server implementation. I was able to find and fix this (including puzzling over how to make the actual function body not look insane) in about 40 minutes.