### PR TITLE
POC: Store read_state in process dictionary

### DIFF
--- a/lib/bandit/http1/handler.ex
+++ b/lib/bandit/http1/handler.ex
@@ -140,10 +140,13 @@ defmodule Bandit.HTTP1.Handler do
     end
   end
 
-  defp ensure_body_read(%{read_state: :no_body}), do: :ok
-  defp ensure_body_read(%{read_state: :body_read}), do: :ok
+  defp ensure_body_read(req, read_state \\ Bandit.HTTP1.Adapter.process_read_state())
 
-  defp ensure_body_read(req) do
+  defp ensure_body_read(%{read_state: :no_body}, _), do: :ok
+  defp ensure_body_read(%{read_state: :body_read}, _), do: :ok
+  defp ensure_body_read(_req, :body_read), do: :ok
+
+  defp ensure_body_read(req, _) do
     case Bandit.HTTP1.Adapter.read_req_body(req, []) do
       {:ok, _data, _req} -> :ok
       {:more, _data, req} -> ensure_body_read(req)

--- a/lib/bandit/http1/handler.ex
+++ b/lib/bandit/http1/handler.ex
@@ -3,6 +3,7 @@ defmodule Bandit.HTTP1.Handler do
   # An HTTP 1.0 & 1.1 Thousand Island Handler
 
   use ThousandIsland.Handler
+  require Logger
 
   @already_sent {:plug_conn, :sent}
 
@@ -144,7 +145,14 @@ defmodule Bandit.HTTP1.Handler do
 
   defp ensure_body_read(%{read_state: :no_body}, _), do: :ok
   defp ensure_body_read(%{read_state: :body_read}, _), do: :ok
-  defp ensure_body_read(_req, :body_read), do: :ok
+
+  defp ensure_body_read(_req, :body_read) do
+    Logger.error("""
+    Bandit: Invalid req state detected! This means that a Plug.Conn token was mishandled
+    """)
+
+    :ok
+  end
 
   defp ensure_body_read(req, _) do
     case Bandit.HTTP1.Adapter.read_req_body(req, []) do

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -50,17 +50,22 @@ defmodule HTTP1RequestTest do
       Process.sleep(100)
       Transport.send(client, body)
 
-      assert {:ok, "200 OK", _, _} = SimpleHTTP1Client.recv_reply(client)
+      logs =
+        capture_log(fn ->
+          assert {:ok, "200 OK", _, _} = SimpleHTTP1Client.recv_reply(client)
 
-      SimpleHTTP1Client.send(
-        client,
-        "POST",
-        "/bad_plug",
-        ["Host: example.com"],
-        "1.1"
-      )
+          SimpleHTTP1Client.send(
+            client,
+            "POST",
+            "/bad_plug",
+            ["Host: example.com"],
+            "1.1"
+          )
 
-      assert {:ok, "200 OK", _, _} = SimpleHTTP1Client.recv_reply(client)
+          assert {:ok, "200 OK", _, _} = SimpleHTTP1Client.recv_reply(client)
+        end)
+
+      assert logs =~ "Bandit: Invalid req state detected!"
     end
 
     def bad_plug(conn) do


### PR DESCRIPTION
Hi @mtrudel,

This can be a potential temporary for issues like #260 and #294. It uses process dictionary to store the `read_state` in the HTTP1 adapter. For now it handles the error and relies on the state in dictionary (which probably is not a good idea). We can also fail, close the connection and log a better message helping users with debugging their codebases.

I personally don't like using process dictionary but in this case it seemed to me like a good use-case (at least for short while to help with integration of bandit).

P.S This is just a POC and if you think it can be useful we can work on actually implementing it properly :)