### PR TITLE
Use valid path to avoid false negative

### DIFF
--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -21,7 +21,7 @@ defmodule HTTP1RequestTest do
     @tag capture_log: true
     test "returns a 400 if the request has an invalid http version", context do
       client = SimpleHTTP1Client.tcp_client(context)
-      SimpleHTTP1Client.send(client, "GET", "./../non_absolute_path", ["host: localhost"], "0.9")
+      SimpleHTTP1Client.send(client, "GET", "/echo_components", ["host: localhost"], "0.9")
       assert {:ok, "400 Bad Request", _headers, <<>>} = SimpleHTTP1Client.recv_reply(client)
     end
   end


### PR DESCRIPTION
When testing for invalid version, we should use a valid path. 
Otherwise the assert wouldn't fail when the version check fails, since the invalid path also returns `400` (with "Unsupported request target (RFC9112§3.2)")