### PR TITLE
Port number guard checks valid port range

### DIFF
--- a/lib/bandit/headers.ex
+++ b/lib/bandit/headers.ex
@@ -18,7 +18,7 @@ defmodule Bandit.Headers do
     |> case do
       [host, port] ->
         case Integer.parse(port) do
-          {port, ""} when port > 0 -> {:ok, host <> "]", port}
+          {port, ""} when port in 0..65_535 -> {:ok, host <> "]", port}
           _ -> {:error, "Header contains invalid port"}
         end
 
@@ -33,7 +33,7 @@ defmodule Bandit.Headers do
     |> case do
       [host, port] ->
         case Integer.parse(port) do
-          {port, ""} when port > 0 -> {:ok, host, port}
+          {port, ""} when port in 0..65_535 -> {:ok, host, port}
           _ -> {:error, "Header contains invalid port"}
         end
 


### PR DESCRIPTION
Should it check that `port` matches `t:inet.port_number/0`?