### PR TITLE
allow http/1.0 to work with mixed-case Keep-Alive

### DIFF
--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -159,6 +159,7 @@ defmodule Bandit.HTTP1.Adapter do
   # `close` & `keep-alive` always means what they say, otherwise keepalive if we're on HTTP/1.1
   defp should_keepalive?(_, "close"), do: false
   defp should_keepalive?(_, "keep-alive"), do: true
+  defp should_keepalive?(_, "Keep-Alive"), do: true
   defp should_keepalive?(:"HTTP/1.1", _), do: true
   defp should_keepalive?(_, _), do: false
 

--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -157,6 +157,7 @@ defmodule Bandit.HTTP1.Adapter do
   end
 
   # `close` & `keep-alive` always means what they say, otherwise keepalive if we're on HTTP/1.1
+  # Case insensitivity per RFC9110§7.6.1
   defp should_keepalive?(_, "close"), do: false
   defp should_keepalive?(_, "keep-alive"), do: true
   defp should_keepalive?(_, "Keep-Alive"), do: true

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -75,6 +75,16 @@ defmodule HTTP1RequestTest do
       assert SimpleHTTP1Client.connection_closed_for_reading?(client)
     end
 
+    test "keepalive mixed-case header connections are respected in HTTP/1.0", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "GET", "/echo_components", ["host: localhost", "connection: Keep-Alive"], "1.0")
+      assert {:ok, "200 OK", _headers, _body} = SimpleHTTP1Client.recv_reply(client)
+
+      SimpleHTTP1Client.send(client, "GET", "/echo_components", ["host: localhost", "connection: Keep-Alive"], "1.0")
+      assert {:ok, "200 OK", _headers, _body} = SimpleHTTP1Client.recv_reply(client)
+    end
+
     test "unread content length bodies are read before starting a new request", context do
       client = SimpleHTTP1Client.tcp_client(context)
 


### PR DESCRIPTION
tldr; Is that certain clients (in this case apache bench) will send http/1.0 requests with "Keep-Alive" and not "keep-alive" and we currently don't respect that.

I noticed this issue while comparing ab to other servers which seem to handle this correctly. I originally asked about this behavior in the [elixir forums](https://elixirforum.com/t/bandit-keep-alives-not-working-in-apache-bench/61672)

After taking a look and doing some debugging I saw that we fail to lower-case the connection header prior to comparison. Instead of incurring the penalty of lower-casing the entire header I'm assuming the mixed-case pattern match is a performant solution? Strictly speaking we probably should lower-case it to be "compliant"

I did look at the `get_connection_header_keys/1` function but it didn't really look like a good fit since it returns that list. Happy to hear feedback and change anything.