### PR TITLE
Add support to :max_heap_size in websocket handler

### DIFF
--- a/lib/bandit/websocket/handler.ex
+++ b/lib/bandit/websocket/handler.ex
@@ -11,7 +11,7 @@ defmodule Bandit.WebSocket.Handler do
     {websock, websock_opts, connection_opts} = state.upgrade_opts
 
     connection_opts
-    |> Keyword.take([:fullsweep_after])
+    |> Keyword.take([:fullsweep_after, :max_heap_size])
     |> Enum.each(fn {key, value} -> :erlang.process_flag(key, value) end)
 
     connection_opts = Keyword.merge(state.opts.websocket, connection_opts)


### PR DESCRIPTION
See https://github.com/phoenixframework/websock_adapter/pull/15 for the reasoning. 

Felt like this was necessary here as well, but maybe bandit/thousand_island architecture wouldn't require it, I didn't really look deeply into it.