### PR TITLE
Add credo config file

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -1,0 +1,216 @@
+# This file contains the configuration for Credo and you are probably reading
+# this after creating it with `mix credo.gen.config`.
+#
+# If you find anything wrong or unclear in this file, please report an
+# issue on GitHub: https://github.com/rrrene/credo/issues
+#
+%{
+  #
+  # You can have as many configs as you like in the `configs:` field.
+  configs: [
+    %{
+      #
+      # Run any config using `mix credo -C <name>`. If no config name is given
+      # "default" is used.
+      #
+      name: "default",
+      #
+      # These are the files included in the analysis:
+      files: %{
+        #
+        # You can give explicit globs or simply directories.
+        # In the latter case `**/*.{ex,exs}` will be used.
+        #
+        included: [
+          "lib/",
+          "src/",
+          "test/",
+          "web/",
+          "apps/*/lib/",
+          "apps/*/src/",
+          "apps/*/test/",
+          "apps/*/web/"
+        ],
+        excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/"]
+      },
+      #
+      # Load and configure plugins here:
+      #
+      plugins: [],
+      #
+      # If you create your own checks, you must specify the source files for
+      # them here, so they can be loaded by Credo before running the analysis.
+      #
+      requires: [],
+      #
+      # If you want to enforce a style guide and need a more traditional linting
+      # experience, you can change `strict` to `true` below:
+      #
+      strict: false,
+      #
+      # To modify the timeout for parsing files, change this value:
+      #
+      parse_timeout: 5000,
+      #
+      # If you want to use uncolored output by default, you can change `color`
+      # to `false` below:
+      #
+      color: true,
+      #
+      # You can customize the parameters of any check by adding a second element
+      # to the tuple.
+      #
+      # To disable a check put `false` as second element:
+      #
+      #     {Credo.Check.Design.DuplicatedCode, false}
+      #
+      checks: %{
+        enabled: [
+          #
+          ## Consistency Checks
+          #
+          {Credo.Check.Consistency.ExceptionNames, []},
+          {Credo.Check.Consistency.LineEndings, []},
+          {Credo.Check.Consistency.ParameterPatternMatching, []},
+          {Credo.Check.Consistency.SpaceAroundOperators, []},
+          {Credo.Check.Consistency.SpaceInParentheses, []},
+          {Credo.Check.Consistency.TabsOrSpaces, []},
+
+          #
+          ## Design Checks
+          #
+          # You can customize the priority of any check
+          # Priority values are: `low, normal, high, higher`
+          #
+          {Credo.Check.Design.AliasUsage,
+           [priority: :low, if_nested_deeper_than: 2, if_called_more_often_than: 0]},
+          # You can also customize the exit_status of each check.
+          # If you don't want TODO comments to cause `mix credo` to fail, just
+          # set this value to 0 (zero).
+          #
+          {Credo.Check.Design.TagTODO, [exit_status: 2]},
+          {Credo.Check.Design.TagFIXME, []},
+
+          #
+          ## Readability Checks
+          #
+          {Credo.Check.Readability.AliasOrder, []},
+          {Credo.Check.Readability.FunctionNames, []},
+          {Credo.Check.Readability.LargeNumbers, []},
+          {Credo.Check.Readability.MaxLineLength, [priority: :low, max_length: 120]},
+          {Credo.Check.Readability.ModuleAttributeNames, []},
+          {Credo.Check.Readability.ModuleDoc, []},
+          {Credo.Check.Readability.ModuleNames, []},
+          {Credo.Check.Readability.ParenthesesInCondition, []},
+          {Credo.Check.Readability.ParenthesesOnZeroArityDefs, []},
+          {Credo.Check.Readability.PipeIntoAnonymousFunctions, []},
+          {Credo.Check.Readability.PredicateFunctionNames, []},
+          {Credo.Check.Readability.PreferImplicitTry, []},
+          {Credo.Check.Readability.RedundantBlankLines, []},
+          {Credo.Check.Readability.Semicolons, []},
+          {Credo.Check.Readability.SpaceAfterCommas, []},
+          {Credo.Check.Readability.StringSigils, []},
+          {Credo.Check.Readability.TrailingBlankLine, []},
+          {Credo.Check.Readability.TrailingWhiteSpace, []},
+          {Credo.Check.Readability.UnnecessaryAliasExpansion, []},
+          {Credo.Check.Readability.VariableNames, []},
+          {Credo.Check.Readability.WithSingleClause, []},
+
+          #
+          ## Refactoring Opportunities
+          #
+          {Credo.Check.Refactor.Apply, []},
+          {Credo.Check.Refactor.CondStatements, []},
+          {Credo.Check.Refactor.CyclomaticComplexity, []},
+          {Credo.Check.Refactor.FunctionArity, []},
+          {Credo.Check.Refactor.LongQuoteBlocks, []},
+          {Credo.Check.Refactor.MatchInCondition, []},
+          {Credo.Check.Refactor.MapJoin, []},
+          {Credo.Check.Refactor.NegatedConditionsInUnless, []},
+          {Credo.Check.Refactor.NegatedConditionsWithElse, []},
+          {Credo.Check.Refactor.Nesting, []},
+          {Credo.Check.Refactor.UnlessWithElse, []},
+          {Credo.Check.Refactor.WithClauses, []},
+          {Credo.Check.Refactor.FilterCount, []},
+          {Credo.Check.Refactor.FilterFilter, []},
+          {Credo.Check.Refactor.RejectReject, []},
+          {Credo.Check.Refactor.RedundantWithClauseResult, []},
+
+          #
+          ## Warnings
+          #
+          {Credo.Check.Warning.ApplicationConfigInModuleAttribute, []},
+          {Credo.Check.Warning.BoolOperationOnSameValues, []},
+          {Credo.Check.Warning.Dbg, []},
+          {Credo.Check.Warning.ExpensiveEmptyEnumCheck, []},
+          {Credo.Check.Warning.IExPry, []},
+          {Credo.Check.Warning.IoInspect, []},
+          {Credo.Check.Warning.MissedMetadataKeyInLoggerConfig, []},
+          {Credo.Check.Warning.OperationOnSameValues, []},
+          {Credo.Check.Warning.OperationWithConstantResult, []},
+          {Credo.Check.Warning.RaiseInsideRescue, []},
+          {Credo.Check.Warning.SpecWithStruct, []},
+          {Credo.Check.Warning.WrongTestFileExtension, []},
+          {Credo.Check.Warning.UnusedEnumOperation, []},
+          {Credo.Check.Warning.UnusedFileOperation, []},
+          {Credo.Check.Warning.UnusedKeywordOperation, []},
+          {Credo.Check.Warning.UnusedListOperation, []},
+          {Credo.Check.Warning.UnusedPathOperation, []},
+          {Credo.Check.Warning.UnusedRegexOperation, []},
+          {Credo.Check.Warning.UnusedStringOperation, []},
+          {Credo.Check.Warning.UnusedTupleOperation, []},
+          {Credo.Check.Warning.UnsafeExec, []}
+        ],
+        disabled: [
+          #
+          # Checks scheduled for next check update (opt-in for now, just replace `false` with `[]`)
+
+          #
+          # Controversial and experimental checks (opt-in, just move the check to `:enabled`
+          #   and be sure to use `mix credo --strict` to see low priority checks)
+          #
+          {Credo.Check.Consistency.MultiAliasImportRequireUse, []},
+          {Credo.Check.Consistency.UnusedVariableNames, []},
+          {Credo.Check.Design.DuplicatedCode, []},
+          {Credo.Check.Design.SkipTestWithoutComment, []},
+          {Credo.Check.Readability.AliasAs, []},
+          {Credo.Check.Readability.BlockPipe, []},
+          {Credo.Check.Readability.ImplTrue, []},
+          {Credo.Check.Readability.MultiAlias, []},
+          {Credo.Check.Readability.NestedFunctionCalls, []},
+          {Credo.Check.Readability.OneArityFunctionInPipe, []},
+          {Credo.Check.Readability.SeparateAliasRequire, []},
+          {Credo.Check.Readability.SingleFunctionToBlockPipe, []},
+          {Credo.Check.Readability.SinglePipe, []},
+          {Credo.Check.Readability.Specs, []},
+          {Credo.Check.Readability.StrictModuleLayout, []},
+          {Credo.Check.Readability.WithCustomTaggedTuple, []},
+          {Credo.Check.Readability.OnePipePerLine, []},
+          {Credo.Check.Refactor.ABCSize, []},
+          {Credo.Check.Refactor.AppendSingleItem, []},
+          {Credo.Check.Refactor.DoubleBooleanNegation, []},
+          {Credo.Check.Refactor.FilterReject, []},
+          {Credo.Check.Refactor.IoPuts, []},
+          {Credo.Check.Refactor.MapMap, []},
+          {Credo.Check.Refactor.ModuleDependencies, []},
+          {Credo.Check.Refactor.NegatedIsNil, []},
+          {Credo.Check.Refactor.PassAsyncInTestCases, []},
+          {Credo.Check.Refactor.PipeChainStart, []},
+          {Credo.Check.Refactor.RejectFilter, []},
+          {Credo.Check.Refactor.VariableRebinding, []},
+          {Credo.Check.Warning.LazyLogging, []},
+          {Credo.Check.Warning.LeakyEnvironment, []},
+          {Credo.Check.Warning.MapGetUnsafePass, []},
+          {Credo.Check.Warning.MixEnv, []},
+          {Credo.Check.Warning.UnsafeToAtom, []}
+
+          # {Credo.Check.Refactor.MapInto, []},
+
+          #
+          # Custom checks can be created using `mix credo.gen.check`.
+          #
+        ]
+      }
+    }
+  ]
+}

