### PR TITLE
Refine telemetry behaviour in error cases 

### DIFF
--- a/lib/bandit/http1/handler.ex
+++ b/lib/bandit/http1/handler.ex
@@ -36,7 +36,7 @@ defmodule Bandit.HTTP1.Handler do
                headers,
                state.plug
              ) do
-        Bandit.Telemetry.stop_span(span, Map.put(req.metrics, :conn, conn))
+        Bandit.Telemetry.stop_span(span, req.metrics, %{conn: conn})
         maybe_keepalive(req, state)
       else
         {:error, reason} ->
@@ -45,7 +45,7 @@ defmodule Bandit.HTTP1.Handler do
           {:error, reason, state}
 
         {:ok, :websocket, %Plug.Conn{adapter: {Bandit.HTTP1.Adapter, req}} = conn, upgrade_opts} ->
-          Bandit.Telemetry.stop_span(span, Map.put(req.metrics, :conn, conn))
+          Bandit.Telemetry.stop_span(span, req.metrics, %{conn: conn})
 
           state =
             state

--- a/lib/bandit/http1/handler.ex
+++ b/lib/bandit/http1/handler.ex
@@ -20,59 +20,85 @@ defmodule Bandit.HTTP1.Handler do
       websocket_enabled: state.websocket_enabled
     }
 
-    try do
-      with {:ok, transport_info} <- Bandit.TransportInfo.init(socket),
-           req <- %{req | transport_info: transport_info},
-           {:ok, method, request_target, req} <- Bandit.HTTP1.Adapter.read_request_line(req),
-           {:ok, headers, req} <- Bandit.HTTP1.Adapter.read_headers(req),
-           {:ok, :no_upgrade} <-
-             maybe_upgrade_h2c(state, req, transport_info, method, request_target, headers),
-           {:ok, %Plug.Conn{adapter: {Bandit.HTTP1.Adapter, req}} = conn} <-
-             Bandit.Pipeline.run(
-               {Bandit.HTTP1.Adapter, req},
-               transport_info,
-               method,
-               request_target,
-               headers,
-               state.plug
-             ) do
-        Bandit.Telemetry.stop_span(span, req.metrics, %{conn: conn})
-        maybe_keepalive(req, state)
-      else
-        {:error, reason} ->
-          _ = attempt_to_send_fallback(req, code_for_reason(reason))
-          Bandit.Telemetry.stop_span(span, %{}, %{error: reason})
-          {:error, reason, state}
+    with {:ok, transport_info} <- Bandit.TransportInfo.init(socket),
+         req <- %{req | transport_info: transport_info},
+         {:ok, method, request_target, req} <- Bandit.HTTP1.Adapter.read_request_line(req) do
+      try do
+        with {:ok, headers, req} <- Bandit.HTTP1.Adapter.read_headers(req),
+             {:ok, :no_upgrade} <-
+               maybe_upgrade_h2c(state, req, transport_info, method, request_target, headers),
+             {:ok, %Plug.Conn{adapter: {Bandit.HTTP1.Adapter, req}} = conn} <-
+               Bandit.Pipeline.run(
+                 {Bandit.HTTP1.Adapter, req},
+                 transport_info,
+                 method,
+                 request_target,
+                 headers,
+                 state.plug
+               ) do
+          Bandit.Telemetry.stop_span(span, req.metrics, %{
+            conn: conn,
+            status: conn.status,
+            method: method,
+            request_target: request_target
+          })
 
-        {:ok, :websocket, %Plug.Conn{adapter: {Bandit.HTTP1.Adapter, req}} = conn, upgrade_opts} ->
-          Bandit.Telemetry.stop_span(span, req.metrics, %{conn: conn})
+          maybe_keepalive(req, state)
+        else
+          {:error, reason} ->
+            code = code_for_reason(reason)
+            _ = attempt_to_send_fallback(req, code)
 
-          state =
-            state
-            |> Map.put(:upgrade_opts, upgrade_opts)
-            |> Map.put(
-              :origin_telemetry_span_context,
-              Bandit.Telemetry.telemetry_span_context(span)
-            )
+            Bandit.Telemetry.stop_span(span, %{}, %{
+              error: reason,
+              status: code,
+              method: method,
+              request_target: request_target
+            })
 
-          {:switch, Bandit.WebSocket.Handler, state}
+            {:error, reason, state}
 
