### PR TITLE
don't send the transfer-encoding: chunked header for 100..199, 204

### DIFF
--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -479,11 +479,12 @@ defmodule Bandit.HTTP1.Adapter do
   def send_chunked(%__MODULE__{socket: socket, version: version} = req, status, headers) do
     start_time = Bandit.Telemetry.monotonic_time()
 
-    headers = if status >= 200 and status != 204 do
-      [{"transfer-encoding", "chunked"} | headers]
-    else
-      headers
-    end
+    headers =
+      if status >= 200 and status != 204 do
+        [{"transfer-encoding", "chunked"} | headers]
+      else
+        headers
+      end
 
     {header_iodata, header_metrics} = response_header(version, status, headers)
     _ = ThousandIsland.Socket.send(socket, header_iodata)

--- a/lib/bandit/http1/adapter.ex
+++ b/lib/bandit/http1/adapter.ex
@@ -479,7 +479,12 @@ defmodule Bandit.HTTP1.Adapter do
   def send_chunked(%__MODULE__{socket: socket, version: version} = req, status, headers) do
     start_time = Bandit.Telemetry.monotonic_time()
 
-    headers = [{"transfer-encoding", "chunked"} | headers]
+    headers = if status >= 200 and status != 204 do
+      [{"transfer-encoding", "chunked"} | headers]
+    else
+      headers
+    end
+
     {header_iodata, header_metrics} = response_header(version, status, headers)
     _ = ThousandIsland.Socket.send(socket, header_iodata)
 

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -1248,6 +1248,23 @@ defmodule HTTP1RequestTest do
       conn
     end
 
+    test "does not add the transfer-encoding header for 204 responses", context do
+      response = Req.get!(context.req, url: "/send_chunked_204")
+
+      assert response.status == 204
+      assert response.body == ""
+      refute Map.has_key?(response.headers, "transfer-encoding")
+    end
+
+    def send_chunked_204(conn) do
+      {:ok, conn} =
+        conn
+        |> send_chunked(204)
+        |> chunk("")
+
+      conn
+    end
+
     test "does not write out a body for a chunked response to a HEAD request", context do
       client = SimpleHTTP1Client.tcp_client(context)
       SimpleHTTP1Client.send(client, "HEAD", "/send_chunked_200", ["host: localhost"])


### PR DESCRIPTION
In [RFC 7320 section 3.3.1](https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.1), it states:

> A server MUST NOT send a Transfer-Encoding header field in any response with a status code of 1xx (Informational) or 204 (No Content).

this conditional brings Bandit into line with the RFC and Cowboy