### PR TITLE
Support extended connection close return values

### DIFF
--- a/lib/bandit/websocket/connection.ex
+++ b/lib/bandit/websocket/connection.ex
@@ -170,15 +170,8 @@ defmodule Bandit.WebSocket.Connection do
 
   def handle_close(socket, connection), do: do_error(1006, :closed, socket, connection)
 
-  def handle_shutdown(socket, connection) do
-    if connection.state == :open do
-      connection.websock.terminate(:shutdown, connection.websock_state)
-
-      # Some uncertainty if this should be 1000 or 1001 @ https://github.com/mtrudel/bandit/issues/89
-      Socket.close(socket, 1000)
-      Bandit.Telemetry.stop_span(connection.span, connection.metrics)
-    end
-  end
+  # Some uncertainty if this should be 1000 or 1001 @ https://github.com/mtrudel/bandit/issues/89
+  def handle_shutdown(socket, connection), do: do_stop(1000, :shutdown, socket, connection)
 
   def handle_error({:protocol, reason}, socket, connection),
     do: do_error(1002, reason, socket, connection)

--- a/lib/bandit/websocket/connection.ex
+++ b/lib/bandit/websocket/connection.ex
@@ -210,10 +210,10 @@ defmodule Bandit.WebSocket.Connection do
         do_deflate(msg, socket, %{connection | websock_state: websock_state})
 
       {:stop, :normal, websock_state} ->
-        do_stop(1000, socket, %{connection | websock_state: websock_state})
+        do_stop(1000, :normal, socket, %{connection | websock_state: websock_state})
 
       {:stop, :normal, code, websock_state} ->
-        do_stop(code, socket, %{connection | websock_state: websock_state})
+        do_stop(code, :normal, socket, %{connection | websock_state: websock_state})
 
       {:stop, reason, websock_state} ->
         do_error(1011, reason, socket, %{connection | websock_state: websock_state})
@@ -223,9 +223,9 @@ defmodule Bandit.WebSocket.Connection do
     end
   end
 
-  defp do_stop(code, socket, connection) do
+  defp do_stop(code, reason, socket, connection) do
     if connection.state == :open do
-      connection.websock.terminate(:normal, connection.websock_state)
+      connection.websock.terminate(reason, connection.websock_state)
       Socket.close(socket, code)
       Bandit.Telemetry.stop_span(connection.span, connection.metrics)
     end

--- a/lib/bandit/websocket/connection.ex
+++ b/lib/bandit/websocket/connection.ex
@@ -184,14 +184,7 @@ defmodule Bandit.WebSocket.Connection do
     do: do_error(1002, reason, socket, connection)
 
   def handle_error(reason, socket, connection), do: do_error(1011, reason, socket, connection)
-
-  def handle_timeout(socket, connection) do
-    if connection.state == :open do
-      connection.websock.terminate(:timeout, connection.websock_state)
-      Socket.close(socket, 1002)
-      Bandit.Telemetry.stop_span(connection.span, connection.metrics, %{error: :timeout})
-    end
-  end
+  def handle_timeout(socket, connection), do: do_error(1002, :timeout, socket, connection)
 
   def handle_info(msg, socket, connection) do
     connection.websock.handle_info(msg, connection.websock_state)

--- a/lib/bandit/websocket/connection.ex
+++ b/lib/bandit/websocket/connection.ex
@@ -117,8 +117,8 @@ defmodule Bandit.WebSocket.Connection do
         # This is a bit of a subtle case, see RFC6455§7.4.1-2
         reply_code =
           case frame.code do
-            code when code in 0..999 or code in 1004..1006 or code in 1012..2999 -> 1002
-            _code -> 1000
+            code when code in 1000..1003 or code in 1007..1011 or code > 2999 -> 1000
+            _code -> 1002
           end
 
         do_stop(reply_code, :remote, socket, connection)

--- a/lib/bandit/websocket/socket.ex
+++ b/lib/bandit/websocket/socket.ex
@@ -10,7 +10,7 @@ defprotocol Bandit.WebSocket.Socket do
           keyword()
   def send_frame(socket, data_and_frame_type, compressed)
 
-  @spec close(socket :: t(), code :: Bandit.WebSocket.Frame.ConnectionClose.status_code()) :: :ok
+  @spec close(socket :: t(), code :: WebSock.close_detail()) :: :ok
   def close(socket, code)
 end
 
@@ -42,7 +42,12 @@ defimpl Bandit.WebSocket.Socket, for: ThousandIsland.Socket do
     [send_pong_frame_count: 1, send_pong_frame_bytes: IO.iodata_length(data)]
   end
 
