### PR TITLE
Start using `:proc_lib.set_label/1` if available

### DIFF
--- a/lib/bandit/application.ex
+++ b/lib/bandit/application.ex
@@ -8,6 +8,10 @@ defmodule Bandit.Application do
           {:ok, pid}
           | {:error, {:already_started, pid} | {:shutdown, term} | term}
   def start(_type, _args) do
+    if function_exported?(:proc_lib, :set_label, 1) do
+      apply(:proc_lib, :set_label, ["Bandit.Application"])
+    end
+
     children = [Bandit.Clock]
     Supervisor.start_link(children, strategy: :one_for_one)
   end

--- a/lib/bandit/clock.ex
+++ b/lib/bandit/clock.ex
@@ -36,6 +36,10 @@ defmodule Bandit.Clock do
 
   @spec init :: no_return()
   def init do
+    if function_exported?(:proc_lib, :set_label, 1) do
+      apply(:proc_lib, :set_label, ["Bandit.Clock"])
+    end
+
     __MODULE__ = :ets.new(__MODULE__, [:set, :protected, :named_table, {:read_concurrency, true}])
 
     run()


### PR DESCRIPTION
Starting in OTP 27.0, `:proc_lib.set_label/1` allows setting labels on processes whether or not they have a registered name. These labels are shown in Observer and in the future may be shown in other tools.

Using such labels has the potential to make a process tree more comprehensible. This commit just serves as an example for getting started.

Before:
![before](https://github.com/mtrudel/bandit/assets/338814/c95756a2-644b-4ebd-8b0b-5e75fbdf1fdf)

After (With OTP 
![after](https://github.com/mtrudel/bandit/assets/338814/24504967-5e47-4082-ab52-c3324d30b7bb)
27.0-rc1):
