### PR TITLE
Stop requiring HTTP/2 adapter commands to come from stream owner process

### DIFF
--- a/lib/bandit/http2/connection.ex
+++ b/lib/bandit/http2/connection.ex
@@ -408,20 +408,19 @@ defmodule Bandit.HTTP2.Connection do
   #
   # Sending logic
   #
-  # All callers of functions below will be from stream tasks, looked up via pid
+  # All callers of functions below will be from stream tasks
   #
 
   #
   # Stream-level sending
   #
 
-  @spec send_headers(Stream.stream_id(), pid(), Plug.Conn.headers(), boolean(), Socket.t(), t()) ::
+  @spec send_headers(Stream.stream_id(), Plug.Conn.headers(), boolean(), Socket.t(), t()) ::
           {:ok, t()} | {:error, term()}
-  def send_headers(stream_id, pid, headers, end_stream, socket, connection) do
+  def send_headers(stream_id, headers, end_stream, socket, connection) do
     with enc_headers <- Enum.map(headers, fn {key, value} -> {:store, key, value} end),
          {block, send_hpack_state} <- HPAX.encode(enc_headers, connection.send_hpack_state),
          {:ok, stream} <- StreamCollection.get_stream(connection.streams, stream_id),
-         :ok <- Stream.owner?(stream, pid),
          {:ok, stream} <- Stream.send_headers(stream),
          {:ok, stream} <- Stream.send_end_of_stream(stream, end_stream),
          {:ok, streams} <- StreamCollection.put_stream(connection.streams, stream) do
@@ -436,13 +435,10 @@ defmodule Bandit.HTTP2.Connection do
     end
   end
 
-  @spec send_data(Stream.stream_id(), pid(), iodata(), boolean(), fun(), Socket.t(), t()) ::
+  @spec send_data(Stream.stream_id(), iodata(), boolean(), fun(), Socket.t(), t()) ::
           {:ok, boolean(), t()} | {:error, term()}
-  def send_data(stream_id, pid, data, end_stream, on_unblock, socket, connection) do
-    with {:ok, stream} <- StreamCollection.get_stream(connection.streams, stream_id),
-         :ok <- Stream.owner?(stream, pid) do
-      do_send_data(stream_id, data, end_stream, on_unblock, socket, connection)
-    end
+  def send_data(stream_id, data, end_stream, on_unblock, socket, connection) do
+    do_send_data(stream_id, data, end_stream, on_unblock, socket, connection)
   end
 
   defp do_send_data(stream_id, data, end_stream, on_unblock, socket, connection) do

--- a/lib/bandit/http2/handler.ex
+++ b/lib/bandit/http2/handler.ex
@@ -57,8 +57,8 @@ defmodule Bandit.HTTP2.Handler do
     Connection.shutdown_connection(Errors.no_error(), "Client timeout", socket, state.connection)
   end
 
-  def handle_call({:send_headers, stream_id, headers, end_stream}, {pid, _tag}, {socket, state}) do
-    case Connection.send_headers(stream_id, pid, headers, end_stream, socket, state.connection) do
+  def handle_call({:send_headers, stream_id, headers, end_stream}, _from, {socket, state}) do
+    case Connection.send_headers(stream_id, headers, end_stream, socket, state.connection) do
       {:ok, connection} ->
         {:reply, :ok, {socket, %{state | connection: connection}}}
 
@@ -67,7 +67,7 @@ defmodule Bandit.HTTP2.Handler do
     end
   end
 
-  def handle_call({:send_data, stream_id, data, end_stream}, {pid, _tag} = from, {socket, state}) do
+  def handle_call({:send_data, stream_id, data, end_stream}, from, {socket, state}) do
     # It's possible that this send could not complete synchronously if we do not have enough space
     # in either/both our connection or stream send windows. In this case Connection.send_data will
     # return false as the second value of its result tuple, signaling that we should `:no_reply`
@@ -77,7 +77,7 @@ defmodule Bandit.HTTP2.Handler do
     # stream's handler process in the event of window overruns
     unblock = fn -> GenServer.reply(from, :ok) end
 
-    case Connection.send_data(stream_id, pid, data, end_stream, unblock, socket, state.connection) do
+    case Connection.send_data(stream_id, data, end_stream, unblock, socket, state.connection) do
       {:ok, true, connection} ->
         {:reply, :ok, {socket, %{state | connection: connection}}}
 

--- a/lib/bandit/http2/stream.ex
+++ b/lib/bandit/http2/stream.ex
@@ -217,10 +217,6 @@ defmodule Bandit.HTTP2.Stream do
       "Received end of stream with #{stream.pending_content_length} byte(s) pending"}}
   end
 
-  @spec owner?(t(), pid()) :: :ok | {:error, :not_owner}
-  def owner?(%__MODULE__{pid: pid}, pid), do: :ok
-  def owner?(%__MODULE__{}, _pid), do: {:error, :not_owner}
-
   @spec get_send_window_size(t()) :: non_neg_integer()
   def get_send_window_size(%__MODULE__{} = stream), do: stream.send_window_size
 


### PR DESCRIPTION
Relevant to your interests @danschultzer