-  def close(socket, code) do
+  def close(socket, {code, detail}) when is_integer(code) do
+    do_send_frame(socket, %Frame.ConnectionClose{code: code, reason: detail})
+    ThousandIsland.Socket.shutdown(socket, :write)
+  end
+
+  def close(socket, code) when is_integer(code) do
     do_send_frame(socket, %Frame.ConnectionClose{code: code})
     ThousandIsland.Socket.shutdown(socket, :write)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule Bandit.MixProject do
     [
       {:thousand_island, "~> 0.6.1"},
       {:plug, "~> 1.14"},
-      {:websock, "~> 0.4.3"},
+      {:websock, "~> 0.5"},
       {:hpax, "~> 0.1.1"},
       {:telemetry, "~> 0.4 or ~> 1.0"},
       {:finch, "~> 0.8", only: [:dev, :test]},

--- a/mix.lock
+++ b/mix.lock
@@ -24,5 +24,5 @@
   "plug_crypto": {:hex, :plug_crypto, "1.2.3", "8f77d13aeb32bfd9e654cb68f0af517b371fb34c56c9f2b58fe3df1235c1251a", [:mix], [], "hexpm", "b5672099c6ad5c202c45f5a403f21a3411247f164e4a8fab056e5cd8a290f4a2"},
   "telemetry": {:hex, :telemetry, "1.2.1", "68fdfe8d8f05a8428483a97d7aab2f268aaff24b49e0f599faa091f1d4e7f61c", [:rebar3], [], "hexpm", "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5"},
   "thousand_island": {:hex, :thousand_island, "0.6.2", "4b87f315b767ed6960d1d4b5aee015522d2d2ba12a14144a7b03e706d945e60b", [:mix], [{:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "84dde4cc8a876bc5993083153ec90a8c3f2feeb57b4a12b1a3206c929e75e226"},
-  "websock": {:hex, :websock, "0.4.3", "184ac396bdcd3dfceb5b74c17d221af659dd559a95b1b92041ecb51c9b728093", [:mix], [], "hexpm", "5e4dd85f305f43fd3d3e25d70bec4a45228dfed60f0f3b072d8eddff335539cf"},
+  "websock": {:hex, :websock, "0.5.0", "f6bbce90226121d62a0715bca7c986c5e43de0ccc9475d79c55381d1796368cc", [:mix], [], "hexpm", "b51ac706df8a7a48a2c622ee02d09d68be8c40418698ffa909d73ae207eb5fb8"},
 }

--- a/test/bandit/websocket/protocol_test.exs
+++ b/test/bandit/websocket/protocol_test.exs
@@ -471,7 +471,7 @@ defmodule WebSocketProtocolTest do
       SimpleWebSocketClient.http1_handshake(client, TerminateWebSock)
 
       # Get the error that terminate saw, to ensure we're closing for the expected reason
-      assert_receive :timeout, 1500
+      assert_receive {:error, :timeout}, 1500
 
       # Validate that the server has started the shutdown handshake from RFC6455§7.1.2
       assert SimpleWebSocketClient.recv_connection_close_frame(client) == {:ok, <<1002::16>>}
@@ -488,7 +488,7 @@ defmodule WebSocketProtocolTest do
       SimpleWebSocketClient.send_text_frame(client, "OK")
 
       # Get the error that terminate saw, to ensure we're closing for the expected reason
-      assert_receive :timeout, 1500
+      assert_receive {:error, :timeout}, 1500
 
       # Validate that the server has started the shutdown handshake from RFC6455§7.1.2
       assert SimpleWebSocketClient.recv_connection_close_frame(client) == {:ok, <<1002::16>>}

--- a/test/bandit/websocket/sock_test.exs
+++ b/test/bandit/websocket/sock_test.exs
@@ -931,7 +931,7 @@ defmodule WebSocketWebSockTest do
       client = SimpleWebSocketClient.tcp_client(context)
       SimpleWebSocketClient.http1_handshake(client, TerminateWebSock)
 
-      assert_receive :timeout, 1500
+      assert_receive {:error, :timeout}, 1500
     end
   end
 

--- a/test/bandit/websocket/upgrade_test.exs
+++ b/test/bandit/websocket/upgrade_test.exs
@@ -48,7 +48,7 @@ defmodule WebSocketUpgradeTest do
 
       # Ensure that the passed timeout was recognized
       then = System.monotonic_time(:millisecond)
-      assert_receive :timeout, 500
+      assert_receive {:error, :timeout}, 500
       now = System.monotonic_time(:millisecond)
       assert_in_delta now, then + 250, 50
     end


### PR DESCRIPTION
Implements Bandit support for close tuples as described in https://github.com/phoenixframework/websock_adapter/issues/2; supports callbacks to return {:stop, reason, code, state} or {:stop, reason, {code, detail}, state}.

Pairs with / requires https://github.com/phoenixframework/websock/pull/6.