-        {:ok, :h2c, req, remote_settings, initial_request} ->
-          Bandit.Telemetry.stop_span(span, req.metrics)
+          {:ok, :websocket, %Plug.Conn{adapter: {Bandit.HTTP1.Adapter, req}} = conn, upgrade_opts} ->
+            Bandit.Telemetry.stop_span(span, req.metrics, %{
+              conn: conn,
+              status: conn.status,
+              method: method,
+              request_target: request_target
+            })
 
-          state =
-            state
-            |> Map.put(:remote_settings, remote_settings)
-            |> Map.put(:initial_request, initial_request)
+            state =
+              state
+              |> Map.put(:upgrade_opts, upgrade_opts)
+              |> Map.put(
+                :origin_telemetry_span_context,
+                Bandit.Telemetry.telemetry_span_context(span)
+              )
 
-          {:switch, Bandit.HTTP2.Handler, state}
+            {:switch, Bandit.WebSocket.Handler, state}
+
+          {:ok, :h2c, req, remote_settings, initial_request} ->
+            Bandit.Telemetry.stop_span(span, req.metrics)
+
+            state =
+              state
+              |> Map.put(:remote_settings, remote_settings)
+              |> Map.put(:initial_request, initial_request)
+
+            {:switch, Bandit.HTTP2.Handler, state}
+        end
+      rescue
+        exception ->
+          # Raise here so that users can see useful stacktraces
+          _ = attempt_to_send_fallback(req, 500)
+          Bandit.Telemetry.span_exception(span, :exit, exception, __STACKTRACE__)
+          reraise(exception, __STACKTRACE__)
       end
-    rescue
-      exception ->
-        # Raise here so that users can see useful stacktraces
-        _ = attempt_to_send_fallback(req, 500)
-        Bandit.Telemetry.span_exception(span, :exit, exception, __STACKTRACE__)
-        reraise(exception, __STACKTRACE__)
+    else
+      {:error, reason} ->
+        code = code_for_reason(reason)
+        _ = attempt_to_send_fallback(req, code)
+        Bandit.Telemetry.stop_span(span, %{}, %{error: reason, code: code})
+        {:error, reason, state}
     end
   end
 

--- a/lib/bandit/http1/handler.ex
+++ b/lib/bandit/http1/handler.ex
@@ -23,8 +23,8 @@ defmodule Bandit.HTTP1.Handler do
     try do
       with {:ok, transport_info} <- Bandit.TransportInfo.init(socket),
            req <- %{req | transport_info: transport_info},
-           {:ok, headers, method, request_target, req} <-
-             Bandit.HTTP1.Adapter.read_headers(req),
+           {:ok, method, request_target, req} <- Bandit.HTTP1.Adapter.read_request_line(req),
+           {:ok, headers, req} <- Bandit.HTTP1.Adapter.read_headers(req),
            {:ok, :no_upgrade} <-
              maybe_upgrade_h2c(state, req, transport_info, method, request_target, headers),
            {:ok, %Plug.Conn{adapter: {Bandit.HTTP1.Adapter, req}} = conn} <-

--- a/lib/bandit/http2/stream_task.ex
+++ b/lib/bandit/http2/stream_task.ex
@@ -66,7 +66,7 @@ defmodule Bandit.HTTP2.StreamTask do
          adapter <- {Bandit.HTTP2.Adapter, req},
          {:ok, %Plug.Conn{adapter: {Bandit.HTTP2.Adapter, req}} = conn} <-
            Bandit.Pipeline.run(adapter, transport_info, method, request_target, headers, plug) do
-      Bandit.Telemetry.stop_span(span, Map.put(req.metrics, :conn, conn))
+      Bandit.Telemetry.stop_span(span, req.metrics, %{conn: conn})
       :ok
     else
       {:error, reason} -> raise Bandit.HTTP2.Stream.StreamError, reason

--- a/lib/bandit/http2/stream_task.ex
+++ b/lib/bandit/http2/stream_task.ex
@@ -52,22 +52,35 @@ defmodule Bandit.HTTP2.StreamTask do
 
   def run(req, transport_info, all_headers, plug, span) do
     with {:ok, request_target} <- build_request_target(all_headers),
