### PR TITLE
Improve String.valid?/1 performance

### DIFF
--- a/lib/bandit/utils.ex
+++ b/lib/bandit/utils.ex
@@ -1,4 +1,6 @@
 defmodule Bandit.Utils do
+  @moduledoc false
+
   @doc ~S"""
   Checks whether `string` contains only valid characters.
 
@@ -29,6 +31,7 @@ defmodule Bandit.Utils do
       a > 191 and a < 224 -> valid_two?(rest)
       a > 223 and a < 240 -> valid_three?(rest)
       a > 239 -> valid_four?(rest)
+      :otherwise -> false
     end
   end
 

--- a/lib/bandit/utils.ex
+++ b/lib/bandit/utils.ex
@@ -1,0 +1,69 @@
+defmodule Bandit.Utils do
+  @doc ~S"""
+  Checks whether `string` contains only valid characters.
+
+  ## Examples
+
+      iex> Bandit.Utils.valid?("a")
+      true
+
+      iex> Bandit.Utils.valid?("ø")
+      true
+
+      iex> Bandit.Utils.valid?(<<0xFFFF::16>>)
+      false
+
+      iex> Bandit.Utils.valid?(<<0xEF, 0xB7, 0x90>>)
+      true
+
+      iex> Bandit.Utils.valid?("asd" <> <<0xFFFF::16>>)
+      false
+
+      iex> Bandit.Utils.valid?(4)
+      ** (FunctionClauseError) no function clause matching in Bandit.Utils.valid?/1
+
+  """
+  def valid?(<<a::8, rest::binary>>) do
+    cond do
+      a < 128 -> valid_one?(rest)
+      a > 191 and a < 224 -> valid_two?(rest)
+      a > 223 and a < 240 -> valid_three?(rest)
+      a > 239 -> valid_four?(rest)
+    end
+  end
+
+  def valid?(<<>>), do: true
+  def valid?(str) when is_binary(str), do: false
+
+  @compile {:inline, valid_one?: 1, valid_two?: 1, valid_three?: 1, valid_four?: 1}
+
+  defp valid_two?(<<a::8, rest::binary>>)
+       when a < 192,
+       do: valid?(rest)
+
+  defp valid_two?(_),
+    do: false
+
+  defp valid_three?(<<a::16, rest::binary>>)
+       when Bitwise.band(a, 0x8080) == 0x8080 and
+              Bitwise.bor(a, 0xBFBF) == 0xBFBF,
+       do: valid?(rest)
+
+  defp valid_three?(_),
+    do: false
+
+  defp valid_four?(<<a::24, rest::binary>>)
+       when Bitwise.band(a, 0x808080) == 0x808080 and
+              Bitwise.bor(a, 0xBFBFBF) == 0xBFBFBF,
+       do: valid?(rest)
+
+  defp valid_four?(_),
+    do: false
+
+  defp valid_one?(<<a::56, rest::binary>>)
+       when Bitwise.band(a, 0x80808080808080) == 0,
+       do: valid?(rest)
+
+  defp valid_one?(rest),
+    do: valid?(rest)
+end

--- a/lib/bandit/websocket/connection.ex
+++ b/lib/bandit/websocket/connection.ex
@@ -62,7 +62,7 @@ defmodule Bandit.WebSocket.Connection do
         do_inflate(frame, socket, connection)
 
       %Frame.Text{fin: true} = frame ->
-        if !Keyword.get(connection.opts, :validate_text_frames, true) || String.valid?(frame.data) do
+        if !Keyword.get(connection.opts, :validate_text_frames, true) || Bandit.Utils.valid?(frame.data) do
           connection.websock.handle_in({frame.data, opcode: :text}, connection.websock_state)
           |> handle_continutation(socket, connection)
         else

--- a/lib/bandit/websocket/connection.ex
+++ b/lib/bandit/websocket/connection.ex
@@ -62,7 +62,8 @@ defmodule Bandit.WebSocket.Connection do
         do_inflate(frame, socket, connection)
 
       %Frame.Text{fin: true} = frame ->
-        if !Keyword.get(connection.opts, :validate_text_frames, true) || Bandit.Utils.valid?(frame.data) do
+        if !Keyword.get(connection.opts, :validate_text_frames, true) ||
+             Bandit.Utils.valid?(frame.data) do
           connection.websock.handle_in({frame.data, opcode: :text}, connection.websock_state)
           |> handle_continutation(socket, connection)
         else

--- a/lib/bandit/websocket/frame/connection_close.ex
+++ b/lib/bandit/websocket/frame/connection_close.ex
@@ -19,7 +19,7 @@ defmodule Bandit.WebSocket.Frame.ConnectionClose do
   end
 
   def deserialize(true, false, <<code::16, reason::binary>>) when byte_size(reason) <= 123 do
-    if String.valid?(reason) do
+    if Bandit.Utils.valid?(reason) do
       {:ok, %__MODULE__{code: code, reason: reason}}
     else
       {:error, "Received non UTF-8 connection close frame (RFC6455§5.5.1)"}

--- a/test/bandit/utils_test.exs
+++ b/test/bandit/utils_test.exs
@@ -1,0 +1,23 @@
+defmodule Bandit.UtilsTest do
+  use ExUnit.Case, async: true
+
+  doctest Bandit.Utils
+
+  test "valid?/1" do
+    assert Bandit.Utils.valid?("afds")
+    assert Bandit.Utils.valid?("øsdfh")
+    assert Bandit.Utils.valid?("dskfjあska")
+    assert Bandit.Utils.valid?(<<0xEF, 0xB7, 0x90>>)
+
+    refute Bandit.Utils.valid?(<<0xFFFF::16>>)
+    refute Bandit.Utils.valid?("asd" <> <<0xFFFF::16>>)
+
+    assert Bandit.Utils.valid?("afdsafdsafds")
+    assert Bandit.Utils.valid?("øsdfhøsdfh")
+    assert Bandit.Utils.valid?("dskfjあskadskfjあska")
+    assert Bandit.Utils.valid?(<<0xEF, 0xB7, 0x90, 0xEF, 0xB7, 0x90, 0xEF, 0xB7, 0x90>>)
+
+    refute Bandit.Utils.valid?(<<0xFFFF::16>>)
+    refute Bandit.Utils.valid?("asdasdasd" <> <<0xFFFF::16>>)
+  end
+end


### PR DESCRIPTION
Hi @mtrudel 

I did some tinkering around String.valid?/1 and bumped it performance twice on average. Benchmark is here https://gist.github.com/asakura/0a61b18587bef406de1b3f591b9a6126

Few notes on the benchmark:
- `String.valid?/2` with `:fast_ascii` would be closed to `32`
- `AndOr3` 18% faster than `32` on validating single byte sequences
- `AndOr3` twice or more faster than `Native` (`String.valid?/1`) on 2,3,4 byte sequences
- on mixed and mixed reversed data `AndOr3` doesn't choke and shows significant boost
- on less than 64 bytes dataset `AndOr3` shows  slightly better performance than `Native` (14.69 M vs 11.30 M), but slower than `32` 14.99 M (which might be statistically insignificant)

I don't have an ARM computer to run the benchmark on to see if the proposed code gives boost there unfortunately.

Result are:
```
Operating System: Linux
CPU Information: AMD Ryzen 7 7700X 8-Core Processor
Number of Available Cores: 16
Available memory: 30.99 GB
Elixir 1.16.2
Erlang 26.2.3
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 2 s
memory time: 2 s
reduction time: 0 ns
parallel: 1
inputs: 1byte, 2byte, 3byte, 4byte, less than 64 bytes, mixed, mixed rev
Estimated total run time: 4 min 54 s

Benchmarking 32 with input 1byte ...
Benchmarking 32 with input 2byte ...
Benchmarking 32 with input 3byte ...
Benchmarking 32 with input 4byte ...
Benchmarking 32 with input less than 64 bytes ...
Benchmarking 32 with input mixed ...
Benchmarking 32 with input mixed rev ...
Benchmarking AndOr with input 1byte ...
Benchmarking AndOr with input 2byte ...
Benchmarking AndOr with input 3byte ...
Benchmarking AndOr with input 4byte ...
Benchmarking AndOr with input less than 64 bytes ...
Benchmarking AndOr with input mixed ...
Benchmarking AndOr with input mixed rev ...
Benchmarking AndOr2 with input 1byte ...
Benchmarking AndOr2 with input 2byte ...
Benchmarking AndOr2 with input 3byte ...
Benchmarking AndOr2 with input 4byte ...
Benchmarking AndOr2 with input less than 64 bytes ...
Benchmarking AndOr2 with input mixed ...
Benchmarking AndOr2 with input mixed rev ...
Benchmarking AndOr3 with input 1byte ...
Benchmarking AndOr3 with input 2byte ...
Benchmarking AndOr3 with input 3byte ...
Benchmarking AndOr3 with input 4byte ...
Benchmarking AndOr3 with input less than 64 bytes ...
Benchmarking AndOr3 with input mixed ...
Benchmarking AndOr3 with input mixed rev ...
Benchmarking Lookup with input 1byte ...
Benchmarking Lookup with input 2byte ...
Benchmarking Lookup with input 3byte ...
Benchmarking Lookup with input 4byte ...
Benchmarking Lookup with input less than 64 bytes ...
Benchmarking Lookup with input mixed ...
Benchmarking Lookup with input mixed rev ...
Benchmarking Native with input 1byte ...
Benchmarking Native with input 2byte ...
Benchmarking Native with input 3byte ...
Benchmarking Native with input 4byte ...
Benchmarking Native with input less than 64 bytes ...
Benchmarking Native with input mixed ...
Benchmarking Native with input mixed rev ...
Benchmarking cowboy with input 1byte ...
Benchmarking cowboy with input 2byte ...
Benchmarking cowboy with input 3byte ...
Benchmarking cowboy with input 4byte ...
Benchmarking cowboy with input less than 64 bytes ...
Benchmarking cowboy with input mixed ...
Benchmarking cowboy with input mixed rev ...
Calculating statistics...
Formatting results...

##### With input 1byte #####
Name             ips        average  deviation         median         99th %
AndOr3      355.31 K        2.81 μs    ±17.07%        2.77 μs        2.92 μs
32          302.08 K        3.31 μs    ±15.20%        3.31 μs        4.83 μs
Native      129.44 K        7.73 μs     ±5.02%        7.69 μs        8.22 μs
AndOr2       88.64 K       11.28 μs     ±6.98%       11.21 μs       12.12 μs
Lookup       86.81 K       11.52 μs     ±8.15%       11.39 μs       16.31 μs
AndOr        77.06 K       12.98 μs     ±3.33%       12.96 μs       14.60 μs
cowboy       65.82 K       15.19 μs     ±2.67%       15.18 μs       16.14 μs

Comparison: 
AndOr3      355.31 K
32          302.08 K - 1.18x slower +0.50 μs
Native      129.44 K - 2.74x slower +4.91 μs
AndOr2       88.64 K - 4.01x slower +8.47 μs
Lookup       86.81 K - 4.09x slower +8.70 μs
AndOr        77.06 K - 4.61x slower +10.16 μs
cowboy       65.82 K - 5.40x slower +12.38 μs

Memory usage statistics:

Name      Memory usage
AndOr3            40 B
32                40 B - 1.00x memory usage +0 B
Native            40 B - 1.00x memory usage +0 B
AndOr2            40 B - 1.00x memory usage +0 B
Lookup            40 B - 1.00x memory usage +0 B
AndOr             40 B - 1.00x memory usage +0 B
cowboy            40 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

##### With input 2byte #####
Name             ips        average  deviation         median         99th %
AndOr3       47.86 K       20.89 μs     ±6.21%       20.76 μs       23.96 μs
AndOr2       47.23 K       21.17 μs     ±7.11%       21.15 μs       25.27 μs
AndOr        44.87 K       22.29 μs     ±2.89%       22.25 μs       25.74 μs
32           31.62 K       31.62 μs     ±5.78%       31.42 μs       36.23 μs
cowboy       21.67 K       46.15 μs     ±4.68%       45.97 μs       49.97 μs
Native       20.19 K       49.54 μs     ±1.77%       49.68 μs       53.09 μs
Lookup        6.94 K      144.06 μs     ±4.66%      144.01 μs      151.19 μs

Comparison: 
AndOr3       47.86 K
AndOr2       47.23 K - 1.01x slower +0.28 μs
AndOr        44.87 K - 1.07x slower +1.39 μs
32           31.62 K - 1.51x slower +10.73 μs
cowboy       21.67 K - 2.21x slower +25.26 μs
Native       20.19 K - 2.37x slower +28.64 μs
Lookup        6.94 K - 6.89x slower +123.17 μs

Memory usage statistics:

Name      Memory usage
AndOr3            40 B
AndOr2            40 B - 1.00x memory usage +0 B
AndOr             40 B - 1.00x memory usage +0 B
32                40 B - 1.00x memory usage +0 B
cowboy            40 B - 1.00x memory usage +0 B
Native            40 B - 1.00x memory usage +0 B
Lookup            40 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

##### With input 3byte #####
Name             ips        average  deviation         median         99th %
AndOr2       41.79 K       23.93 μs     ±6.66%       23.91 μs       27.25 μs
AndOr3       38.71 K       25.83 μs     ±8.01%       25.72 μs       29.66 μs
AndOr        30.08 K       33.24 μs     ±3.67%       33.23 μs       36.95 μs
32           24.27 K       41.20 μs     ±5.09%       40.69 μs       45.59 μs
Native       20.20 K       49.50 μs     ±1.96%       49.58 μs       53.11 μs
cowboy       13.29 K       75.24 μs     ±1.86%       75.30 μs       78.85 μs
Lookup        5.66 K      176.74 μs     ±4.86%      174.87 μs      190.80 μs

Comparison: 
AndOr2       41.79 K
AndOr3       38.71 K - 1.08x slower +1.90 μs
AndOr        30.08 K - 1.39x slower +9.31 μs
32           24.27 K - 1.72x slower +17.27 μs
Native       20.20 K - 2.07x slower +25.57 μs
cowboy       13.29 K - 3.14x slower +51.31 μs
Lookup        5.66 K - 7.39x slower +152.81 μs

Memory usage statistics:

Name      Memory usage
AndOr2            40 B
AndOr3            40 B - 1.00x memory usage +0 B
AndOr             40 B - 1.00x memory usage +0 B
32                40 B - 1.00x memory usage +0 B
Native            40 B - 1.00x memory usage +0 B
cowboy            40 B - 1.00x memory usage +0 B
Lookup            40 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

##### With input 4byte #####
Name             ips        average  deviation         median         99th %
AndOr2       44.51 K       22.46 μs     ±7.84%       22.22 μs       25.45 μs
AndOr3       41.12 K       24.32 μs     ±2.73%       24.20 μs       27.04 μs
AndOr        21.87 K       45.73 μs     ±1.93%       45.73 μs       49.51 μs
Native       19.91 K       50.24 μs     ±1.93%       50.26 μs       53.60 μs
32           19.25 K       51.94 μs     ±4.31%       51.84 μs       55.83 μs
cowboy        9.89 K      101.12 μs     ±1.95%      101.60 μs      105.06 μs
Lookup        4.69 K      213.19 μs     ±4.41%      217.27 μs      229.56 μs

Comparison: 
AndOr2       44.51 K
AndOr3       41.12 K - 1.08x slower +1.85 μs
AndOr        21.87 K - 2.04x slower +23.27 μs
Native       19.91 K - 2.24x slower +27.77 μs
32           19.25 K - 2.31x slower +29.48 μs
cowboy        9.89 K - 4.50x slower +78.66 μs
Lookup        4.69 K - 9.49x slower +190.73 μs

Memory usage statistics:

Name      Memory usage
AndOr2            40 B
AndOr3            40 B - 1.00x memory usage +0 B
AndOr             40 B - 1.00x memory usage +0 B
Native            40 B - 1.00x memory usage +0 B
32                40 B - 1.00x memory usage +0 B
cowboy            40 B - 1.00x memory usage +0 B
Lookup            40 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

##### With input less than 64 bytes #####
Name             ips        average  deviation         median         99th %
32           14.99 M       66.72 ns ±18823.38%          60 ns         100 ns
AndOr3       14.69 M       68.07 ns ±18253.58%          60 ns         100 ns
Native       11.30 M       88.46 ns  ±6695.36%          80 ns         101 ns
Lookup        8.50 M      117.58 ns  ±5300.57%         110 ns         200 ns
AndOr2        8.44 M      118.50 ns  ±5311.60%         110 ns         200 ns
AndOr         7.84 M      127.61 ns  ±5015.24%         120 ns         210 ns
cowboy        6.77 M      147.72 ns  ±5538.35%         140 ns         230 ns

Comparison: 
32           14.99 M
AndOr3       14.69 M - 1.02x slower +1.35 ns
Native       11.30 M - 1.33x slower +21.73 ns
Lookup        8.50 M - 1.76x slower +50.86 ns
AndOr2        8.44 M - 1.78x slower +51.77 ns
AndOr         7.84 M - 1.91x slower +60.88 ns
cowboy        6.77 M - 2.21x slower +80.99 ns

Memory usage statistics:

Name      Memory usage
32                40 B
AndOr3            40 B - 1.00x memory usage +0 B
Native            40 B - 1.00x memory usage +0 B
Lookup            40 B - 1.00x memory usage +0 B
AndOr2            40 B - 1.00x memory usage +0 B
AndOr             40 B - 1.00x memory usage +0 B
cowboy            40 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

##### With input mixed #####
Name             ips        average  deviation         median         99th %
AndOr2       12.02 K       83.18 μs     ±3.23%       82.58 μs       89.37 μs
AndOr3       10.52 K       95.08 μs     ±2.66%       94.39 μs      108.30 μs
AndOr         8.13 K      122.97 μs     ±6.68%      122.10 μs      135.31 μs
Native        6.43 K      155.52 μs     ±1.84%      155.44 μs      159.88 μs
32            5.31 K      188.41 μs     ±3.27%      187.34 μs      218.95 μs
cowboy        3.88 K      257.99 μs     ±2.41%      256.86 μs      273.06 μs
Lookup        1.82 K      549.16 μs     ±3.08%      553.92 μs      606.36 μs

Comparison: 
AndOr2       12.02 K
AndOr3       10.52 K - 1.14x slower +11.90 μs
AndOr         8.13 K - 1.48x slower +39.78 μs
Native        6.43 K - 1.87x slower +72.34 μs
32            5.31 K - 2.27x slower +105.23 μs
cowboy        3.88 K - 3.10x slower +174.81 μs
Lookup        1.82 K - 6.60x slower +465.98 μs

Memory usage statistics:

Name      Memory usage
AndOr2            40 B
AndOr3            40 B - 1.00x memory usage +0 B
AndOr             40 B - 1.00x memory usage +0 B
Native            40 B - 1.00x memory usage +0 B
32                40 B - 1.00x memory usage +0 B
cowboy            40 B - 1.00x memory usage +0 B
Lookup            40 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

##### With input mixed rev #####
Name             ips        average  deviation         median         99th %
AndOr2       11.95 K       83.67 μs     ±2.29%       83.99 μs       88.74 μs
AndOr3       10.54 K       94.85 μs     ±1.25%       94.47 μs      100.72 μs
AndOr         8.33 K      120.01 μs     ±2.82%      119.66 μs      126.83 μs
Native        6.39 K      156.46 μs     ±1.31%      157.16 μs      160.65 μs
32            5.39 K      185.58 μs     ±2.28%      185.06 μs      208.44 μs
cowboy        3.91 K      255.66 μs     ±2.15%      255.16 μs      273.52 μs
Lookup        1.85 K      540.67 μs     ±3.40%      534.72 μs      605.05 μs

Comparison: 
AndOr2       11.95 K
AndOr3       10.54 K - 1.13x slower +11.18 μs
AndOr         8.33 K - 1.43x slower +36.33 μs
Native        6.39 K - 1.87x slower +72.79 μs
32            5.39 K - 2.22x slower +101.90 μs
cowboy        3.91 K - 3.06x slower +171.99 μs
Lookup        1.85 K - 6.46x slower +456.99 μs

Memory usage statistics:

Name      Memory usage
AndOr2            40 B
AndOr3            40 B - 1.00x memory usage +0 B
AndOr             40 B - 1.00x memory usage +0 B
Native            40 B - 1.00x memory usage +0 B
32                40 B - 1.00x memory usage +0 B
cowboy            40 B - 1.00x memory usage +0 B
Lookup            40 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**

```