### PR TITLE
Fix typo in  Bandit docs

### DIFF
--- a/lib/bandit.ex
+++ b/lib/bandit.ex
@@ -25,7 +25,7 @@ defmodule Bandit do
     valid `certfile` and `keyfile` values (or an equivalent value within
     `thousand_island_options.transport_options`). Defaults to `:http`
   * `port`: The TCP port to listen on. This option is offered as a convenience and actually sets
-    the option of the same name within `thousand_island_options`. If ia string value is passed, it
+    the option of the same name within `thousand_island_options`. If a string value is passed, it
     will be parsed as an integer. Defaults to 4000 if `scheme` is `:http`, and 4040 if `scheme` is
     `:https`
   * `ip`:  The interface(s) to listen on. This option is offered as a convenience and actually sets the


### PR DESCRIPTION
Fixes a small typo.