### PR TITLE
Fix failing connection when peer doesn't provide a certificate

### DIFF
--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -510,6 +510,9 @@ defmodule Bandit.HTTP1.Adapter do
         {:ok, cert} ->
           cert
 
+        {:error, :no_peercert} ->
+          nil
+
         {:error, reason} ->
           raise "Unable to obtain peer cert: #{inspect(reason)}"
       end


### PR DESCRIPTION
Currently all HTTPS connection via HTTP1 will fail, because a client certificate is required (?) when using TLS.
This changes the behavior to allow HTTPS connections without a client certificate