### PR TITLE
Improve handling of iolist response bodies

### DIFF
--- a/lib/bandit/compression.ex
+++ b/lib/bandit/compression.ex
@@ -11,7 +11,7 @@ defmodule Bandit.Compression do
     |> Enum.find(&(&1 in ~w(deflate gzip x-gzip)))
   end
 
-  @spec compress(binary(), String.t(), Bandit.deflate_options()) :: iodata()
+  @spec compress(iolist(), String.t(), Bandit.deflate_options()) :: iodata()
   def compress(response, "deflate", opts) do
     deflate_context = :zlib.open()
 

--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -369,13 +369,15 @@ defmodule Bandit.HTTP1.Adapter do
         header -> "no-transform" in Plug.Conn.Utils.list(header)
       end
 
+    raw_body_bytes = IO.iodata_length(body)
+
     {body, headers, compression_metrics} =
       case {body, req.content_encoding, response_content_encoding_header,
             response_has_strong_etag, response_indicates_no_transform} do
         {body, content_encoding, nil, false, false}
-        when byte_size(body) > 0 and not is_nil(content_encoding) ->
+        when raw_body_bytes > 0 and not is_nil(content_encoding) ->
           metrics = %{
-            resp_uncompressed_body_bytes: IO.iodata_length(body),
+            resp_uncompressed_body_bytes: raw_body_bytes,
             resp_compression_method: content_encoding
           }
 

--- a/lib/bandit/http2/adapter.ex
+++ b/lib/bandit/http2/adapter.ex
@@ -120,13 +120,15 @@ defmodule Bandit.HTTP2.Adapter do
         header -> "no-transform" in Plug.Conn.Utils.list(header)
       end
 
+    raw_body_bytes = IO.iodata_length(body)
+
     {body, headers, compression_metrics} =
       case {body, adapter.content_encoding, response_content_encoding_header,
             response_has_strong_etag, response_indicates_no_transform} do
         {body, content_encoding, nil, false, false}
-        when body != <<>> and not is_nil(content_encoding) ->
+        when raw_body_bytes > 0 and not is_nil(content_encoding) ->
           metrics = %{
-            resp_uncompressed_body_bytes: IO.iodata_length(body),
+            resp_uncompressed_body_bytes: raw_body_bytes,
             resp_compression_method: content_encoding
           }
 
@@ -215,7 +217,7 @@ defmodule Bandit.HTTP2.Adapter do
     # details) and closing the stream here carves closest to the underlying HTTP/1.1 behaviour
     # (RFC9112§7.1). The whole notion of chunked encoding is moot in HTTP/2 anyway (RFC9113§8.1)
     # so this entire section of the API is a bit slanty regardless.
-    _ = send_data(adapter, chunk, chunk == <<>>)
+    _ = send_data(adapter, chunk, IO.iodata_length(chunk) == 0)
     :ok
   end
 

--- a/lib/bandit/http2/connection.ex
+++ b/lib/bandit/http2/connection.ex
@@ -485,7 +485,7 @@ defmodule Bandit.HTTP2.Connection do
          {data_to_send, bytes_to_send, rest} <- split_data(data, max_bytes_to_send),
          {:ok, stream} <- Stream.send_data(stream, bytes_to_send),
          connection <- %{connection | send_window_size: connection_window_size - bytes_to_send},
-         end_stream_to_send <- end_stream && rest == <<>>,
+         end_stream_to_send <- end_stream && byte_size(rest) == 0,
          {:ok, stream} <- Stream.send_end_of_stream(stream, end_stream_to_send),
          {:ok, streams} <- StreamCollection.put_stream(connection.streams, stream) do
       _ =


### PR DESCRIPTION
As noted in #230, there were a few places where we weren't optimally deflating iolist response bodies. This PR fixes those cases, as well as updates a few comparisons of the form `a == <<>>` with `byte_size(a) == 0` where we know for sure that `a` is a binary.