### PR TITLE
Fix Bandit.HTTP1.Adapter.inform/3 return value

### DIFF
--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -505,19 +505,10 @@ defmodule Bandit.HTTP1.Adapter do
   @impl Plug.Conn.Adapter
   def inform(%__MODULE__{version: :"HTTP/1.0"}, _status, _headers), do: {:error, :not_supported}
 
-  def inform(%__MODULE__{socket: socket, version: version} = req, status, headers) do
-    start_time = Bandit.Telemetry.monotonic_time()
-
-    {header_iodata, header_metrics} = response_header(version, status, headers)
+  def inform(%__MODULE__{socket: socket, version: version}, status, headers) do
+    {header_iodata, _header_metrics} = response_header(version, status, headers)
     _ = ThousandIsland.Socket.send(socket, header_iodata)
-
-    metrics =
-      req.metrics
-      |> Map.merge(header_metrics)
-      |> Map.put(:resp_start_time, start_time)
-      |> Map.put(:resp_body_bytes, 0)
-
-    {:ok, nil, %{req | metrics: metrics}}
+    :ok
   end
 
   defp response_header(nil, status, headers), do: response_header("HTTP/1.0", status, headers)

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -1336,7 +1336,7 @@ defmodule HTTP1RequestTest do
 
   test "sending informational responses", context do
     client = SimpleHTTP1Client.tcp_client(context)
-    SimpleHTTP1Client.send(client, "GET", "/send_inform!", ["host: localhost"])
+    SimpleHTTP1Client.send(client, "GET", "/send_inform", ["host: localhost"])
 
     Process.sleep(100)
     assert {:ok, "100 Continue", headers, rest} = SimpleHTTP1Client.recv_reply(client)
@@ -1353,11 +1353,6 @@ defmodule HTTP1RequestTest do
 
   def send_inform(conn) do
     conn = conn |> inform(100, [{"x-from", "inform"}])
-    conn |> send_resp(200, "Informer")
-  end
-
-  def send_inform!(conn) do
-    conn = conn |> inform!(100, [{"x-from", "inform"}])
     conn |> send_resp(200, "Informer")
   end
 

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -1336,7 +1336,7 @@ defmodule HTTP1RequestTest do
 
   test "sending informational responses", context do
     client = SimpleHTTP1Client.tcp_client(context)
-    SimpleHTTP1Client.send(client, "GET", "/send_inform", ["host: localhost"])
+    SimpleHTTP1Client.send(client, "GET", "/send_inform!", ["host: localhost"])
 
     Process.sleep(100)
     assert {:ok, "100 Continue", headers, rest} = SimpleHTTP1Client.recv_reply(client)
@@ -1353,6 +1353,11 @@ defmodule HTTP1RequestTest do
 
   def send_inform(conn) do
     conn = conn |> inform(100, [{"x-from", "inform"}])
+    conn |> send_resp(200, "Informer")
+  end
+
+  def send_inform!(conn) do
+    conn = conn |> inform!(100, [{"x-from", "inform"}])
     conn |> send_resp(200, "Informer")
   end
 


### PR DESCRIPTION
Per https://hexdocs.pm/plug/Plug.Conn.Adapter.html#c:inform/3, the callback should return:

    :ok | {:error, :not_supported}

The way Plug.Conn.inform! is implemented at the moment, https://github.com/elixir-plug/plug/blob/v1.15.2/lib/plug/conn.ex#L1335, it looked like Bandit did _not_ implement inform but it sure does!
