### PR TITLE
Explicitly set Hex package files

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,8 @@ defmodule Bandit.MixProject do
       package: [
         maintainers: ["Mat Trudel"],
         licenses: ["MIT"],
-        links: %{"GitHub" => "https://github.com/mtrudel/bandit"}
+        links: %{"GitHub" => "https://github.com/mtrudel/bandit"},
+        files: ["lib", "mix.exs", "README*", "LICENSE*", "CHANGELOG*"]
       ],
       docs: docs()
     ]


### PR DESCRIPTION
Closes #265

Sanity check:

    % mix hex.build --unpack -o pkg
    % iex
    Erlang/OTP 26 [erts-14.2.1] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit]

    Interactive Elixir (1.17.0-dev) - press Ctrl+C to exit (type h() ENTER for help)
    iex> Mix.install([:req, {:bandit, path: "pkg"}])
    iex> {:ok, _} = Bandit.start_link(scheme: :http, plug: fn conn, _ -> Plug.Conn.send_resp(conn, 200, "hi") end)

    14:12:40.784 [info] Running #Function<41.105768164/2 in :erl_eval.expr/6> with Bandit 1.1.2 at 0.0.0.0:4000 (http)
    iex> Req.get!("http://localhost:4000")
    %Req.Response{
      status: 200,
      headers: %{
        "cache-control" => ["max-age=0, private, must-revalidate"],
        "date" => ["Fri, 29 Dec 2023 13:12:40 GMT"],
        "vary" => ["accept-encoding"]
      },
      body: "hi",
      trailers: %{},
      private: %{}
    }
