### PR TITLE
Further optimize websocket frame mask

### DIFF
--- a/lib/bandit/websocket/frame.ex
+++ b/lib/bandit/websocket/frame.ex
@@ -173,7 +173,8 @@ defmodule Bandit.WebSocket.Frame do
 
   # Note that masking is an involution, so we don't need a separate unmask function
   @spec mask(binary(), integer()) :: binary()
-  def mask(payload, mask) when is_binary(payload) and is_integer(mask) and mask >= 0x00000000 and mask <= 0xFFFFFFFF do
+  def mask(payload, mask)
+      when is_binary(payload) and is_integer(mask) and mask >= 0x00000000 and mask <= 0xFFFFFFFF do
     mask(<<>>, payload, mask)
   end
 


### PR DESCRIPTION
Late to the party, but suggesting a further optimization of #272 that avoids constructing the extra mask binary. With JIT improvements like https://github.com/erlang/otp/pull/5849 and https://github.com/erlang/otp/pull/7828 this could get better in future releases too.

On my system the benchmark from https://github.com/mtrudel/bandit/pull/272#issuecomment-1847571663 gives this ("proposed" being this PR):

```
Elixir 1.15.7
Erlang 26.2

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
memory time: 2 s
reduction time: 0 ns
parallel: 1
inputs: lg, md, sm
Estimated total run time: 54 s

Benchmarking PR272 with input lg ...
Benchmarking PR272 with input md ...
Benchmarking PR272 with input sm ...
Benchmarking proposed with input lg ...
Benchmarking proposed with input md ...
Benchmarking proposed with input sm ...

##### With input lg #####
Name               ips        average  deviation         median         99th %
proposed         41.59       24.04 ms     ±0.82%       24.02 ms       24.70 ms
PR272            38.93       25.69 ms     ±0.81%       25.64 ms       26.52 ms

Comparison:
proposed         41.59
PR272            38.93 - 1.07x slower +1.65 ms

Memory usage statistics:

Name        Memory usage
proposed        0.125 KB
PR272          249.88 KB - 1999.06x memory usage +249.76 KB

**All measurements for memory usage were the same**

##### With input md #####
Name               ips        average  deviation         median         99th %
proposed        1.53 K      652.61 μs     ±1.86%      649.13 μs      696.49 μs
PR272           1.28 K      779.08 μs     ±2.03%      778.58 μs      824.66 μs

Comparison:
proposed        1.53 K
PR272           1.28 K - 1.19x slower +126.47 μs

Memory usage statistics:

Name        Memory usage
proposed        0.125 KB
PR272            7.72 KB - 61.75x memory usage +7.59 KB

**All measurements for memory usage were the same**

##### With input sm #####
Name               ips        average  deviation         median         99th %
proposed        1.24 M        0.81 μs  ±1723.26%        0.75 μs        0.92 μs
PR272           0.90 M        1.11 μs  ±2424.93%        0.92 μs        2.04 μs

Comparison:
proposed        1.24 M
PR272           0.90 M - 1.38x slower +0.31 μs

Memory usage statistics:

Name        Memory usage
proposed           128 B
PR272              120 B - 0.94x memory usage -8 B

**All measurements for memory usage were the same**
```

CC @crertel @ryanwinchester 