--- a/.credo.exs
+++ b/.credo.exs
@@ -1,69 +1,9 @@
-# This file contains the configuration for Credo and you are probably reading
-# this after creating it with `mix credo.gen.config`.
-#
-# If you find anything wrong or unclear in this file, please report an
-# issue on GitHub: https://github.com/rrrene/credo/issues
-#
 %{
   #
-  # You can have as many configs as you like in the `configs:` field.
   configs: [
     %{
-      #
-      # Run any config using `mix credo -C <name>`. If no config name is given
-      # "default" is used.
-      #
       name: "default",
-      #
-      # These are the files included in the analysis:
-      files: %{
-        #
-        # You can give explicit globs or simply directories.
-        # In the latter case `**/*.{ex,exs}` will be used.
-        #
-        included: [
-          "lib/",
-          "src/",
-          "test/",
-          "web/",
-          "apps/*/lib/",
-          "apps/*/src/",
-          "apps/*/test/",
-          "apps/*/web/"
-        ],
-        excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/"]
-      },
-      #
-      # Load and configure plugins here:
-      #
-      plugins: [],
-      #
-      # If you create your own checks, you must specify the source files for
-      # them here, so they can be loaded by Credo before running the analysis.
-      #
-      requires: [],
-      #
-      # If you want to enforce a style guide and need a more traditional linting
-      # experience, you can change `strict` to `true` below:
-      #
       strict: true,
-      #
-      # To modify the timeout for parsing files, change this value:
-      #
-      parse_timeout: 5000,
-      #
-      # If you want to use uncolored output by default, you can change `color`
-      # to `false` below:
-      #
-      color: true,
-      #
-      # You can customize the parameters of any check by adding a second element
-      # to the tuple.
-      #
-      # To disable a check put `false` as second element:
-      #
-      #     {Credo.Check.Design.DuplicatedCode, false}
-      #
       checks: %{
         enabled: [
           #
@@ -176,9 +116,6 @@
         ],
         disabled: [
           #
-          # Checks scheduled for next check update (opt-in for now, just replace `false` with `[]`)
-
-          #
           # Controversial and experimental checks (opt-in, just move the check to `:enabled`
           #   and be sure to use `mix credo --strict` to see low priority checks)
           #
@@ -218,10 +155,6 @@
           {Credo.Check.Warning.UnsafeToAtom, []}
 
           # {Credo.Check.Refactor.MapInto, []},
-
-          #
-          # Custom checks can be created using `mix credo.gen.check`.
-          #
         ]
       }
     }

--- a/.credo.exs
+++ b/.credo.exs
@@ -19,28 +19,7 @@
           #
           ## Design Checks
           #
-          # You can customize the priority of any check
-          # Priority values are: `low, normal, high, higher`
-          #
-          {Credo.Check.Design.AliasUsage,
-           [
-            priority: :low,
-            if_nested_deeper_than: 2,
-            if_called_more_often_than: 1,
-            # List of default excluded last names `++` the ones we added.
-            excluded_lastnames: ~w[Access Agent Application Atom Base Behaviour
-                          Bitwise Code Date DateTime Dict Enum Exception
-                          File Float GenEvent GenServer HashDict HashSet
-                          Integer IO Kernel Keyword List Macro Map MapSet
-                          Module NaiveDateTime Node OptionParser Path Port
-                          Process Protocol Range Record Regex Registry Set
-                          Stream String StringIO Supervisor System Task Time
-                          Tuple URI Version] ++ ~w[Adapter Utils]
-          ]},
-          # You can also customize the exit_status of each check.
-          # If you don't want TODO comments to cause `mix credo` to fail, just
-          # set this value to 0 (zero).
-          #
+          {Credo.Check.Design.AliasUsage, false},
           {Credo.Check.Design.TagTODO, [exit_status: 2]},
           {Credo.Check.Design.TagFIXME, []},
 

--- a/.credo.exs
+++ b/.credo.exs
@@ -53,7 +53,7 @@
           #
           {Credo.Check.Refactor.Apply, []},
           {Credo.Check.Refactor.CondStatements, []},
-          {Credo.Check.Refactor.CyclomaticComplexity, []},
+          {Credo.Check.Refactor.CyclomaticComplexity, [max_complexity: 15]},
           {Credo.Check.Refactor.FunctionArity, []},
           {Credo.Check.Refactor.LongQuoteBlocks, []},
           {Credo.Check.Refactor.MatchInCondition, []},

--- a/.credo.exs
+++ b/.credo.exs
@@ -46,7 +46,7 @@
       # If you want to enforce a style guide and need a more traditional linting
       # experience, you can change `strict` to `true` below:
       #
-      strict: false,
+      strict: true,
       #
       # To modify the timeout for parsing files, change this value:
       #
@@ -83,7 +83,20 @@
           # Priority values are: `low, normal, high, higher`
           #
           {Credo.Check.Design.AliasUsage,
-           [priority: :low, if_nested_deeper_than: 2, if_called_more_often_than: 0]},
+           [
+            priority: :low,
+            if_nested_deeper_than: 2,
+            if_called_more_often_than: 1,
+            # List of default excluded last names `++` the ones we added.
+            excluded_lastnames: ~w[Access Agent Application Atom Base Behaviour
+                          Bitwise Code Date DateTime Dict Enum Exception
+                          File Float GenEvent GenServer HashDict HashSet
+                          Integer IO Kernel Keyword List Macro Map MapSet
+                          Module NaiveDateTime Node OptionParser Path Port
+                          Process Protocol Range Record Regex Registry Set
+                          Stream String StringIO Supervisor System Task Time
+                          Tuple URI Version] ++ ~w[Adapter Utils]
+          ]},
           # You can also customize the exit_status of each check.
           # If you don't want TODO comments to cause `mix credo` to fail, just
           # set this value to 0 (zero).

--- a/lib/bandit/compression.ex
+++ b/lib/bandit/compression.ex
@@ -1,8 +1,6 @@
 defmodule Bandit.Compression do
   @moduledoc false
 
-  # credo:disable-for-this-file Credo.Check.Design.AliasUsage
-
   @spec negotiate_content_encoding(String.t(), boolean()) :: String.t() | nil
   def negotiate_content_encoding(nil, _), do: nil
   def negotiate_content_encoding(_, false), do: nil

--- a/lib/bandit/headers.ex
+++ b/lib/bandit/headers.ex
@@ -2,8 +2,6 @@ defmodule Bandit.Headers do
   @moduledoc false
   # Conveniences for dealing with headers
 
-  # credo:disable-for-this-file Credo.Check.Design.AliasUsage
-
   def get_header(headers, header) do
     case List.keyfind(headers, header, 0) do
       {_, value} -> value

--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -18,8 +18,6 @@ defmodule Bandit.HTTP1.Adapter do
             websocket_enabled: false,
             opts: []
 
-  # credo:disable-for-this-file Credo.Check.Design.AliasUsage
-
   ################
   # Header Reading
   ################

--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -59,7 +59,6 @@ defmodule Bandit.HTTP1.Adapter do
   end
 
   @dialyzer {:no_improper_lists, do_read_headers: 5}
-  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   defp do_read_headers(
          req,
          type \\ :http_bin,

--- a/lib/bandit/http1/handler.ex
+++ b/lib/bandit/http1/handler.ex
@@ -4,8 +4,6 @@ defmodule Bandit.HTTP1.Handler do
 
   use ThousandIsland.Handler
 
-  # credo:disable-for-this-file Credo.Check.Design.AliasUsage
-
   @impl ThousandIsland.Handler
   def handle_data(data, socket, state) do
     {_, _, _, connection_span} = transport_info = build_transport_info(socket)

--- a/lib/bandit/http2/frame.ex
+++ b/lib/bandit/http2/frame.ex
@@ -24,7 +24,6 @@ defmodule Bandit.HTTP2.Frame do
 
   @spec deserialize(binary(), non_neg_integer()) ::
           {{:ok, frame()}, iodata()} | {{:error, Connection.error()}, iodata()}
-  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   def deserialize(
         <<length::24, type::8, flags::8, _reserved::1, stream_id::31,
           payload::binary-size(length), rest::binary>>,

--- a/lib/bandit/http2/stream.ex
+++ b/lib/bandit/http2/stream.ex
@@ -23,8 +23,6 @@ defmodule Bandit.HTTP2.Stream do
 
   defmodule StreamError, do: defexception([:message])
 
-  # credo:disable-for-this-file Credo.Check.Design.AliasUsage
-
   @typedoc "An HTTP/2 stream identifier"
   @type stream_id :: non_neg_integer()
 

--- a/lib/bandit/http2/stream_task.ex
+++ b/lib/bandit/http2/stream_task.ex
@@ -22,8 +22,6 @@ defmodule Bandit.HTTP2.StreamTask do
 
   use Task
 
-  # credo:disable-for-this-file Credo.Check.Design.AliasUsage
-
   # A stream process can be created only once we have an adapter & set of headers. Pass them in
   # at creation time to ensure this invariant
   @spec start_link(

--- a/lib/bandit/pipeline.ex
+++ b/lib/bandit/pipeline.ex
@@ -12,8 +12,6 @@ defmodule Bandit.Pipeline do
   @type host :: Plug.Conn.host() | nil
   @type path :: String.t() | :*
 
-  # credo:disable-for-this-file Credo.Check.Design.AliasUsage
-
   @spec run(
           Plug.Conn.adapter(),
           transport_info(),

--- a/lib/bandit/websocket/connection.ex
+++ b/lib/bandit/websocket/connection.ex
@@ -28,8 +28,6 @@ defmodule Bandit.WebSocket.Connection do
           metrics: map()
         }
 
-  # credo:disable-for-this-file Credo.Check.Refactor.CyclomaticComplexity
-
   def init(websock, websock_state, connection_opts, socket, origin_telemetry_span_context) do
     compress = Keyword.get(connection_opts, :compress)
 

--- a/lib/bandit/websocket/connection.ex
+++ b/lib/bandit/websocket/connection.ex
@@ -28,7 +28,6 @@ defmodule Bandit.WebSocket.Connection do
           metrics: map()
         }
 
-  # credo:disable-for-this-file Credo.Check.Design.AliasUsage
   # credo:disable-for-this-file Credo.Check.Refactor.CyclomaticComplexity
 
   def init(websock, websock_state, connection_opts, socket, origin_telemetry_span_context) do

--- a/lib/bandit/websocket/frame.ex
+++ b/lib/bandit/websocket/frame.ex
@@ -117,7 +117,6 @@ defmodule Bandit.WebSocket.Frame do
     {{:error, "Received unsupported RSV flags #{rsv}"}, rest}
   end
 
-  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   defp to_frame(fin, compressed, 0x0, opcode, mask, payload, rest) do
     fin = fin == 0x1
     compressed = compressed == 0x1

--- a/lib/bandit/websocket/handshake.ex
+++ b/lib/bandit/websocket/handshake.ex
@@ -4,8 +4,6 @@ defmodule Bandit.WebSocket.Handshake do
 
   import Plug.Conn
 
-  # credo:disable-for-this-file Credo.Check.Design.AliasUsage
-
   def valid_upgrade?(%Plug.Conn{} = conn) do
     case get_http_protocol(conn) do
       :"HTTP/1.1" ->

--- a/test/bandit/websocket/autobahn_test.exs
+++ b/test/bandit/websocket/autobahn_test.exs
@@ -1,8 +1,6 @@
 defmodule WebsocketAutobahnTest do
   use ExUnit.Case, async: true
 
-  # credo:disable-for-this-file Credo.Check.Design.AliasUsage
-
   @moduletag :external_conformance
   @moduletag timeout: 3_600_000
 

--- a/test/bandit/websocket/http1_handshake_test.exs
+++ b/test/bandit/websocket/http1_handshake_test.exs
@@ -5,8 +5,6 @@ defmodule WebSocketHTTP1HandshakeTest do
   use ExUnit.Case, async: true
   use ServerHelpers
 
-  # credo:disable-for-this-file Credo.Check.Design.AliasUsage
-
   setup :http_server
 
   defmodule MyNoopWebSock do

--- a/test/bandit/websocket/protocol_test.exs
+++ b/test/bandit/websocket/protocol_test.exs
@@ -2,8 +2,6 @@ defmodule WebSocketProtocolTest do
   use ExUnit.Case, async: true
   use ServerHelpers
 
-  # credo:disable-for-this-file Credo.Check.Design.AliasUsage
-
   setup :http_server
 
   def call(conn, _opts) do

--- a/test/bandit/websocket/sock_test.exs
+++ b/test/bandit/websocket/sock_test.exs
@@ -6,8 +6,6 @@ defmodule WebSocketWebSockTest do
 
   import ExUnit.CaptureLog
 
-  # credo:disable-for-this-file Credo.Check.Design.AliasUsage
-
   setup :http_server
 
   def call(conn, _opts) do

--- a/test/bandit/websocket/upgrade_test.exs
+++ b/test/bandit/websocket/upgrade_test.exs
@@ -4,8 +4,6 @@ defmodule WebSocketUpgradeTest do
   use ServerHelpers
   use Machete
 
-  # credo:disable-for-this-file Credo.Check.Design.AliasUsage
-
   setup :http_server
 
   def call(conn, _opts) do


### PR DESCRIPTION
Make it easier to configure how `credo` is run.

Example: CI uses `--strict`, so in the config I turned `strict` on by default to avoid running `mix credo` locally and thinking all is well before pushing.

Also added custom config for `Credo.Check.Design.AliasUsage` so we could remove some magic credo comments.

i.e.

```elixir
[
  if_called_more_often_than: 1,
  excluded_lastnames: defaults ++ ~w[Adapter Utils]
]
```

or could just disable the alias check altogether?

Could potentially do similar for `Credo.Check.Refactor.CyclomaticComplexity`.

