### PR TITLE
Show which port is in use when startup fails

### DIFF
--- a/lib/bandit.ex
+++ b/lib/bandit.ex
@@ -284,7 +284,7 @@ defmodule Bandit do
         {:ok, pid}
 
       {:error, {:shutdown, {:failed_to_start_child, :listener, :eaddrinuse}}} = error ->
-        Logger.error([info(scheme, display_plug, nil), " failed, port already in use"])
+        Logger.error([info(scheme, display_plug, nil), " failed, port #{port} already in use"])
         error
 
       {:error, _} = error ->

--- a/test/bandit/server_test.exs
+++ b/test/bandit/server_test.exs
@@ -34,7 +34,7 @@ defmodule ServerTest do
       end)
 
     assert logs =~
-             "Running ServerTest with Bandit #{Application.spec(:bandit)[:vsn]} at http failed, port already in use"
+             "Running ServerTest with Bandit #{Application.spec(:bandit)[:vsn]} at http failed, port #{port} already in use"
   end
 
   test "can run multiple instances of Bandit" do


### PR DESCRIPTION
🐈