### PR TITLE
Refactor tests with adding Transport abstraction

### DIFF
--- a/test/bandit/http2/plug_test.exs
+++ b/test/bandit/http2/plug_test.exs
@@ -463,7 +463,7 @@ defmodule HTTP2PlugTest do
     SimpleH2Client.send_simple_headers(socket, 1, :get, "/peer_data", context.port)
     SimpleH2Client.recv_headers(socket)
     {:ok, 1, true, body} = SimpleH2Client.recv_body(socket)
-    {:ok, {ip, port}} = :ssl.sockname(socket)
+    {:ok, {ip, port}} = Transport.sockname(socket)
 
     assert body == inspect(%{address: ip, port: port, ssl_cert: nil})
   end
@@ -703,7 +703,8 @@ defmodule HTTP2PlugTest do
         <<130, 135, 68, 137, 98, 114, 209, 65, 226, 240, 123, 40, 147, 65, 139, 8, 157, 92, 11,
           129, 112, 220, 109, 199, 26, 127, 64, 6, 88, 45, 84, 69, 83, 84, 2, 111, 107>>
 
-      :ssl.send(socket, [<<IO.iodata_length(headers)::24, 1::8, 5::8, 0::1, 1::31>>, headers])
+      Transport.send(socket, [<<IO.iodata_length(headers)::24, 1::8, 5::8, 0::1, 1::31>>, headers])
+
       Process.sleep(100)
 
       assert Bandit.TelemetryCollector.get_events(collector_pid)

--- a/test/bandit/initial_handler_test.exs
+++ b/test/bandit/initial_handler_test.exs
@@ -22,8 +22,8 @@ defmodule InitialHandlerTest do
     test "closes connection on HTTP/2 request if so configured", context do
       context = https_server(context, http_2_options: [enabled: false])
       socket = SimpleH2Client.tls_client(context)