-         {:ok, pseudo_headers, headers} <- split_headers(all_headers),
-         :ok <- pseudo_headers_all_request(pseudo_headers),
-         :ok <- exactly_one_instance_of(pseudo_headers, ":scheme"),
-         :ok <- exactly_one_instance_of(pseudo_headers, ":method"),
-         :ok <- exactly_one_instance_of(pseudo_headers, ":path"),
-         method <- Bandit.Headers.get_header(pseudo_headers, ":method"),
-         :ok <- headers_all_lowercase(headers),
-         :ok <- no_connection_headers(headers),
-         :ok <- valid_te_header(headers),
-         headers <- combine_cookie_crumbs(headers),
-         req <- Bandit.HTTP2.Adapter.add_end_header_metric(req),
-         adapter <- {Bandit.HTTP2.Adapter, req},
-         {:ok, %Plug.Conn{adapter: {Bandit.HTTP2.Adapter, req}} = conn} <-
-           Bandit.Pipeline.run(adapter, transport_info, method, request_target, headers, plug) do
-      Bandit.Telemetry.stop_span(span, req.metrics, %{conn: conn})
-      :ok
+         method <- Bandit.Headers.get_header(all_headers, ":method") do
+      with {:ok, pseudo_headers, headers} <- split_headers(all_headers),
+           :ok <- pseudo_headers_all_request(pseudo_headers),
+           :ok <- exactly_one_instance_of(pseudo_headers, ":scheme"),
+           :ok <- exactly_one_instance_of(pseudo_headers, ":method"),
+           :ok <- exactly_one_instance_of(pseudo_headers, ":path"),
+           :ok <- headers_all_lowercase(headers),
+           :ok <- no_connection_headers(headers),
+           :ok <- valid_te_header(headers),
+           headers <- combine_cookie_crumbs(headers),
+           req <- Bandit.HTTP2.Adapter.add_end_header_metric(req),
+           adapter <- {Bandit.HTTP2.Adapter, req},
+           {:ok, %Plug.Conn{adapter: {Bandit.HTTP2.Adapter, req}} = conn} <-
+             Bandit.Pipeline.run(adapter, transport_info, method, request_target, headers, plug) do
+        Bandit.Telemetry.stop_span(span, req.metrics, %{
+          conn: conn,
+          method: method,
+          request_target: request_target,
+          status: conn.status
+        })
+
+        :ok
+      else
+        {:error, reason} ->
+          raise Bandit.HTTP2.Stream.StreamError,
+            message: reason,
+            method: method,
+            request_target: request_target
+      end
     else
       {:error, reason} -> raise Bandit.HTTP2.Stream.StreamError, reason
     end

--- a/lib/bandit/telemetry.ex
+++ b/lib/bandit/telemetry.ex
@@ -60,7 +60,14 @@ defmodule Bandit.Telemetry do
       * `telemetry_span_context`: A unique identifier for this span
       * `connection_telemetry_span_context`: The span context of the Thousand Island `:connection`
         span which contains this request
-      * `conn`: The `Plug.Conn` representing this connection
+      * `method`: The HTTP method of the request. If Bandit could not determine the method, this
+        will be nil
+      * `request_target`: The raw request target for the request. Returned as a tuple comprising the
+        constituent parts of the request target: `{scheme, host, port, path}`. If Bandit could not
+        determine the request target, this will be nil
+      * `status`: The numeric response status code of the response
+      * `conn`: The `Plug.Conn` representing this connection. Not present in cases where `error`
+        is also set
       * `stream_id`: The stream ID of the request, if part of an HTTP/2 connection
       * `error`: The error that caused the span to end, if it ended in error
 

--- a/lib/bandit/telemetry.ex
+++ b/lib/bandit/telemetry.ex
@@ -32,7 +32,6 @@ defmodule Bandit.Telemetry do
 
       * `monotonic_time`: The time of this event, in `:native` units
       * `duration`: The span duration, in `:native` units
-      * `conn`: The `Plug.Conn` representing this connection
       * `req_header_end_time`: The time that header reading completed, in `:native` units
       * `req_body_start_time`: The time that request body reading started, in `:native` units.
       * `req_body_end_time`: The time that request body reading completed, in `:native` units
@@ -61,6 +60,8 @@ defmodule Bandit.Telemetry do
       * `telemetry_span_context`: A unique identifier for this span
       * `connection_telemetry_span_context`: The span context of the Thousand Island `:connection`
         span which contains this request
+      * `conn`: The `Plug.Conn` representing this connection
+      * `stream_id`: The stream ID of the request, if part of an HTTP/2 connection
       * `error`: The error that caused the span to end, if it ended in error
 
   The following events may be emitted within this span:

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -1264,7 +1264,10 @@ defmodule HTTP1RequestTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
-                  conn: struct_like(Plug.Conn, [])
+                  conn: struct_like(Plug.Conn, []),
+                  status: 200,
+                  method: "GET",
+                  request_target: {nil, nil, nil, "/send_200"}
                 }}
              ]
     end
