### PR TITLE
Fix handling of requests with more content than given in content-length

### DIFF
--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -445,13 +445,12 @@ defmodule HTTP1RequestTest do
       send_resp(conn, 200, "OK")
     end
 
-    @tag capture_log: true
     test "reads only the amount of data specified in content-length", context do
       response =
         Req.post!(context.req,
           url: "/respect_content_length",
           headers: [{"content-length", "20"}],
-          body: String.duplicate("a", 8_000_000)
+          body: String.duplicate("a", 100)
         )
 
       assert response.status == 200

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -453,6 +453,7 @@ defmodule HTTP1RequestTest do
           headers: [{"content-length", "20"}],
           body: String.duplicate("a", 8_000_000)
         )
+
       assert response.status == 200
       assert response.body == "OK"
     end


### PR DESCRIPTION
Currently if a request has a larger body than given in `content-length` we get the error:
```elixir
[error] GenServer #PID<0.720.0> terminating
** (FunctionClauseError) no function clause matching in :prim_inet.recv0/3
    :prim_inet.recv0(#Port<0.22>, -25, 60000)
    (thousand_island 1.0.0-pre.5) lib/thousand_island/socket.ex:59: ThousandIsland.Socket.recv/3
    (bandit 1.0.0-pre.9) lib/bandit/http1/adapter.ex:346: Bandit.HTTP1.Adapter.read/5
    (bandit 1.0.0-pre.9) lib/bandit/http1/adapter.ex:234: Bandit.HTTP1.Adapter.read_req_body/2
    (plug 1.14.2) lib/plug/conn.ex:1153: Plug.Conn.read_body/2
    (phx_test 0.1.0) lib/phx_test_web/controllers/some_controller.ex:11: PhxTestWeb.SomeController.a/2
    (phx_test 0.1.0) lib/phx_test_web/controllers/some_controller.ex:1: PhxTestWeb.SomeController.action/2
    (phx_test 0.1.0) lib/phx_test_web/controllers/some_controller.ex:1: PhxTestWeb.SomeController.phoenix_controller_pipeline/2
    (phoenix 1.7.6) lib/phoenix/router.ex:430: Phoenix.Router.__call__/5
    (phx_test 0.1.0) lib/phx_test_web/endpoint.ex:1: PhxTestWeb.Endpoint.plug_builder_call/2
    (phx_test 0.1.0) deps/plug/lib/plug/debugger.ex:136: PhxTestWeb.Endpoint."call (overridable 3)"/2
    (phx_test 0.1.0) lib/phx_test_web/endpoint.ex:1: PhxTestWeb.Endpoint.call/2
    (phoenix 1.7.6) lib/phoenix/endpoint/sync_code_reload_plug.ex:22: Phoenix.Endpoint.SyncCodeReloadPlug.do_call/4
    (bandit 1.0.0-pre.9) lib/bandit/pipeline.ex:110: Bandit.Pipeline.call_plug/2
    (bandit 1.0.0-pre.9) lib/bandit/pipeline.ex:25: Bandit.Pipeline.run/6
    (bandit 1.0.0-pre.9) lib/bandit/http1/handler.ex:27: Bandit.HTTP1.Handler.handle_data/3
    (bandit 1.0.0-pre.9) lib/bandit/delegating_handler.ex:18: Bandit.DelegatingHandler.handle_data/3
    (bandit 1.0.0-pre.9) /Users/kevin/Developer/repos/phx_test/deps/thousand_island/lib/thousand_island/handler.ex:399: Bandit.DelegatingHandler.handle_continue/2
    (stdlib 5.0.1) gen_server.erl:1067: :gen_server.try_handle_continue/3
    (stdlib 5.0.1) gen_server.erl:977: :gen_server.loop/7
Last message: {:continue, :handle_connection}
State: {%ThousandIsland.Socket{socket: #Port<0.22>, transport_module: ThousandIsland.Transports.TCP, read_timeout: 60000, span: %ThousandIsland.Telemetry{span_name: :connection, telemetry_span_context: #Reference<0.513344876.2758541319.164812>, start_time: -576460742372031167, start_metadata: %{remote_address: {127, 0, 0, 1}, remote_port: 51244, telemetry_span_context: #Reference<0.513344876.2758541319.164812>, parent_telemetry_span_context: #Reference<0.513344876.2758541316.161650>}}}, %{opts: %{websocket: [], http_1: [], http_2: []}, plug: {Phoenix.Endpoint.SyncCodeReloadPlug, {PhxTestWeb.Endpoint, []}}, websocket_enabled: true, handler_module: Bandit.InitialHandler, http_1_enabled: true, http_2_enabled: true}}
```

because [this](https://github.com/mtrudel/bandit/blob/5268c2eb5e8a86c0583b815c9918b829e0a88d88/lib/bandit/http1/adapter.ex#L64) will get negative, since we do not limit the first read.

This adds a handler for negative values and only returns the amount of bytes given in `content-length` as body.