### PR TITLE
Better handle errors from Thousand Island when unable to get local/peer info

### DIFF
--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -475,7 +475,12 @@ defmodule Bandit.HTTP1.Adapter do
   def push(_req, _path, _headers), do: {:error, :not_supported}
 
   @impl Plug.Conn.Adapter
-  def get_peer_data(%__MODULE__{socket: socket}), do: ThousandIsland.Socket.peer_info(socket)
+  def get_peer_data(%__MODULE__{socket: socket}) do
+    case ThousandIsland.Socket.peer_info(socket) do
+      peer_info when is_map(peer_info) -> peer_info
+      error -> raise "Unable to obtain peer info: #{inspect(error)}"
+    end
+  end
 
   @impl Plug.Conn.Adapter
   def get_http_protocol(%__MODULE__{version: version}), do: version

--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -477,12 +477,6 @@ defmodule Bandit.HTTP1.Adapter do
   @impl Plug.Conn.Adapter
   def get_peer_data(%__MODULE__{socket: socket}), do: ThousandIsland.Socket.peer_info(socket)
 
-  def get_local_data(%__MODULE__{socket: socket}), do: ThousandIsland.Socket.local_info(socket)
-
-  def secure?(%__MODULE__{socket: socket}), do: ThousandIsland.Socket.secure?(socket)
-
   @impl Plug.Conn.Adapter
   def get_http_protocol(%__MODULE__{version: version}), do: version
-
-  def keepalive?(%__MODULE__{keepalive: keepalive}), do: keepalive
 end

--- a/lib/bandit/http1/handler.ex
+++ b/lib/bandit/http1/handler.ex
@@ -63,8 +63,15 @@ defmodule Bandit.HTTP1.Handler do
   end
 
   defp build_transport_info(socket) do
-    {ThousandIsland.Socket.secure?(socket), ThousandIsland.Socket.local_info(socket),
-     ThousandIsland.Socket.peer_info(socket), ThousandIsland.Socket.telemetry_span(socket)}
+    secure? = ThousandIsland.Socket.secure?(socket)
+    telemetry_span = ThousandIsland.Socket.telemetry_span(socket)
+
+    with local_info when is_map(local_info) <- ThousandIsland.Socket.local_info(socket),
+         peer_info when is_map(peer_info) <- ThousandIsland.Socket.peer_info(socket) do
+      {secure?, local_info, peer_info, telemetry_span}
+    else
+      error -> raise "Unable to obtain local/peer info: #{inspect(error)}"
+    end
   end
 
   defp code_for_reason(:timeout), do: 408

--- a/lib/bandit/http1/handler.ex
+++ b/lib/bandit/http1/handler.ex
@@ -84,7 +84,7 @@ defmodule Bandit.HTTP1.Handler do
     request_limit = Keyword.get(state.opts.http_1, :max_requests, 0)
     under_limit = request_limit == 0 || requests_processed < request_limit
 
-    if under_limit && Bandit.HTTP1.Adapter.keepalive?(req) do
+    if under_limit && req.keepalive do
       {:continue, Map.put(state, :requests_processed, requests_processed)}
     else
       {:close, state}

--- a/lib/bandit/http2/connection.ex
+++ b/lib/bandit/http2/connection.ex
@@ -352,8 +352,15 @@ defmodule Bandit.HTTP2.Connection do
   end
 
   defp build_transport_info(socket) do
-    {ThousandIsland.Socket.secure?(socket), ThousandIsland.Socket.local_info(socket),
-     ThousandIsland.Socket.peer_info(socket), ThousandIsland.Socket.telemetry_span(socket)}
+    secure? = ThousandIsland.Socket.secure?(socket)
+    telemetry_span = ThousandIsland.Socket.telemetry_span(socket)
+
+    with local_info when is_map(local_info) <- ThousandIsland.Socket.local_info(socket),
+         peer_info when is_map(peer_info) <- ThousandIsland.Socket.peer_info(socket) do
+      {secure?, local_info, peer_info, telemetry_span}
+    else
+      error -> raise "Unable to obtain local/peer info: #{inspect(error)}"
+    end
   end
 
   # Shared logic to send any pending frames upon adjustment of our send window


### PR DESCRIPTION
basred on @asakura's [recent work](https://github.com/mtrudel/thousand_island/pull/62) on Thousand Island, we should be smarter about handling errors when asking for information about local or peer info. Sadly, there's not much we can do in the case where we DO get errors back, but at least we're now erroring with something more clear than a match error. 