-      :ssl.send(socket, "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
-      assert :ssl.recv(socket, 0) == {:error, :closed}
+      Transport.send(socket, "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
+      assert Transport.recv(socket, 0) == {:error, :closed}
     end
   end
 
@@ -47,8 +47,8 @@ defmodule InitialHandlerTest do
     @tag :capture_log
     test "closes with an error if HTTP/1.1 is attempted over an h2 ALPN connection", context do
       socket = SimpleH2Client.tls_client(context)
-      :ssl.send(socket, "GET / HTTP/1.1\r\n")
-      assert :ssl.recv(socket, 0) == {:error, :closed}
+      Transport.send(socket, "GET / HTTP/1.1\r\n")
+      assert Transport.recv(socket, 0) == {:error, :closed}
     end
   end
 
@@ -71,9 +71,9 @@ defmodule InitialHandlerTest do
 
     @tag :capture_log
     test "closes with an error if HTTP2 is attempted over a HTTP/1.1 connection", context do
-      socket = SimpleHTTP1Client.tls_client(context, ["http/1.1"])
-      :ssl.send(socket, "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
-      assert :ssl.recv(socket, 0) == {:error, :closed}
+      socket = Transport.tls_client(context, ["http/1.1"])
+      Transport.send(socket, "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
+      assert Transport.recv(socket, 0) == {:error, :closed}
     end
   end
 

--- a/test/bandit/websocket/protocol_test.exs
+++ b/test/bandit/websocket/protocol_test.exs
@@ -48,7 +48,7 @@ defmodule WebSocketProtocolTest do
         <<>> -> nil
         <<byte::binary-size(1), rest::binary>> -> {byte, rest}
       end)
-      |> Enum.each(fn byte -> :gen_tcp.send(client, byte) end)
+      |> Enum.each(fn byte -> Transport.send(client, byte) end)
 
       assert SimpleWebSocketClient.recv_text_frame(client) == {:ok, "OK"}
     end
@@ -59,11 +59,11 @@ defmodule WebSocketProtocolTest do
       SimpleWebSocketClient.http1_handshake(client, EchoWebSock)
 
       # Send one and a half frames
-      :gen_tcp.send(client, <<8::4, 1::4, 1::1, 2::7, 0::32>> <> "OK" <> <<8::4, 1::4>>)
+      Transport.send(client, <<8::4, 1::4, 1::1, 2::7, 0::32>> <> "OK" <> <<8::4, 1::4>>)
       assert SimpleWebSocketClient.recv_text_frame(client) == {:ok, "OK"}
 
       # Now send the rest of the second frame
-      :gen_tcp.send(client, <<1::1, 2::7, 0::32>> <> "OK")
+      Transport.send(client, <<1::1, 2::7, 0::32>> <> "OK")
 
       assert SimpleWebSocketClient.recv_text_frame(client) == {:ok, "OK"}
     end
@@ -73,7 +73,7 @@ defmodule WebSocketProtocolTest do
       SimpleWebSocketClient.http1_handshake(client, EchoWebSock)
 
       # Send two text frames at once one byte at a time
-      :gen_tcp.send(
+      Transport.send(
         client,
         <<8::4, 1::4, 1::1, 2::7, 0::32>> <> "OK" <> <<8::4, 1::4, 1::1, 2::7, 0::32>> <> "OK"
       )

--- a/test/bandit/websocket/sock_test.exs
+++ b/test/bandit/websocket/sock_test.exs
@@ -969,7 +969,7 @@ defmodule WebSocketWebSockTest do
       client = SimpleWebSocketClient.tcp_client(context)
       SimpleWebSocketClient.http1_handshake(client, TerminateWebSock)
 
-      :gen_tcp.close(client)
+      Transport.close(client)
 
       assert_receive {:error, :closed}
     end

--- a/test/support/simple_h2_client.ex
+++ b/test/support/simple_h2_client.ex
@@ -3,7 +3,7 @@ defmodule SimpleH2Client do
 
   import Bitwise
 
-  def tls_client(context), do: SimpleHTTP1Client.tls_client(context, ["h2"])
+  def tls_client(context), do: Transport.tls_client(context, ["h2"])
 
   def setup_connection(context) do
     socket = tls_client(context)
@@ -13,33 +13,33 @@ defmodule SimpleH2Client do
   end
 
   def exchange_prefaces(socket) do
-    :ssl.send(socket, "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
-    {:ok, <<0, 0, 0, 4, 0, 0, 0, 0, 0>>} = :ssl.recv(socket, 9)
-    :ssl.send(socket, <<0, 0, 0, 4, 1, 0, 0, 0, 0>>)
+    Transport.send(socket, "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
+    {:ok, <<0, 0, 0, 4, 0, 0, 0, 0, 0>>} = Transport.recv(socket, 9)
+    Transport.send(socket, <<0, 0, 0, 4, 1, 0, 0, 0, 0>>)
   end
 
   def exchange_client_settings(socket, settings \\ <<>>) do
-    :ssl.send(socket, <<IO.iodata_length(settings)::24, 4, 0, 0, 0, 0, 0>>)
-    :ssl.send(socket, settings)
-    {:ok, <<0, 0, 0, 4, 1, 0, 0, 0, 0>>} = :ssl.recv(socket, 9)
+    Transport.send(socket, <<IO.iodata_length(settings)::24, 4, 0, 0, 0, 0, 0>>)
+    Transport.send(socket, settings)
+    {:ok, <<0, 0, 0, 4, 1, 0, 0, 0, 0>>} = Transport.recv(socket, 9)
   end
 
   def connection_alive?(socket) do
-    :ssl.send(socket, <<0, 0, 8, 6, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8>>)
-    :ssl.recv(socket, 17) == {:ok, <<0, 0, 8, 6, 1, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8>>}
+    Transport.send(socket, <<0, 0, 8, 6, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8>>)
+    Transport.recv(socket, 17) == {:ok, <<0, 0, 8, 6, 1, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8>>}
   end
 
   def recv_goaway_and_close(socket) do
     {:ok, <<0, 0, 8, 7, 0, 0, 0, 0, 0, last_stream_id::32, error_code::32>>} =
-      :ssl.recv(socket, 17)
+      Transport.recv(socket, 17)
 
-    {:error, :closed} = :ssl.recv(socket, 0)
+    {:error, :closed} = Transport.recv(socket, 0)
 
     {:ok, last_stream_id, error_code}
   end
 
   def send_goaway(socket, last_stream_id, error_code) do
-    :ssl.send(socket, <<0, 0, 8, 7, 0, 0, 0, 0, 0, last_stream_id::32, error_code::32>>)
+    Transport.send(socket, <<0, 0, 8, 7, 0, 0, 0, 0, 0, last_stream_id::32, error_code::32>>)
   end
 
   def send_simple_headers(socket, stream_id, verb, path, port, ctx \\ HPAX.new(4096)) do
@@ -68,7 +68,7 @@ defmodule SimpleH2Client do
     {headers, _} = headers |> Enum.map(fn {k, v} -> {:store, k, v} end) |> HPAX.encode(ctx)
     flags = if end_stream, do: 0x05, else: 0x04
 
-    :ssl.send(socket, [
+    Transport.send(socket, [
       <<IO.iodata_length(headers)::24, 1::8, flags::8, 0::1, stream_id::31>>,
       headers
     ])
@@ -77,7 +77,7 @@ defmodule SimpleH2Client do
   end
 
   def send_priority(socket, stream_id, dependent_stream_id, weight) do
-    :ssl.send(socket, <<0, 0, 5, 2, 0, stream_id::32, dependent_stream_id::32, weight::8>>)
+    Transport.send(socket, <<0, 0, 5, 2, 0, stream_id::32, dependent_stream_id::32, weight::8>>)
   end
 
   def successful_response?(socket, stream_id, end_stream, ctx \\ HPAX.new(4096)) do
@@ -85,43 +85,49 @@ defmodule SimpleH2Client do
   end
 
   def recv_headers(socket, ctx \\ HPAX.new(4096)) do
-    {:ok, <<length::24, 1::8, flags::8, 0::1, stream_id::31>>} = :ssl.recv(socket, 9)
-    {:ok, header_block} = :ssl.recv(socket, length)
+    {:ok, <<length::24, 1::8, flags::8, 0::1, stream_id::31>>} = Transport.recv(socket, 9)
+    {:ok, header_block} = Transport.recv(socket, length)
     {:ok, headers, ctx} = HPAX.decode(header_block, ctx)
     {:ok, stream_id, (flags &&& 0x01) == 0x01, headers, ctx}
   end
 
   def send_body(socket, stream_id, end_stream, body) do
     flags = if end_stream, do: 0x01, else: 0x00
-    :ssl.send(socket, [<<IO.iodata_length(body)::24, 0::8, flags::8, 0::1, stream_id::31>>, body])
+
+    Transport.send(socket, [
+      <<IO.iodata_length(body)::24, 0::8, flags::8, 0::1, stream_id::31>>,
+      body
+    ])
   end
 
   def send_window_update(socket, stream_id, increment) do
-    :ssl.send(socket, <<4::24, 8::8, 0::8, 0::1, stream_id::31, 0::1, increment::31>>)
+    Transport.send(socket, <<4::24, 8::8, 0::8, 0::1, stream_id::31, 0::1, increment::31>>)
   end
 
   def recv_window_update(socket) do
-    {:ok, <<4::24, 8::8, 0::8, 0::1, stream_id::31, 0::1, update::31>>} = :ssl.recv(socket, 13)
+    {:ok, <<4::24, 8::8, 0::8, 0::1, stream_id::31, 0::1, update::31>>} =
+      Transport.recv(socket, 13)
+
     {:ok, stream_id, update}
   end
 
   def recv_body(socket) do
-    {:ok, <<body_length::24, 0::8, flags::8, 0::1, stream_id::31>>} = :ssl.recv(socket, 9)
+    {:ok, <<body_length::24, 0::8, flags::8, 0::1, stream_id::31>>} = Transport.recv(socket, 9)
 
     if body_length == 0 do
       {:ok, stream_id, (flags &&& 0x01) == 0x01, <<>>}
     else
-      {:ok, body} = :ssl.recv(socket, body_length)
+      {:ok, body} = Transport.recv(socket, body_length)
       {:ok, stream_id, (flags &&& 0x01) == 0x01, body}
     end
   end
 
   def send_rst_stream(socket, stream_id, error_code) do
-    :ssl.send(socket, [<<0, 0, 4, 3, 0, 0::1, stream_id::31>>, <<error_code::32>>])
+    Transport.send(socket, [<<0, 0, 4, 3, 0, 0::1, stream_id::31>>, <<error_code::32>>])
   end
 
   def recv_rst_stream(socket) do
-    {:ok, <<0, 0, 4, 3, 0, 0::1, stream_id::31, error_code::32>>} = :ssl.recv(socket, 13)
+    {:ok, <<0, 0, 4, 3, 0, 0::1, stream_id::31, error_code::32>>} = Transport.recv(socket, 13)
     {:ok, stream_id, error_code}
   end
 end

--- a/test/support/transport.ex
+++ b/test/support/transport.ex
@@ -1,0 +1,44 @@
+defmodule Transport do
+  @moduledoc false
+
+  def tcp_client(context) do
+    {:ok, socket} =
+      :gen_tcp.connect(~c"localhost", context[:port], active: false, mode: :binary, nodelay: true)
+
+    {:client, %{socket: socket, transport: :gen_tcp}}
+  end
+
+  def tls_client(context, protocols) do
+    {:ok, socket} =
+      :ssl.connect(~c"localhost", context[:port],
+        active: false,
+        mode: :binary,
+        nodelay: true,
+        verify: :verify_peer,
+        cacertfile: Path.join(__DIR__, "../support/ca.pem"),
+        alpn_advertised_protocols: protocols
+      )
+
+    {:client, %{socket: socket, transport: :ssl}}
+  end
+
+  def send({:client, %{transport: transport, socket: socket}}, data) do
+    transport.send(socket, data)
+  end
+
+  def recv({:client, %{transport: transport, socket: socket}}, length) do
+    transport.recv(socket, length)
+  end
+
+  def close({:client, %{transport: transport, socket: socket}}) do
+    transport.close(socket)
+  end
+
+  def sockname({:client, %{transport: :gen_tcp, socket: socket}}) do
+    :inet.sockname(socket)
+  end
+
+  def sockname({:client, %{transport: :ssl, socket: socket}}) do
+    :ssl.sockname(socket)
+  end
+end


### PR DESCRIPTION
A small refactoring for the SimpleH2Client and SimpleHTTP1Client to support both transports (TCP and SSL) for both of the protocols (HTTP/1.1 and HTTP/2)