### PR TITLE
Require Elixir 1.12

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Bandit.MixProject do
     [
       app: :bandit,
       version: "0.7.4",
-      elixir: "~> 1.11",
+      elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       elixirc_paths: elixirc_path(Mix.env()),


### PR DESCRIPTION
Got an error testing with Elixir 1.11, because of `Kernel.then/2` usage.

`mtrudel/elixir-ci-actions/.github/workflows/test.yml@main` tests from 1.12 so this was not caught, maybe it should explicitly test the lowest version supported just to ensure that there's no drift in the CI?