### PR TITLE
Provide config option to disable logging of protocol errors

### DIFF
--- a/lib/bandit.ex
+++ b/lib/bandit.ex
@@ -96,6 +96,8 @@ defmodule Bandit do
     HTTP/1.1 connection before closing the connection. Defaults to 0 (no limit)
   * `log_unknown_messages`: Whether or not to log unknown messages sent to the handler process.
     Defaults to `false`
+  * `log_protocol_errors`: Whether or not to log protocol errors such as malformed requests.
+    Defaults to `true`
   * `compress`: Whether or not to attempt compression of responses via content-encoding
     negotiation as described in
     [RFC9110§8.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4). Defaults to true
@@ -109,6 +111,7 @@ defmodule Bandit do
           max_header_count: pos_integer(),
           max_requests: pos_integer(),
           log_unknown_messages: boolean(),
+          log_protocol_errors: boolean(),
           compress: boolean(),
           deflate_opions: deflate_options()
         ]
@@ -191,7 +194,7 @@ defmodule Bandit do
   end
 
   @top_level_keys ~w(plug scheme port ip keyfile certfile otp_app cipher_suite display_plug startup_log thousand_island_options http_1_options http_2_options websocket_options)a
-  @http_1_keys ~w(enabled max_request_line_length max_header_length max_header_count max_requests log_unknown_messages compress deflate_options)a
+  @http_1_keys ~w(enabled max_request_line_length max_header_length max_header_count max_requests log_unknown_messages log_protocol_errors compress deflate_options)a
   @http_2_keys ~w(enabled max_header_key_length max_header_value_length max_header_count max_requests default_local_settings compress deflate_options)a
   @websocket_keys ~w(enabled max_frame_size validate_text_frames compress)a
   @thousand_island_keys ThousandIsland.ServerConfig.__struct__()

--- a/test/support/req_helpers.ex
+++ b/test/support/req_helpers.ex
@@ -9,7 +9,7 @@ defmodule ReqHelpers do
       end
 
       def req_h2_client(context) do
-        start_finch(context, protocol: :http2)
+        start_finch(context, protocols: [:http2])
         [req: build_req(context)]
       end
 


### PR DESCRIPTION
As a potential fix to #320, add an option to disable the logging of protocol errors in HTTP/1. Logging is still enabled by default (at least for now; I'd like to get some idea of how many errors this ends up hiding before enabling by default). You can disable logging by:

```
config :my_phoenix_app, MyPhoenixAppWeb.Endpoint,
  http: [
    ip: ...,
    port: ...,
    http_1_options: [log_protocol_errors: false]
  ]
  ...
```