### PR TITLE
Use `byte_size/1` instead of `String.length/1`

### DIFF
--- a/lib/bandit/http2/connection.ex
+++ b/lib/bandit/http2/connection.ex
@@ -338,7 +338,7 @@ defmodule Bandit.HTTP2.Connection do
            false
 
          {key, value} ->
-           String.length(key) > max_key_length || String.length(value) > max_value_length
+           byte_size(key) > max_key_length || byte_size(value) > max_value_length
        end) do
       {:error,
        {:stream, stream.stream_id, Errors.frame_size_error(),


### PR DESCRIPTION
The documentation states:

> max_header_key_length: The maximum permitted length of any single header key (expressed as the number of decompressed bytes) in an HTTP/2 request. Defaults to 10_000 bytes

This isn't the case with `String.length/1` (which is also quite a bit slower than `byte_size/1`) since it counts multi-byte characters as 1. 