### PR TITLE
Add a port number guard and use that in the checks instead of range

### DIFF
--- a/lib/bandit/headers.ex
+++ b/lib/bandit/headers.ex
@@ -2,6 +2,8 @@ defmodule Bandit.Headers do
   @moduledoc false
   # Conveniences for dealing with headers
 
+  defguardp is_port_number(port) when Bitwise.band(port, 0xFFFF) === port
+
   def get_header(headers, header) do
     case List.keyfind(headers, header, 0) do
       {_, value} -> value
@@ -16,7 +18,7 @@ defmodule Bandit.Headers do
     |> case do
       [host, port] ->
         case Integer.parse(port) do
-          {port, ""} when port in 0..65_535 -> {:ok, host <> "]", port}
+          {port, ""} when is_port_number(port) -> {:ok, host <> "]", port}
           _ -> {:error, "Header contains invalid port"}
         end
 
@@ -31,7 +33,7 @@ defmodule Bandit.Headers do
     |> case do
       [host, port] ->
         case Integer.parse(port) do
-          {port, ""} when port in 0..65_535 -> {:ok, host, port}
+          {port, ""} when is_port_number(port) -> {:ok, host, port}
           _ -> {:error, "Header contains invalid port"}
         end
 

--- a/test/bandit/headers_test.exs
+++ b/test/bandit/headers_test.exs
@@ -1,0 +1,44 @@
+defmodule Bandit.HeadersTest do
+  use ExUnit.Case, async: true
+
+  alias Bandit.Headers
+
+  @valid_ports 0..65_535
+
+  @invalid_ports [
+    -999_999_999,
+    -1,
+    65_536,
+    999_999_999,
+    "abc123",
+    "123abc"
+  ]
+
+  describe "parse_hostlike_header/1" do
+    @error_msg "Header contains invalid port"
+
+    test "parses host and port for all valid ports" do
+      for port <- @valid_ports do
+        assert {:ok, "banana", ^port} = Headers.parse_hostlike_header("banana:#{port}")
+      end
+    end
+
+    test "parses host and port for ipv6 all valid ports" do
+      for port <- @valid_ports do
+        assert {:ok, "[::1]", ^port} = Headers.parse_hostlike_header("[::1]:#{port}")
+      end
+    end
+
+    test "returns error for invalid ports" do
+      for port <- @invalid_ports do
+        assert {:error, @error_msg} = Headers.parse_hostlike_header("banana:#{port}")
+      end
+    end
+
+    test "returns error for ipv6 invalid ports" do
+      for port <- @invalid_ports do
+        assert {:error, @error_msg} = Headers.parse_hostlike_header("[::1]:#{port}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
I talked about it at the end of #145 although it's a micro-optimization.

I didn't know where to put it, I could put it as a private guard in the headers module? Or somewhere else?