@@ -1299,7 +1302,10 @@ defmodule HTTP1RequestTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
-                  conn: struct_like(Plug.Conn, [])
+                  conn: struct_like(Plug.Conn, []),
+                  status: 200,
+                  method: "POST",
+                  request_target: {nil, nil, nil, "/do_read_body"}
                 }}
              ]
     end
@@ -1338,7 +1344,10 @@ defmodule HTTP1RequestTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
-                  conn: struct_like(Plug.Conn, [])
+                  conn: struct_like(Plug.Conn, []),
+                  status: 200,
+                  method: "POST",
+                  request_target: {nil, nil, nil, "/do_read_body"}
                 }}
              ]
     end
@@ -1373,7 +1382,10 @@ defmodule HTTP1RequestTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
-                  conn: struct_like(Plug.Conn, [])
+                  conn: struct_like(Plug.Conn, []),
+                  status: 200,
+                  method: "POST",
+                  request_target: {nil, nil, nil, "/do_read_body"}
                 }}
              ]
     end
@@ -1414,7 +1426,10 @@ defmodule HTTP1RequestTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
-                  conn: struct_like(Plug.Conn, [])
+                  conn: struct_like(Plug.Conn, []),
+                  status: 200,
+                  method: "POST",
+                  request_target: {nil, nil, nil, "/do_read_body"}
                 }}
              ]
     end
@@ -1444,7 +1459,10 @@ defmodule HTTP1RequestTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
-                  conn: struct_like(Plug.Conn, [])
+                  conn: struct_like(Plug.Conn, []),
+                  status: 200,
+                  method: "GET",
+                  request_target: {nil, nil, nil, "/send_chunked_200"}
                 }}
              ]
     end
@@ -1475,7 +1493,10 @@ defmodule HTTP1RequestTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
-                  conn: struct_like(Plug.Conn, [])
+                  conn: struct_like(Plug.Conn, []),
+                  status: 200,
+                  method: "GET",
+                  request_target: {nil, nil, nil, "/send_full_file"}
                 }}
              ]
     end
@@ -1495,7 +1516,10 @@ defmodule HTTP1RequestTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
-                  error: string()
+                  error: string(),
+                  status: 400,
+                  method: "GET",
+                  request_target: {nil, nil, nil, "/"}
                 }}
              ]
     end
@@ -1515,7 +1539,10 @@ defmodule HTTP1RequestTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
-                  error: :timeout
+                  error: :timeout,
+                  status: 408,
+                  method: "GET",
+                  request_target: {nil, nil, nil, "/"}
                 }}
              ]
     end

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -1252,7 +1252,6 @@ defmodule HTTP1RequestTest do
                 %{
                   monotonic_time: integer(),
                   duration: integer(),
-                  conn: struct_like(Plug.Conn, []),
                   req_line_bytes: 24,
                   req_header_end_time: integer(),
                   req_header_bytes: 19,
@@ -1264,7 +1263,8 @@ defmodule HTTP1RequestTest do
                 },
                 %{
                   connection_telemetry_span_context: reference(),
-                  telemetry_span_context: reference()
+                  telemetry_span_context: reference(),
+                  conn: struct_like(Plug.Conn, [])
                 }}
              ]
     end
@@ -1284,7 +1284,6 @@ defmodule HTTP1RequestTest do
                 %{
                   monotonic_time: integer(),
                   duration: integer(),
-                  conn: struct_like(Plug.Conn, []),
                   req_line_bytes: integer(),
                   req_header_end_time: integer(),
                   req_header_bytes: integer(),
@@ -1299,7 +1298,8 @@ defmodule HTTP1RequestTest do
                 },
                 %{
                   connection_telemetry_span_context: reference(),
-                  telemetry_span_context: reference()
+                  telemetry_span_context: reference(),
+                  conn: struct_like(Plug.Conn, [])
                 }}
              ]
     end
@@ -1323,7 +1323,6 @@ defmodule HTTP1RequestTest do
                 %{
                   monotonic_time: integer(),
                   duration: integer(),
-                  conn: struct_like(Plug.Conn, []),
                   req_line_bytes: integer(),
                   req_header_end_time: integer(),
                   req_header_bytes: integer(),
@@ -1338,7 +1337,8 @@ defmodule HTTP1RequestTest do
                 },
                 %{
                   connection_telemetry_span_context: reference(),
-                  telemetry_span_context: reference()
+                  telemetry_span_context: reference(),
+                  conn: struct_like(Plug.Conn, [])
                 }}
              ]
     end
