### PR TITLE
Adjustable info log for server startup

### DIFF
--- a/lib/bandit.ex
+++ b/lib/bandit.ex
@@ -71,7 +71,7 @@ defmodule Bandit do
   * `scheme`: One of `:http` or `:https`. If `:https` is specified, you will need
      to specify `certfile` and `keyfile` in the `transport_options` subsection of `options`.
      Defaults to `:http`
-  * `:log` - Log level to use for Bandit start log event.
+  * `:startup_log` - The log level at which Bandit should log startup info.
     Defaults to `:info` log level, can be set to false to disable it.
   * `options`: Options to pass to `ThousandIsland`. For an exhaustive list of options see the
     `ThousandIsland` documentation, however some common options are:
@@ -216,7 +216,7 @@ defmodule Bandit do
     arg =
       arg
       |> validate_options(
-        ~w(scheme plug display_plug options http_1_options http_2_options websocket_options log)a,
+        ~w(scheme plug display_plug options http_1_options http_2_options websocket_options startup_log)a,
         "top level"
       )
 
@@ -254,7 +254,7 @@ defmodule Bandit do
 
     {plug_mod, _} = plug = plug(arg)
     display_plug = Keyword.get(arg, :display_plug, plug_mod)
-    log = Keyword.get(arg, :log, :info)
+    startup_log = Keyword.get(arg, :startup_log, :info)
 
     handler_options = %{
       plug: plug,
@@ -278,7 +278,7 @@ defmodule Bandit do
     |> ThousandIsland.start_link()
     |> case do
       {:ok, pid} ->
-        log && Logger.log(log, info(scheme, display_plug, pid))
+        startup_log && Logger.log(startup_log, info(scheme, display_plug, pid))
         {:ok, pid}
 
       {:error, _} = error ->

--- a/lib/bandit.ex
+++ b/lib/bandit.ex
@@ -281,6 +281,13 @@ defmodule Bandit do
         startup_log && Logger.log(startup_log, info(scheme, display_plug, pid))
         {:ok, pid}
 
+      {:error, {:shutdown, {:failed_to_start_child, :listener, :eaddrinuse}}} = error ->
+        port = Keyword.get(options, :port, 4000)
+        address = options |> Keyword.get(:transport_options, []) |> Keyword.get(:ip, {127, 0, 0, 1})
+
+        Logger.error([info(scheme, display_plug, %{port: port, address: address}), " failed, port already in use"])
+        error
+
       {:error, _} = error ->
         error
     end
@@ -306,14 +313,18 @@ defmodule Bandit do
     end
   end
 
-  defp info(scheme, plug, pid) do
+  defp info(scheme, plug, pid_or_info) do
     server_vsn = Application.spec(:bandit)[:vsn]
-    "Running #{inspect(plug)} with Bandit #{server_vsn} at #{bound_address(scheme, pid)}"
+    "Running #{inspect(plug)} with Bandit #{server_vsn} at #{bound_address(scheme, pid_or_info)}"
   end
 
-  defp bound_address(scheme, pid) do
-    {:ok, %{address: address, port: port}} = ThousandIsland.listener_info(pid)
+  defp bound_address(scheme, pid) when is_pid(pid) do
+    {:ok, info} = ThousandIsland.listener_info(pid)
 
+    bound_address(scheme, info)
+  end
+
+  defp bound_address(scheme, %{address: address, port: port}) do
     case address do
       {:local, unix_path} ->
         "#{unix_path} (#{scheme}+unix)"

--- a/lib/bandit.ex
+++ b/lib/bandit.ex
@@ -282,10 +282,7 @@ defmodule Bandit do
         {:ok, pid}
 
       {:error, {:shutdown, {:failed_to_start_child, :listener, :eaddrinuse}}} = error ->
-        port = Keyword.get(options, :port, 4000)
-        address = options |> Keyword.get(:transport_options, []) |> Keyword.get(:ip, {127, 0, 0, 1})
-
-        Logger.error([info(scheme, display_plug, %{port: port, address: address}), " failed, port already in use"])
+        Logger.error("Startup failed; address/port already in use")
         error
 
       {:error, _} = error ->
@@ -313,18 +310,14 @@ defmodule Bandit do
     end
   end
 
-  defp info(scheme, plug, pid_or_info) do
+  defp info(scheme, plug, pid) do
     server_vsn = Application.spec(:bandit)[:vsn]
-    "Running #{inspect(plug)} with Bandit #{server_vsn} at #{bound_address(scheme, pid_or_info)}"
+    "Running #{inspect(plug)} with Bandit #{server_vsn} at #{bound_address(scheme, pid)}"
   end
 
-  defp bound_address(scheme, pid) when is_pid(pid) do
-    {:ok, info} = ThousandIsland.listener_info(pid)
+  defp bound_address(scheme, pid) do
+    {:ok, %{address: address, port: port}} = ThousandIsland.listener_info(pid)
 
-    bound_address(scheme, info)
-  end
-
-  defp bound_address(scheme, %{address: address, port: port}) do
     case address do
       {:local, unix_path} ->
         "#{unix_path} (#{scheme}+unix)"

--- a/lib/bandit.ex
+++ b/lib/bandit.ex
@@ -71,6 +71,8 @@ defmodule Bandit do
   * `scheme`: One of `:http` or `:https`. If `:https` is specified, you will need
      to specify `certfile` and `keyfile` in the `transport_options` subsection of `options`.
      Defaults to `:http`
+  * `:log` - Log level to use for Bandit start log event.
+    Defaults to `:info` log level, can be set to false to disable it.
   * `options`: Options to pass to `ThousandIsland`. For an exhaustive list of options see the
     `ThousandIsland` documentation, however some common options are:
       * `port`: The port to bind to. Defaults to 4000
@@ -214,7 +216,7 @@ defmodule Bandit do
     arg =
       arg
       |> validate_options(
-        ~w(scheme plug display_plug options http_1_options http_2_options websocket_options)a,
+        ~w(scheme plug display_plug options http_1_options http_2_options websocket_options log)a,
         "top level"
       )
 
@@ -252,6 +254,7 @@ defmodule Bandit do
 
     {plug_mod, _} = plug = plug(arg)
     display_plug = Keyword.get(arg, :display_plug, plug_mod)
+    log = Keyword.get(arg, :log, :info)
 
     handler_options = %{
       plug: plug,
@@ -275,7 +278,7 @@ defmodule Bandit do
     |> ThousandIsland.start_link()
     |> case do
       {:ok, pid} ->
-        Logger.info(info(scheme, display_plug, pid))
+        log && Logger.log(log, info(scheme, display_plug, pid))
         {:ok, pid}
 
       {:error, _} = error ->

--- a/lib/bandit.ex
+++ b/lib/bandit.ex
@@ -282,7 +282,7 @@ defmodule Bandit do
         {:ok, pid}
 
       {:error, {:shutdown, {:failed_to_start_child, :listener, :eaddrinuse}}} = error ->
-        Logger.error("Startup failed; address/port already in use")
+        Logger.error([info(scheme, display_plug, nil), " failed, port already in use"])
         error
 
       {:error, _} = error ->
@@ -315,15 +315,14 @@ defmodule Bandit do
     "Running #{inspect(plug)} with Bandit #{server_vsn} at #{bound_address(scheme, pid)}"
   end
 
+  defp bound_address(scheme, nil), do: scheme
+
   defp bound_address(scheme, pid) do
     {:ok, %{address: address, port: port}} = ThousandIsland.listener_info(pid)
 
     case address do
-      {:local, unix_path} ->
-        "#{unix_path} (#{scheme}+unix)"
-
-      address ->
-        "#{:inet.ntoa(address)}:#{port} (#{scheme})"
+      {:local, unix_path} -> "#{unix_path} (#{scheme}+unix)"
+      address -> "#{:inet.ntoa(address)}:#{port} (#{scheme})"
     end
   end
 end

--- a/test/bandit/server_test.exs
+++ b/test/bandit/server_test.exs
@@ -43,15 +43,15 @@ defmodule ServerTest do
     logs =
       capture_log(fn ->
         assert {:error, _} =
-          start_supervised({
-            Bandit,
-            scheme: :http,
-            plug: __MODULE__,
-            options: [port: port, transport_options: [ip: address]]})
+                 start_supervised({
+                   Bandit,
+                   scheme: :http,
+                   plug: __MODULE__,
+                   options: [port: port, transport_options: [ip: address]]
+                 })
       end)
 
-    assert logs =~
-      "Running ServerTest with Bandit #{Application.spec(:bandit)[:vsn]} at 0.0.0.0:4000 (http) failed, port already in use"
+    assert logs =~ " Startup failed; address/port already in use"
   end
 
   test "can run multiple instances of Bandit", context do

--- a/test/bandit/server_test.exs
+++ b/test/bandit/server_test.exs
@@ -22,6 +22,20 @@ defmodule ServerTest do
              "Running ServerTest with Bandit #{Application.spec(:bandit)[:vsn]} at 127.0.0.1"
   end
 
+  test "log: false arg disables connection detail log at startup" do
+    logs =
+      capture_log(fn ->
+        [
+          plug: __MODULE__,
+          options: [port: 0, transport_options: [ip: :loopback], log: false]
+        ]
+        |> Bandit.child_spec()
+        |> start_supervised()
+      end)
+
+    assert logs == ""
+  end
+
   test "can run multiple instances of Bandit", context do
     start_supervised({Bandit, scheme: :http, plug: __MODULE__, options: [port: 4000]})
     start_supervised({Bandit, scheme: :http, plug: __MODULE__, options: [port: 4001]})

--- a/test/bandit/server_test.exs
+++ b/test/bandit/server_test.exs
@@ -22,12 +22,12 @@ defmodule ServerTest do
              "Running ServerTest with Bandit #{Application.spec(:bandit)[:vsn]} at 127.0.0.1"
   end
 
-  test "log: false arg disables connection detail log at startup" do
+  test "startup_log: false arg disables connection detail log at startup" do
     logs =
       capture_log(fn ->
         [
           plug: __MODULE__,
-          options: [port: 0, transport_options: [ip: :loopback], log: false]
+          options: [port: 0, transport_options: [ip: :loopback], startup_log: false]
         ]
         |> Bandit.child_spec()
         |> start_supervised()

--- a/test/bandit/server_test.exs
+++ b/test/bandit/server_test.exs
@@ -51,7 +51,8 @@ defmodule ServerTest do
                  })
       end)
 
-    assert logs =~ " Startup failed; address/port already in use"
+    assert logs =~
+             "Running ServerTest with Bandit #{Application.spec(:bandit)[:vsn]} at http failed, port already in use"
   end
 
   test "can run multiple instances of Bandit", context do


### PR DESCRIPTION
I want to be able to silence the info log that Bandit by default prints. The `:log` option is lifted from how it's usually dealt with in Plug and Phoenix.

But I wonder if there should be an info log by default? With `Plug.Cowboy` and `:httpd` there are no info log for server start. This is something that Phoenix adds to the Cowboy2 adapter. If you start the server yourself you would already be aware of the URL/port settings. It makes sense for higher level like Phoenix though.

So I think maybe this info log belongs in `Bandit.PhoenixAdapter` instead. It should maybe also have a pretty print of common errors just like the Cowboy2 adapter. Right now with `:eaddrinuse` it just shows this:

```
     ** (EXIT from #PID<0.13506.0>) shutdown: failed to start child: :listener
         ** (EXIT) :eaddrinuse
```

Phoenix instead pretty prints this (using the info private function):

```
[error] Running MyAppWeb.Endpoint with cowboy 2.9.0 at http failed, port already in use
```