### PR TITLE
Manually parse integers in headers module

### DIFF
--- a/lib/bandit/headers.ex
+++ b/lib/bandit/headers.ex
@@ -1,6 +1,6 @@
 defmodule Bandit.Headers do
   @moduledoc false
-  # Conveniences for dealing with headers
+  # Conveniences for dealing with headers.
 
   @spec is_port_number(integer()) :: Macro.t()
   defguardp is_port_number(port) when Bitwise.band(port, 0xFFFF) === port
@@ -13,7 +13,7 @@ defmodule Bandit.Headers do
     end
   end
 
-  # covers ipv6 addresses, which look like this: `[::1]:4000` as defined in RFC3986
+  # Covers IPv6 addresses, like `[::1]:4000` as defined in RFC3986.
   @spec parse_hostlike_header(host_header :: binary()) ::
           {:ok, binary(), nil | integer()} | {:error, String.t()}
   def parse_hostlike_header("[" <> _ = host_header) do
@@ -21,7 +21,7 @@ defmodule Bandit.Headers do
     |> :binary.split("]:")
     |> case do
       [host, port] ->
-        case Integer.parse(port) do
+        case parse_integer(port) do
           {port, ""} when is_port_number(port) -> {:ok, host <> "]", port}
           _ -> {:error, "Header contains invalid port"}
         end
@@ -36,7 +36,7 @@ defmodule Bandit.Headers do
     |> :binary.split(":")
     |> case do
       [host, port] ->
-        case Integer.parse(port) do
+        case parse_integer(port) do
           {port, ""} when is_port_number(port) -> {:ok, host, port}
           _ -> {:error, "Header contains invalid port"}
         end
@@ -56,12 +56,9 @@ defmodule Bandit.Headers do
 
   @spec parse_content_length(binary()) :: {:ok, length :: integer()} | {:error, String.t()}
   defp parse_content_length(value) do
-    case Integer.parse(value) do
+    case parse_integer(value) do
       {length, ""} when length >= 0 ->
         {:ok, length}
-
-      {_length, ""} ->
-        {:error, "invalid negative content-length header (RFC9110§8.6)"}
 
       {length, rest} ->
         if rest |> Plug.Conn.Utils.list() |> all?(to_string(length)),
@@ -73,8 +70,23 @@ defmodule Bandit.Headers do
     end
   end
 
+  # Checks if all values in a list are equal to a given value.
   @spec all?([binary()], binary()) :: boolean()
   defp all?([value | rest], value), do: all?(rest, value)
   defp all?([], _str), do: true
   defp all?(_values, _value), do: false
+
+  # Parses non-negative integers from strings. Return the valid portion of an
+  # integer and the remaining string as a tuple like `{123, ""}` or `:error`.
+  def parse_integer(<<digit::8, rest::binary>>) when digit >= ?0 and digit <= ?9 do
+    parse_integer(rest, digit - ?0)
+  end
+
+  def parse_integer(_), do: :error
+
+  defp parse_integer(<<digit::8, rest::binary>>, total) when digit >= ?0 and digit <= ?9 do
+    parse_integer(rest, total * 10 + digit - ?0)
+  end
+
+  defp parse_integer(rest, total), do: {total, rest}
 end

--- a/test/bandit/headers_test.exs
+++ b/test/bandit/headers_test.exs
@@ -3,18 +3,18 @@ defmodule Bandit.HeadersTest do
 
   alias Bandit.Headers
 
-  @valid_ports 0..65_535
-
-  @invalid_ports [
-    -999_999_999,
-    -1,
-    65_536,
-    999_999_999,
-    "abc123",
-    "123abc"
-  ]
-
   describe "parse_hostlike_header/1" do
+    @valid_ports 0..65_535
+
+    @invalid_ports [
+      -999_999_999,
+      -1,
+      65_536,
+      999_999_999,
+      "abc123",
+      "123abc"
+    ]
+
     @error_msg "Header contains invalid port"
 
     test "parses host and port for all valid ports" do
@@ -38,6 +38,38 @@ defmodule Bandit.HeadersTest do
     test "returns error for ipv6 invalid ports" do
       for port <- @invalid_ports do
         assert {:error, @error_msg} = Headers.parse_hostlike_header("[::1]:#{port}")