@@ -1358,7 +1358,6 @@ defmodule HTTP1RequestTest do
                 %{
                   monotonic_time: integer(),
                   duration: integer(),
-                  conn: struct_like(Plug.Conn, []),
                   req_line_bytes: integer(),
                   req_header_end_time: integer(),
                   req_header_bytes: integer(),
@@ -1373,7 +1372,8 @@ defmodule HTTP1RequestTest do
                 },
                 %{
                   connection_telemetry_span_context: reference(),
-                  telemetry_span_context: reference()
+                  telemetry_span_context: reference(),
+                  conn: struct_like(Plug.Conn, [])
                 }}
              ]
     end
@@ -1397,7 +1397,6 @@ defmodule HTTP1RequestTest do
                 %{
                   monotonic_time: integer(),
                   duration: integer(),
-                  conn: struct_like(Plug.Conn, []),
                   req_line_bytes: integer(),
                   req_header_end_time: integer(),
                   req_header_bytes: integer(),
@@ -1414,7 +1413,8 @@ defmodule HTTP1RequestTest do
                 },
                 %{
                   connection_telemetry_span_context: reference(),
-                  telemetry_span_context: reference()
+                  telemetry_span_context: reference(),
+                  conn: struct_like(Plug.Conn, [])
                 }}
              ]
     end
@@ -1433,7 +1433,6 @@ defmodule HTTP1RequestTest do
                 %{
                   monotonic_time: integer(),
                   duration: integer(),
-                  conn: struct_like(Plug.Conn, []),
                   req_line_bytes: 32,
                   req_header_end_time: integer(),
                   req_header_bytes: 49,
@@ -1444,7 +1443,8 @@ defmodule HTTP1RequestTest do
                 },
                 %{
                   connection_telemetry_span_context: reference(),
-                  telemetry_span_context: reference()
+                  telemetry_span_context: reference(),
+                  conn: struct_like(Plug.Conn, [])
                 }}
              ]
     end
@@ -1463,7 +1463,6 @@ defmodule HTTP1RequestTest do
                 %{
                   monotonic_time: integer(),
                   duration: integer(),
-                  conn: struct_like(Plug.Conn, []),
                   req_line_bytes: 30,
                   req_header_end_time: integer(),
                   req_header_bytes: 49,
@@ -1475,7 +1474,8 @@ defmodule HTTP1RequestTest do
                 },
                 %{
                   connection_telemetry_span_context: reference(),
-                  telemetry_span_context: reference()
+                  telemetry_span_context: reference(),
+                  conn: struct_like(Plug.Conn, [])
                 }}
              ]
     end

--- a/test/bandit/http2/plug_test.exs
+++ b/test/bandit/http2/plug_test.exs
@@ -551,7 +551,6 @@ defmodule HTTP2PlugTest do
                 %{
                   monotonic_time: integer(),
                   duration: integer(),
-                  conn: struct_like(Plug.Conn, []),
                   req_header_end_time: integer(),
                   resp_body_bytes: 0,
                   resp_start_time: integer(),
@@ -560,6 +559,7 @@ defmodule HTTP2PlugTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
+                  conn: struct_like(Plug.Conn, []),
                   stream_id: integer()
                 }}
              ]
@@ -578,7 +578,6 @@ defmodule HTTP2PlugTest do
                 %{
                   monotonic_time: integer(),
                   duration: integer(),
-                  conn: struct_like(Plug.Conn, []),
                   req_header_end_time: integer(),
                   req_body_start_time: integer(),
                   req_body_end_time: integer(),
@@ -590,6 +589,7 @@ defmodule HTTP2PlugTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
+                  conn: struct_like(Plug.Conn, []),
                   stream_id: integer()
                 }}
              ]
@@ -612,7 +612,6 @@ defmodule HTTP2PlugTest do
                 %{
                   monotonic_time: integer(),
                   duration: integer(),
-                  conn: struct_like(Plug.Conn, []),
                   req_header_end_time: integer(),
                   req_body_start_time: integer(),
                   req_body_end_time: integer(),
@@ -624,6 +623,7 @@ defmodule HTTP2PlugTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
+                  conn: struct_like(Plug.Conn, []),
                   stream_id: integer()
                 }}
              ]
