### PR TITLE
Remove `:otp_app` after SSL configuration

### DIFF
--- a/lib/bandit.ex
+++ b/lib/bandit.ex
@@ -109,7 +109,7 @@ defmodule Bandit do
     valid `certfile` and `keyfile` values (or an equivalent value within
     `thousand_island_options.transport_options`). Defaults to `:http`
   * `port`: The TCP port to listen on. This option is offered as a convenience and actually sets
-    the option of the same name within `thousand_island_options`. If ia string value is passed, it 
+    the option of the same name within `thousand_island_options`. If ia string value is passed, it
     will be parsed as an integer. Defaults to 4000 if `scheme` is `:http`, and 4040 if `scheme` is
     `:https`
   * `ip`:  The interface(s) to listen on. This option is offered as a convenience and actually sets the
@@ -345,6 +345,7 @@ defmodule Bandit do
               {:ok, options} -> options
               {:error, message} -> raise "Plug.SSL.configure/1 encountered error: #{message}"
             end
+            |> Keyword.delete(:otp_app)
 
           {ThousandIsland.Transports.SSL, transport_options, 4040}
       end


### PR DESCRIPTION
`Plug.SSL.configure/1` [requires the `:otp_app` key,](https://github.com/elixir-plug/plug/blob/2ef07cdd2732cde5cac73fc39b49fe83d5fcc369/lib/plug/ssl.ex#L226-L232) when using relative certificate paths.

If the `:otp_app` key is set, it is kept in the `transport_options` of the `ThousandIsland.ServerConfig`, which results in a `:badarg` when `:ssl.listen/2` is called [here](https://github.com/mtrudel/thousand_island/blob/ed8dff6d5c9bf147bbe06e3e8e501b6e0654fc12/lib/thousand_island/listener.ex#L12).

`Plug.Cowboy` does the same thing [here](https://github.com/elixir-plug/plug_cowboy/blob/1796e77aa42c2284f3667c7aeac7074236f47c07/lib/plug/cowboy.ex#L355).

I am not sure why this field is kept in the config and not removed by `Plug.SSL.configure/1`.