### PR TITLE
Compensate remaining body length by previous buffer size

### DIFF
--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -234,7 +234,7 @@ defmodule Bandit.HTTP1.Adapter do
       with {:ok, iolist} <- read(req.socket, to_read, [], read_size, read_timeout) do
         result = IO.iodata_to_binary([buffer | iolist])
         result_size = byte_size(result)
-        body_remaining = body_remaining - result_size
+        body_remaining = body_remaining - result_size + byte_size(buffer)
 
         if body_remaining > 0 do
           metrics = Map.update(metrics, :req_body_bytes, result_size, &(&1 + result_size))


### PR DESCRIPTION
As shown in https://github.com/mtrudel/bandit/pull/182, `body_remaining` goes down beyond 0. That signalizes that due to size miscalculation, `do_req_body` function skips on reading the last few packets from the socket which contains the tail of the body. Note that `body_remaining` is already being adjusted on line 62 after the headers were read. I'm certain that this should not happen. I'm not sure if that fixes `BodyAlreadyReadError` but I think it's still worth to have that fix in the main branch :)