@@ -646,7 +646,6 @@ defmodule HTTP2PlugTest do
                 %{
                   monotonic_time: integer(),
                   duration: integer(),
-                  conn: struct_like(Plug.Conn, []),
                   req_header_end_time: integer(),
                   req_body_start_time: integer(),
                   req_body_end_time: integer(),
@@ -660,6 +659,7 @@ defmodule HTTP2PlugTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
+                  conn: struct_like(Plug.Conn, []),
                   stream_id: integer()
                 }}
              ]
@@ -677,7 +677,6 @@ defmodule HTTP2PlugTest do
                 %{
                   monotonic_time: integer(),
                   duration: integer(),
-                  conn: struct_like(Plug.Conn, []),
                   req_header_end_time: integer(),
                   resp_body_bytes: 6,
                   resp_start_time: integer(),
@@ -686,6 +685,7 @@ defmodule HTTP2PlugTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
+                  conn: struct_like(Plug.Conn, []),
                   stream_id: integer()
                 }}
              ]

--- a/test/bandit/http2/plug_test.exs
+++ b/test/bandit/http2/plug_test.exs
@@ -560,6 +560,9 @@ defmodule HTTP2PlugTest do
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
                   conn: struct_like(Plug.Conn, []),
+                  status: 200,
+                  method: "GET",
+                  request_target: {"https", "localhost", integer(), "/send_200"},
                   stream_id: integer()
                 }}
              ]
@@ -590,6 +593,9 @@ defmodule HTTP2PlugTest do
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
                   conn: struct_like(Plug.Conn, []),
+                  status: 200,
+                  method: "POST",
+                  request_target: {"https", "localhost", integer(), "/do_read_body"},
                   stream_id: integer()
                 }}
              ]
@@ -624,6 +630,9 @@ defmodule HTTP2PlugTest do
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
                   conn: struct_like(Plug.Conn, []),
+                  status: 200,
+                  method: "POST",
+                  request_target: {"https", "localhost", integer(), "/do_read_body"},
                   stream_id: integer()
                 }}
              ]
@@ -660,6 +669,9 @@ defmodule HTTP2PlugTest do
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
                   conn: struct_like(Plug.Conn, []),
+                  status: 200,
+                  method: "POST",
+                  request_target: {"https", "localhost", integer(), "/do_read_body"},
                   stream_id: integer()
                 }}
              ]
@@ -686,6 +698,9 @@ defmodule HTTP2PlugTest do
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
                   conn: struct_like(Plug.Conn, []),
+                  status: 200,
+                  method: "GET",
+                  request_target: {"https", "localhost", integer(), "/send_full_file"},
                   stream_id: integer()
                 }}
              ]
@@ -713,6 +728,9 @@ defmodule HTTP2PlugTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
+                  status: nil,
+                  method: "GET",
+                  request_target: {"https", "127.0.0.1", integer(), "/hello_world"},
                   stream_id: integer(),
                   error: string()
                 }}

--- a/test/bandit/websocket/upgrade_test.exs
+++ b/test/bandit/websocket/upgrade_test.exs
@@ -80,7 +80,11 @@ defmodule WebSocketUpgradeTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
-                  conn: struct_like(Plug.Conn, [])
+                  conn: struct_like(Plug.Conn, []),
+                  status: 101,
+                  method: "GET",
+                  request_target:
+                    {nil, nil, nil, "/?websock=Elixir.WebSocketUpgradeTest.MyNoopWebSock"}
                 }}
              ]
     end

--- a/test/bandit/websocket/upgrade_test.exs
+++ b/test/bandit/websocket/upgrade_test.exs
@@ -68,7 +68,6 @@ defmodule WebSocketUpgradeTest do
                 %{
                   monotonic_time: integer(),
                   duration: integer(),
-                  conn: struct_like(Plug.Conn, []),
                   req_line_bytes: 66,
                   req_header_end_time: integer(),
                   req_header_bytes: 141,
@@ -80,7 +79,8 @@ defmodule WebSocketUpgradeTest do
                 },
                 %{
                   connection_telemetry_span_context: reference(),
-                  telemetry_span_context: reference()
+                  telemetry_span_context: reference(),
+                  conn: struct_like(Plug.Conn, [])
                 }}
              ]
     end


### PR DESCRIPTION
* Move `conn` into telemetry metadata
* Add `method`, `request_target` and `status` metadata to HTTP telemetry stop events
* Refactor HTTP/1 & HTTP/2 implementations to separate out request line parsing, in order to have access to method & request target for early errors