### PR TITLE
Disable logging of unknown messages received by http/1 handler

### DIFF
--- a/lib/bandit.ex
+++ b/lib/bandit.ex
@@ -94,6 +94,8 @@ defmodule Bandit do
     Defaults to 50 headers
   * `max_requests`: The maximum number of requests to serve in a single
     HTTP/1.1 connection before closing the connection. Defaults to 0 (no limit)
+  * `log_unknown_messages`: Whether or not to log unknown messages sent to the handler process.
+    Defaults to `false`
   * `compress`: Whether or not to attempt compression of responses via content-encoding
     negotiation as described in
     [RFC9110§8.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4). Defaults to true
@@ -106,6 +108,7 @@ defmodule Bandit do
           max_header_length: pos_integer(),
           max_header_count: pos_integer(),
           max_requests: pos_integer(),
+          log_unknown_messages: boolean(),
           compress: boolean(),
           deflate_opions: deflate_options()
         ]
@@ -188,7 +191,7 @@ defmodule Bandit do
   end
 
   @top_level_keys ~w(plug scheme port ip keyfile certfile otp_app cipher_suite display_plug startup_log thousand_island_options http_1_options http_2_options websocket_options)a
-  @http_1_keys ~w(enabled max_request_line_length max_header_length max_header_count max_requests compress deflate_options)a
+  @http_1_keys ~w(enabled max_request_line_length max_header_length max_header_count max_requests log_unknown_messages compress deflate_options)a
   @http_2_keys ~w(enabled max_header_key_length max_header_value_length max_header_count max_requests default_local_settings compress deflate_options)a
   @websocket_keys ~w(enabled max_frame_size validate_text_frames compress)a
   @thousand_island_keys ThousandIsland.ServerConfig.__struct__()

--- a/lib/bandit/http1/handler.ex
+++ b/lib/bandit/http1/handler.ex
@@ -209,7 +209,7 @@ defmodule Bandit.HTTP1.Handler do
     do: {:noreply, {socket, state}, socket.read_timeout}
 
   def handle_info(msg, {socket, state}) do
-    log_no_handle_info(msg)
+    if Keyword.get(state.opts.http_1, :log_unknown_messages, false), do: log_no_handle_info(msg)
     {:noreply, {socket, state}, socket.read_timeout}
   end
 

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -1453,9 +1453,11 @@ defmodule HTTP1RequestTest do
 
   test "does not do anything special with EXIT messages from abnormally terminating spwaned processes",
        context do
+    context = http_server(context, http_1_options: [log_unknown_messages: true])
+
     errors =
       capture_log(fn ->
-        Req.get!(context.req, url: "/spawn_abnormal_child")
+        Req.get!(url: "/spawn_abnormal_child", base_url: context[:base])
 
         # Let the backing process see & handle the handle_info EXIT message
         Process.sleep(100)


### PR DESCRIPTION
We end up unavoidably getting a lot of messages in our mailbox from phoenix long polling, and it's becoming a support burden. There's no loss of messages here, it's just a matter of not being so verbose by default.

 