### PR TITLE
Support `plug: &fun/1`

### DIFF
--- a/lib/bandit.ex
+++ b/lib/bandit.ex
@@ -21,7 +21,7 @@ defmodule Bandit do
   Possible top-level options to configure a Bandit server
 
   * `plug`: The Plug to use to handle connections. Can be specified as:
-      *  `MyPlug`
+      * `MyPlug`
       * `{MyPlug, plug_opts}`
       * `{&fun/2, plug_opts}`
       * `&fun/2`

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -21,15 +21,31 @@ defmodule HTTP1RequestTest do
       send_resp(conn, 200, "OK module")
     end
 
-    test "runs function plugs", context do
+    test "runs plug: {fun/2, options}", context do
+      context =
+        context
+        |> http_server(plug: {fn conn, string -> send_resp(conn, 200, string) end, "hello"})
+        |> Enum.into(context)
+
+      assert Req.get!(context.req, url: "/", base_url: context.base).body == "hello"
+    end
+
+    test "runs plug: fun/2", context do
       context =
         context
         |> http_server(plug: fn conn, _ -> send_resp(conn, 200, "OK function") end)
         |> Enum.into(context)
 
-      response = Req.get!(context.req, url: "/", base_url: context.base)
-      assert response.status == 200
-      assert response.body == "OK function"
+      assert Req.get!(context.req, url: "/", base_url: context.base).body == "OK function"
+    end
+
+    test "runs plug: fun/1", context do
+      context =
+        context
+        |> http_server(plug: fn conn -> send_resp(conn, 200, "OK function") end)
+        |> Enum.into(context)
+
+      assert Req.get!(context.req, url: "/", base_url: context.base).body == "OK function"
     end
   end
 

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -11,7 +11,7 @@ defmodule HTTP1RequestTest do
   setup :req_http1_client
 
   describe "plug definitions" do
-    test "runs module plugs", context do
+    test "runs plug: module", context do
       response = Req.get!(context.req, url: "/hello_world")
       assert response.status == 200
       assert response.body == "OK module"
@@ -21,7 +21,7 @@ defmodule HTTP1RequestTest do
       send_resp(conn, 200, "OK module")
     end
 
-    test "runs plug: {fun/2, options}", context do
+    test "runs plug: {&fun/2, options}", context do
       context =
         context
         |> http_server(plug: {fn conn, string -> send_resp(conn, 200, string) end, "hello"})
@@ -30,7 +30,7 @@ defmodule HTTP1RequestTest do
       assert Req.get!(context.req, url: "/", base_url: context.base).body == "hello"
     end
 
-    test "runs plug: fun/2", context do
+    test "runs plug: &fun/2", context do
       context =
         context
         |> http_server(plug: fn conn, _ -> send_resp(conn, 200, "OK function") end)
@@ -39,7 +39,7 @@ defmodule HTTP1RequestTest do
       assert Req.get!(context.req, url: "/", base_url: context.base).body == "OK function"
     end
 
-    test "runs plug: fun/1", context do
+    test "runs plug: &fun/1", context do
       context =
         context
         |> http_server(plug: fn conn -> send_resp(conn, 200, "OK function") end)

--- a/test/bandit/http2/plug_test.exs
+++ b/test/bandit/http2/plug_test.exs
@@ -11,7 +11,7 @@ defmodule HTTP2PlugTest do
   setup :req_h2_client
 
   describe "plug definitions" do
-    test "runs module plugs", context do
+    test "runs plug: module", context do
       response = Req.get!(context.req, url: "/hello_world")
       assert response.status == 200
       assert response.body == "OK module"
@@ -21,7 +21,7 @@ defmodule HTTP2PlugTest do
       send_resp(conn, 200, "OK module")
     end
 
-    test "runs function plugs", context do
+    test "runs plug: &fun/2", context do
       context =
         context
         |> https_server(plug: fn conn, _ -> send_resp(conn, 200, "OK function") end)


### PR DESCRIPTION
There was a clause:

```elixir
plug_fn when is_function(plug_fn) -> {plug_fn, []}
```

which supported any function but in reality it only allowed 2-arity functions.

This patch adds support for 1-arity functions too. This matches `Plug.run/3`:

```elixir
iex> conn = Plug.Test.conn(:get, "/")
iex> plug = fn conn -> Plug.Conn.send_resp(conn, 200, "hi") end
iex> Plug.run(conn, [plug]).resp_body
"hi"
```

as well as projects along the lines of:

```elixir
Bypass.stub(bypass, "GET", "/", fn conn -> ... end)
```

(wink wink)