+      end
+    end
+  end
+
+  describe "parse_integer/1" do
+    @non_neg_integers ~w[0 1 100 101 420 999999999 0010]
+    @neg_integers ~w[-1 -420 -999_999_999 -0010]
+    @partial_integers ["123abc", "0-0", "0x01", "3.14", "123 123"]
+    @invalid_integers ["abc123", "", " ", " 0", "-123abc"]
+
+    test "parses non-negative integers" do
+      for integer <- @non_neg_integers do
+        assert Headers.parse_integer(integer) == {String.to_integer(integer), ""}
+      end
+    end
+
+    test "parses partial integers" do
+      for integer <- @partial_integers do
+        [num, splitter, rest] = String.split(integer, ~r/[^\d]/, parts: 2, include_captures: true)
+        assert Headers.parse_integer(integer) == {String.to_integer(num), splitter <> rest}
+      end
+    end
+
+    test "errors on negative integers" do
+      for integer <- @neg_integers do
+        assert :error = Headers.parse_integer(integer)
+      end
+    end
+
+    test "errors on invalid integers" do
+      for integer <- @invalid_integers do
+        assert :error = Headers.parse_integer(integer)
       end
     end
   end


### PR DESCRIPTION
I thought we could shave some performance out of integer parsing since we don't care about things like the base or negative integers. We have a specific case in this module of only caring about non-negative integers in base10.

I've also intentionally tried to optimize for the happy path.

### Benchmarks

##### Setup

```elixir
Mix.install([
  {:benchee, "~> 1.0"}
])

numbers = Enum.map(0..999_999, &to_string/1)

defmodule Parser do
  def parse_integer(binary) do
    parse_integer(binary, [])
  end

  defp parse_integer(<<d::8, rest::binary>>, digits) when d >= ?0 and d <= ?9 do
    parse_integer(rest, [d - ?0 | digits])
  end

  defp parse_integer(rest, [_ | _] = digits), do: {Enum.reverse(digits) |> undigits(0), rest}

  defp parse_integer(_, []), do: :error

  # Converts a list of digits to an integer.
  defp undigits([], acc), do: acc
  defp undigits([digit | tail], acc) do
    undigits(tail, digit + acc * 10)
  end

  def parse_integer_b(<<digit::8, rest::binary>>) when digit >= ?0 and digit <= ?9 do
    parse_integer_b(rest, digit - ?0)
  end

  def parse_integer_b(_), do: :error

  defp parse_integer_b(<<digit::8, rest::binary>>, total) when digit >= ?0 and digit <= ?9 do
    parse_integer_b(rest, total * 10 + digit - ?0)
  end

  defp parse_integer_b(rest, total), do: {total, rest}
end

Benchee.run(
  %{
    "Integer.parse/1" => fn ->
      Enum.each(numbers, &Integer.parse/1)
    end,
    "parse_integer/1" => fn ->
      Enum.each(numbers, &Parser.parse_integer/1)
    end,
    "parse_integer_b/1" => fn ->
      Enum.each(numbers, &Parser.parse_integer_b/1)
    end
  }
)
```

#### Results

```
Operating System: macOS
CPU Information: Intel(R) Core(TM) i5-9600K CPU @ 3.70GHz
Number of Available Cores: 6
Available memory: 32 GB
Elixir 1.14.3
Erlang 25.2.3

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
memory time: 0 ns
reduction time: 0 ns
parallel: 1
inputs: none specified
Estimated total run time: 21 s

Benchmarking Integer.parse/1 ...
Benchmarking parse_integer/1 ...
Benchmarking parse_integer_b/1 ...

Name                        ips        average  deviation         median         99th %
parse_integer_b/1         22.37       44.70 ms     ±2.76%       44.54 ms       55.53 ms
parse_integer/1           11.27       88.76 ms     ±1.99%       88.51 ms      100.59 ms
Integer.parse/1           10.15       98.51 ms     ±1.78%       98.38 ms      110.36 ms

Comparison:
parse_integer_b/1         22.37
parse_integer/1           11.27 - 1.99x slower +44.06 ms
Integer.parse/1           10.15 - 2.20x slower +53.81 ms
```

Feel free to golf some more with it 😂
Just make sure you do it with the benchmarks. I've tried several other things I thought would make it better but made it worse.

_Edit: updated benchmarks_