### PR TITLE
Fix `:transport_options` allowing non-typical values

### DIFF
--- a/lib/bandit.ex
+++ b/lib/bandit.ex
@@ -261,7 +261,7 @@ defmodule Bandit do
               {:ok, options} -> options
               {:error, message} -> raise "Plug.SSL.configure/1 encountered error: #{message}"
             end
-            |> Keyword.delete(:otp_app)
+            |> Enum.reject(&(is_tuple(&1) and elem(&1, 0) == :otp_app))
 
           {ThousandIsland.Transports.SSL, transport_options, 4040}
       end


### PR DESCRIPTION
Work was previously done to support non-typical values in the `:transport_options` for ThousandIsland with https://github.com/mtrudel/bandit/commit/43d49c8817b2c2f71bf4149036f5680dae36b02d.

However, if using SSL and including multiple key/value pairs with a non-typical, such as `:inet6`, it would still error because of an attempt to `Keyword.delete/2` out the `:otp_app` key.

This fixes that with `Enum.reject/2` to get the same behavior and still allow the list as expected by `:ssl` and `:gen_tcp`

<details><summary>Example Error</summary>
<p>

```
** (Mix) Could not start application nerves_hub: NervesHub.Application.start(:normal, []) returned an error: shutdown: failed to start child: NervesHubWeb.DeviceEndpoint
    ** (EXIT) shutdown: failed to start child: {NervesHubWeb.DeviceEndpoint, :https}
        ** (EXIT) an exception was raised:
            ** (FunctionClauseError) no function clause matching in Keyword.delete_key/2
                (elixir 1.15.7) lib/keyword.ex:719: Keyword.delete_key([:inet6, {:versions, [:"tlsv1.2"]}, {:verify, :verify_peer}, {:verify_fun, {&NervesHub.SSL.verify_fun/3, nil}}, {:fail_if_no_peer_cert, true}, {:keyfile, ~c"/Users/jonjon/code/nerves_hub_web/test/fixtures/ssl/device.nerves-hub.org-key.pem"}, {:certfile, ~c"/Users/jonjon/code/nerves_hub_web/test/fixtures/ssl/device.nerves-hub.org.pem"}, {:cacertfile, ~c"/Users/jonjon/code/nerves_hub_web/test/fixtures/ssl/ca.pem"}, {:ip, {0, 0, 0, 0}}, {:otp_app, :nerves_hub}, {:alpn_preferred_protocols, ["h2", "http/1.1"]}], :otp_app)
                (elixir 1.15.7) lib/keyword.ex:720: Keyword.delete_key/2
                (bandit 1.1.1) lib/bandit.ex:264: Bandit.start_link/1
                (stdlib 5.1.1) supervisor.erl:420: :supervisor.do_start_child_i/3
                (stdlib 5.1.1) supervisor.erl:406: :supervisor.do_start_child/2
                (stdlib 5.1.1) supervisor.erl:390: anonymous fn/3 in :supervisor.start_children/2
                (stdlib 5.1.1) supervisor.erl:1258: :supervisor.children_map/4
                (stdlib 5.1.1) supervisor.erl:350: :supervisor.init_children/2
                (stdlib 5.1.1) gen_server.erl:962: :gen_server.init_it/2
                (stdlib 5.1.1) gen_server.erl:917: :gen_server.init_it/6
                (stdlib 5.1.1) proc_lib.erl:241: :proc_lib.init_p_do_apply/3
```

</p>
</details> 