### PR TITLE
Tweaks to how Bandit handles unexpected messages

### DIFF
--- a/lib/bandit/http1/handler.ex
+++ b/lib/bandit/http1/handler.ex
@@ -197,4 +197,31 @@ defmodule Bandit.HTTP1.Handler do
 
   def handle_info({:EXIT, _pid, :normal}, {socket, state}),
     do: {:noreply, {socket, state}, socket.read_timeout}
+
+  def handle_info(msg, state) do
+    # Copied verbatim from lib/elixir/lib/gen_server.ex
+    proc =
+      case Process.info(self(), :registered_name) do
+        {_, []} -> self()
+        {_, name} -> name
+      end
+
+    :logger.error(
+      %{
+        label: {GenServer, :no_handle_info},
+        report: %{
+          module: __MODULE__,
+          message: msg,
+          name: proc
+        }
+      },
+      %{
+        domain: [:otp, :elixir],
+        error_logger: %{tag: :error_msg},
+        report_cb: &GenServer.format_report/1
+      }
+    )
+
+    {:noreply, state}
+  end
 end

--- a/lib/bandit/websocket/handler.ex
+++ b/lib/bandit/websocket/handler.ex
@@ -87,9 +87,6 @@ defmodule Bandit.WebSocket.Handler do
   def handle_info({:plug_conn, :sent}, {socket, state}),
     do: {:noreply, {socket, state}, socket.read_timeout}
 
-  def handle_info({:EXIT, _pid, :normal}, {socket, state}),
-    do: {:noreply, {socket, state}, socket.read_timeout}
-
   def handle_info(msg, {socket, state}) do
     case Connection.handle_info(msg, socket, state.connection) do
       {:continue, connection_state} ->

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -1451,7 +1451,7 @@ defmodule HTTP1RequestTest do
     # a single GenServer call & will complete before the handler process handles
     # the handle_info call returned by the spawned process. Look at the logged
     # errors instead
-    assert errors =~ ~r[\[error\] GenServer .* terminating]
+    assert errors =~ ~r[received unexpected message in handle_info/2]
   end
 
   def spawn_abnormal_child(conn) do


### PR DESCRIPTION
Previously, unexpected messages received by an HTTP/1 handler would crash the server; this PR updates this behaviour to log messages in the same way that a stock GenServer which does not implement any `handle_info/2` callbacks does, and thence does not crash. 

Note there's no need to add a similar mechanism on HTTP/2 handlers, since HTTP/2  requests are backed (at least for now) by `Task`

Also note that there's no need to add a similar mechanism to WebSockets, since WebSock already provides a way to forward handle_info calls to the websock implementor. In fact, this PR also stops explicitly catching normal monitored process termination calls in the websocket handler for this reason.