### PR TITLE
Minor performance improvement

### DIFF
--- a/lib/bandit.ex
+++ b/lib/bandit.ex
@@ -109,7 +109,7 @@ defmodule Bandit do
     valid `certfile` and `keyfile` values (or an equivalent value within
     `thousand_island_options.transport_options`). Defaults to `:http`
   * `port`: The TCP port to listen on. This option is offered as a convenience and actually sets
-    the option of the same name within `thousand_island_options`. If ia string value is passed, it 
+    the option of the same name within `thousand_island_options`. If ia string value is passed, it
     will be parsed as an integer. Defaults to 4000 if `scheme` is `:http`, and 4040 if `scheme` is
     `:https`
   * `ip`:  The interface(s) to listen on. This option is offered as a convenience and actually sets the
@@ -321,7 +321,9 @@ defmodule Bandit do
     handler_options = %{
       plug: plug,
       handler_module: Bandit.InitialHandler,
-      opts: %{http_1: http_1_options, http_2: http_2_options, websocket: websocket_options}
+      opts: %{http_1: http_1_options, http_2: http_2_options, websocket: websocket_options},
+      http_1_enabled: http_1_options[:enabled] || true,
+      http_2_enabled: http_2_options[:enabled] || true
     }
 
     scheme = Keyword.get(arg, :scheme, :http)

--- a/lib/bandit.ex
+++ b/lib/bandit.ex
@@ -318,12 +318,17 @@ defmodule Bandit do
     display_plug = Keyword.get(arg, :display_plug, plug_mod)
     startup_log = Keyword.get(arg, :startup_log, :info)
 
+    {http_1_enabled, http_1_options} = Keyword.pop(http_1_options, :enabled, true)
+    {http_2_enabled, http_2_options} = Keyword.pop(http_2_options, :enabled, true)
+    {websocket_enabled, websocket_options} = Keyword.pop(websocket_options, :enabled, true)
+
     handler_options = %{
       plug: plug,
       handler_module: Bandit.InitialHandler,
       opts: %{http_1: http_1_options, http_2: http_2_options, websocket: websocket_options},
-      http_1_enabled: Keyword.get(http_1_options, :enabled, true),
-      http_2_enabled: Keyword.get(http_2_options, :enabled, true)
+      http_1_enabled: http_1_enabled,
+      http_2_enabled: http_2_enabled,
+      websocket_enabled: websocket_enabled
     }
 
     scheme = Keyword.get(arg, :scheme, :http)

--- a/lib/bandit.ex
+++ b/lib/bandit.ex
@@ -322,8 +322,8 @@ defmodule Bandit do
       plug: plug,
       handler_module: Bandit.InitialHandler,
       opts: %{http_1: http_1_options, http_2: http_2_options, websocket: websocket_options},
-      http_1_enabled: http_1_options[:enabled] || true,
-      http_2_enabled: http_2_options[:enabled] || true
+      http_1_enabled: Keyword.get(http_1_options, :enabled, true),
+      http_2_enabled: Keyword.get(http_2_options, :enabled, true)
     }
 
     scheme = Keyword.get(arg, :scheme, :http)

--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -15,6 +15,7 @@ defmodule Bandit.HTTP1.Adapter do
             content_encoding: nil,
             upgrade: nil,
             metrics: %{},
+            websocket_enabled: false,
             opts: []
 
   # credo:disable-for-this-file Credo.Check.Design.AliasUsage
@@ -455,13 +456,8 @@ defmodule Bandit.HTTP1.Adapter do
   def inform(_req, _status, _headers), do: {:error, :not_supported}
 
   @impl Plug.Conn.Adapter
-  def upgrade(req, :websocket, opts) do
-    if Keyword.get(req.opts.websocket, :enabled, true) do
-      {:ok, %{req | upgrade: {:websocket, opts, req.opts.websocket}}}
-    else
-      {:error, :not_supported}
-    end
-  end
+  def upgrade(%Bandit.HTTP1.Adapter{websocket_enabled: true} = req, :websocket, opts),
+    do: {:ok, %{req | upgrade: {:websocket, opts, req.opts.websocket}}}
 
   def upgrade(_req, _upgrade, _opts), do: {:error, :not_supported}
 

--- a/lib/bandit/http1/handler.ex
+++ b/lib/bandit/http1/handler.ex
@@ -15,7 +15,12 @@ defmodule Bandit.HTTP1.Handler do
         connection_telemetry_span_context: connection_span.telemetry_span_context
       })
 
-    req = %Bandit.HTTP1.Adapter{socket: socket, buffer: data, opts: state.opts}
+    req = %Bandit.HTTP1.Adapter{
+      socket: socket,
+      buffer: data,
+      opts: state.opts,
+      websocket_enabled: state.websocket_enabled
+    }
 
     try do
       with {:ok, headers, method, request_target, req} <-

--- a/lib/bandit/initial_handler.ex
+++ b/lib/bandit/initial_handler.ex
@@ -12,10 +12,7 @@ defmodule Bandit.InitialHandler do
   # data consumed in the course of guessing which must be processed by the actual protocol handler
   @impl ThousandIsland.Handler
   def handle_connection(socket, state) do
-    http_1_enabled = Keyword.get(Map.get(state.opts, :http_1, []), :enabled, true)
-    http_2_enabled = Keyword.get(Map.get(state.opts, :http_2, []), :enabled, true)
-
-    case {http_1_enabled, http_2_enabled, alpn_protocol(socket), sniff_wire(socket)} do
+    case {state.http_1_enabled, state.http_2_enabled, alpn_protocol(socket), sniff_wire(socket)} do
       {_, _, _, :likely_tls} ->
         Logger.warning("Connection that looks like TLS received on a clear channel")
         {:close, state}


### PR DESCRIPTION
I think we should avoid a nested lookup on every connection and set the `enabled` flags directly in the `handler_options` / `state`. 

WDYT?