### PR TITLE
Add typespecs to `Headers` module and remove unnecessary guard

### DIFF
--- a/test/bandit/headers_test.exs
+++ b/test/bandit/headers_test.exs
@@ -42,34 +42,66 @@ defmodule Bandit.HeadersTest do
     end
   end
 
-  describe "parse_integer/1" do
-    @non_neg_integers ~w[0 1 100 101 420 999999999 0010]
-    @neg_integers ~w[-1 -420 -999_999_999 -0010]
-    @partial_integers ["123abc", "0-0", "0x01", "3.14", "123 123"]
-    @invalid_integers ["abc123", "", " ", " 0", "-123abc"]
+  describe "get_content_length/1" do
+    @non_neg_ints ~w[0 1 100 101 420 999999999 0010]
+    @neg_ints ~w[-1 -420 -999_999_999 -0010]
+    @repeat_ints ["123, 123", "234,234"]
+    @repeat_ints_ows ["345  , ,  345 ,345,345"]
+    @invalid_repeat_ints ["123, 124", "234 , 235, 235", "345 345"]
+    @partial_ints ["123abc", "0-0", "0x01", "3.14"]
+    @invalid_ints ["abc123", "", " ", " 0", "-123abc"]
 
     test "parses non-negative integers" do
-      for integer <- @non_neg_integers do
-        assert Headers.parse_integer(integer) == {String.to_integer(integer), ""}
+      for integer <- @non_neg_ints do
+        header = [{"content-length", integer}]
+        assert Headers.get_content_length(header) == {:ok, String.to_integer(integer)}
       end
     end
 
-    test "parses partial integers" do
-      for integer <- @partial_integers do
-        [num, splitter, rest] = String.split(integer, ~r/[^\d]/, parts: 2, include_captures: true)
-        assert Headers.parse_integer(integer) == {String.to_integer(num), splitter <> rest}
+    test "parses repeat integers" do
+      for integer <- @repeat_ints do
+        [num, _] = String.split(integer, ~r/[^\d]/, parts: 2)
+        header = [{"content-length", integer}]
+        assert Headers.get_content_length(header) == {:ok, String.to_integer(num)}
+      end
+    end
+
+    # Skipping this until a release of Plug is available with this PR:
+    # https://github.com/elixir-plug/plug/pull/1155
+    @tag :skip
+    test "parses repeat integers with optional whitespace" do
+      for integer <- @repeat_ints_ows do
+        [num, _] = String.split(integer, ~r/[^\d]/, parts: 2)
+        header = [{"content-length", integer}]
+        assert Headers.get_content_length(header) == {:ok, String.to_integer(num)}
+      end
+    end
+
+    test "errors on non-matching repeat integers" do
+      for integer <- @invalid_repeat_ints do
+        header = [{"content-length", integer}]
+        assert {:error, _} = Headers.get_content_length(header)
+      end
+    end
+
+    test "errors on partial integers" do
+      for integer <- @partial_ints do
+        header = [{"content-length", integer}]
+        assert {:error, _} = Headers.get_content_length(header)
       end
     end
 
     test "errors on negative integers" do
-      for integer <- @neg_integers do
-        assert :error = Headers.parse_integer(integer)
+      for integer <- @neg_ints do
+        header = [{"content-length", integer}]
+        assert {:error, _} = Headers.get_content_length(header)
       end
     end
 
     test "errors on invalid integers" do
-      for integer <- @invalid_integers do
-        assert :error = Headers.parse_integer(integer)
+      for integer <- @invalid_ints do
+        header = [{"content-length", integer}]
+        assert {:error, _} = Headers.get_content_length(header)
       end
     end
   end


### PR DESCRIPTION
### Added
- added typespecs for the functions added in #148
- added tests for `get_content_length/1`(won't pass until we have a version with this PR https://github.com/elixir-plug/plug/pull/1155)

### Changed
- made `parse_integer/1` private

### Removed
- removed an unnecessary guard since the parser can never return a negative integer now
- removed tests for `parse_integer/1` (replaced by tests for get_content_length/1`)

## IMPORTANT NOTE

It's easy to miss if skimming: the updated tests **won't pass** _until_ we have a version of `plug` with the above-mentioned PR.