### PR TITLE
Refactor pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Changes
 
+* **BREAKING CHANGE** Move `log_protocol_errors` configuration option into
+  shared `http_options` top-level config (and apply it to HTTP/2 errors as well)
 * **BREAKING CHANGE** Remove `origin_telemetry_span_context` from WebSocket
   telemetry events
 * **BREAKING CHANGE** Remove `stream_id` from HTTP/2 telemetry events

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 1.4.1 (TBD)
+
+### Changes
+
+* **BREAKING CHANGE** Remove `origin_telemetry_span_context` from WebSocket
+  telemetry events
+* **BREAKING CHANGE** Remove `stream_id` from HTTP/2 telemetry events
+* Add `conn` to the metadata of telemetry start events for HTTP requests
+* Stop sending WebSocket upgrade failure reasons to the client (they're still
+  logged)
+
+### Fixes
+
+* Return HTTP semantic errors to HTTP/2 clients as protocol errors instead of
+  internal errors
+
 ## 1.4.0 (26 Mar 2024)
 
 > [!WARNING]

--- a/lib/bandit.ex
+++ b/lib/bandit.ex
@@ -93,10 +93,13 @@ defmodule Bandit do
     [RFC9110§8.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4). Defaults to true
   * `deflate_options`: A keyword list of options to set on the deflate library. A complete list can
     be found at `t:deflate_options/0`
+  * `log_protocol_errors`: Whether or not to log protocol errors such as malformed requests.
+    Defaults to `true`
   """
   @type http_options :: [
           compress: boolean(),
-          deflate_opions: deflate_options()
+          deflate_opions: deflate_options(),
+          log_protocol_errors: boolean()
         ]
 
   @typedoc """
@@ -116,8 +119,6 @@ defmodule Bandit do
     every 5 requests). This option is currently experimental, and may change at any time
   * `log_unknown_messages`: Whether or not to log unknown messages sent to the handler process.
     Defaults to `false`
-  * `log_protocol_errors`: Whether or not to log protocol errors such as malformed requests.
-    Defaults to `true`
   """
   @type http_1_options :: [
           enabled: boolean(),
@@ -126,8 +127,7 @@ defmodule Bandit do
           max_header_count: pos_integer(),
           max_requests: pos_integer(),
           gc_every_n_keepalive_requests: pos_integer(),
-          log_unknown_messages: boolean(),
-          log_protocol_errors: boolean()
+          log_unknown_messages: boolean()
         ]
 
   @typedoc """
@@ -196,8 +196,8 @@ defmodule Bandit do
   end
 
   @top_level_keys ~w(plug scheme port ip keyfile certfile otp_app cipher_suite display_plug startup_log thousand_island_options http_options http_1_options http_2_options websocket_options)a
-  @http_keys ~w(compress deflate_options)a
-  @http_1_keys ~w(enabled max_request_line_length max_header_length max_header_count max_requests gc_every_n_keepalive_requests log_unknown_messages log_protocol_errors)a
+  @http_keys ~w(compress deflate_options log_protocol_errors)a
+  @http_1_keys ~w(enabled max_request_line_length max_header_length max_header_count max_requests gc_every_n_keepalive_requests log_unknown_messages)a
   @http_2_keys ~w(enabled max_header_block_size max_requests default_local_settings)a
   @websocket_keys ~w(enabled max_frame_size validate_text_frames compress)a
   @thousand_island_keys ThousandIsland.ServerConfig.__struct__()

--- a/lib/bandit/adapter.ex
+++ b/lib/bandit/adapter.ex
@@ -262,10 +262,9 @@ defmodule Bandit.Adapter do
 
   @impl Plug.Conn.Adapter
   def get_peer_data(%__MODULE__{} = adapter) do
-    case Bandit.HTTPTransport.transport_info(adapter.transport) do
-      {:ok, transport_info} -> Bandit.TransportInfo.peer_data(transport_info)
-      {:error, reason} -> raise "Unable to obtain transport_info: #{inspect(reason)}"
-    end
+    adapter.transport
+    |> Bandit.HTTPTransport.transport_info()
+    |> Bandit.TransportInfo.peer_data()
   end
 
   @impl Plug.Conn.Adapter

--- a/lib/bandit/headers.ex
+++ b/lib/bandit/headers.ex
@@ -14,35 +14,35 @@ defmodule Bandit.Headers do
   end
 
   # Covers IPv6 addresses, like `[::1]:4000` as defined in RFC3986.
-  @spec parse_hostlike_header(host_header :: binary()) ::
-          {:ok, Plug.Conn.host(), nil | Plug.Conn.port_number()} | {:error, String.t()}
-  def parse_hostlike_header("[" <> _ = host_header) do
+  @spec parse_hostlike_header!(host_header :: binary()) ::
+          {Plug.Conn.host(), nil | Plug.Conn.port_number()}
+  def parse_hostlike_header!("[" <> _ = host_header) do
     host_header
     |> :binary.split("]:")
     |> case do
       [host, port] ->
         case parse_integer(port) do
-          {port, ""} when is_port_number(port) -> {:ok, host <> "]", port}
-          _ -> {:error, "Header contains invalid port"}
+          {port, ""} when is_port_number(port) -> {host <> "]", port}
+          _ -> raise Bandit.HTTPError, "Header contains invalid port"
         end
 
       [host] ->
-        {:ok, host, nil}
+        {host, nil}
     end
   end
 
-  def parse_hostlike_header(host_header) do
+  def parse_hostlike_header!(host_header) do
     host_header
     |> :binary.split(":")
     |> case do
       [host, port] ->
         case parse_integer(port) do
-          {port, ""} when is_port_number(port) -> {:ok, host, port}
-          _ -> {:error, "Header contains invalid port"}
+          {port, ""} when is_port_number(port) -> {host, port}
+          _ -> raise Bandit.HTTPError, "Header contains invalid port"
         end
 
       [host] ->
-        {:ok, host, nil}
+        {host, nil}
     end
   end
 

--- a/lib/bandit/http1/error.ex
+++ b/lib/bandit/http1/error.ex
@@ -1,4 +1,0 @@
-defmodule Bandit.HTTP1.Error do
-  # Represents an error suitable for return as an HTTP status
-  defexception [:message, :status]
-end

--- a/lib/bandit/http1/handler.ex
+++ b/lib/bandit/http1/handler.ex
@@ -45,7 +45,7 @@ defmodule Bandit.HTTP1.Handler do
           {:switch, Bandit.WebSocket.Handler, state}
       end
     rescue
-      error in Bandit.HTTP1.Error ->
+      error in Bandit.HTTPError ->
         _ = attempt_to_send_fallback(transport, error.status)
         Bandit.Telemetry.stop_span(span, %{}, %{error: error.message, status: error.status})
 
@@ -88,7 +88,7 @@ defmodule Bandit.HTTP1.Handler do
 
         {:continue, Map.put(state, :requests_processed, requests_processed)}
       rescue
-        _error in Bandit.HTTP1.Error -> {:close, state}
+        _error in Bandit.HTTPError -> {:close, state}
       end
     else
       {:close, state}

--- a/lib/bandit/http1/handler.ex
+++ b/lib/bandit/http1/handler.ex
@@ -4,96 +4,35 @@ defmodule Bandit.HTTP1.Handler do
 
   use ThousandIsland.Handler
 
-  @already_sent {:plug_conn, :sent}
-
   @impl ThousandIsland.Handler
   def handle_data(data, socket, state) do
+    transport = %Bandit.HTTP1.Socket{socket: socket, buffer: data, opts: state.opts}
     connection_span = ThousandIsland.Socket.telemetry_span(socket)
 
-    span =
-      Bandit.Telemetry.start_span(:request, %{}, %{
-        connection_telemetry_span_context: connection_span.telemetry_span_context
-      })
-
-    transport = %Bandit.HTTP1.Socket{socket: socket, buffer: data, opts: state.opts}
-
-    try do
-      case Bandit.Pipeline.run(transport, state.plug, state.opts) do
-        {:ok, %Plug.Conn{adapter: {_mod, adapter}} = conn} ->
-          Bandit.Telemetry.stop_span(span, adapter.metrics, %{conn: conn})
-          maybe_keepalive(adapter, state)
-
-        {:error, reason} ->
-          attempt_to_send_fallback(transport, 400)
-          Bandit.Telemetry.stop_span(span, %{}, %{error: reason, status: 400})
-
-          if Keyword.get(state.opts.http_1, :log_protocol_errors, true),
-            do: {:error, reason, state},
-            else: {:close, state}
-
-        {:ok, :websocket, %Plug.Conn{adapter: {Bandit.Adapter, adapter}} = conn, upgrade_opts} ->
-          Bandit.Telemetry.stop_span(span, adapter.metrics, %{conn: conn})
-
-          state =
-            state
-            |> Map.put(:upgrade_opts, upgrade_opts)
-            |> Map.put(
-              :origin_telemetry_span_context,
-              Bandit.Telemetry.telemetry_span_context(span)
-            )
-
-          {:switch, Bandit.WebSocket.Handler, state}
-      end
-    rescue
-      error in Bandit.HTTPError ->
-        _ = attempt_to_send_fallback(transport, error.status)
-        Bandit.Telemetry.stop_span(span, %{}, %{error: error.message, status: error.status})
-
-        if Keyword.get(state.opts.http_1, :log_protocol_errors, true),
-          do: {:error, error.message, state},
-          else: {:close, state}
-
-      error ->
-        _ = attempt_to_send_fallback(transport, 500)
-        Bandit.Telemetry.span_exception(span, :exit, error, __STACKTRACE__)
-        reraise error, __STACKTRACE__
+    case Bandit.Pipeline.run(transport, state.plug, connection_span, state.opts) do
+      {:ok, transport} -> maybe_keepalive(transport, state)
+      {:error, _reason} -> {:close, state}
+      {:upgrade, _transport, :websocket, opts} -> do_websocket_upgrade(opts, state)
     end
   end
 
-  defp attempt_to_send_fallback(transport, status) do
-    receive do
-      @already_sent ->
-        send(self(), @already_sent)
-    after
-      0 ->
-        try do
-          Bandit.HTTP1.Socket.send_error(transport, status)
-        rescue
-          _ -> :ok
-        end
-    end
-  end
-
-  defp maybe_keepalive(adapter, state) do
+  defp maybe_keepalive(transport, state) do
     requests_processed = Map.get(state, :requests_processed, 0) + 1
     request_limit = Keyword.get(state.opts.http_1, :max_requests, 0)
     under_limit = request_limit == 0 || requests_processed < request_limit
 
-    if under_limit && adapter.transport.keepalive do
-      try do
-        _ = Bandit.HTTPTransport.ensure_completed(adapter.transport)
-
-        gc_every_n_requests = Keyword.get(state.opts.http_1, :gc_every_n_keepalive_requests, 5)
-        if rem(requests_processed, gc_every_n_requests) == 0, do: :erlang.garbage_collect()
-
-        {:continue, Map.put(state, :requests_processed, requests_processed)}
-      rescue
-        _error in Bandit.HTTPError -> {:close, state}
-      end
+    if under_limit && transport.keepalive do
+      Logger.reset_metadata()
+      gc_every_n_requests = Keyword.get(state.opts.http_1, :gc_every_n_keepalive_requests, 5)
+      if rem(requests_processed, gc_every_n_requests) == 0, do: :erlang.garbage_collect()
+      {:continue, Map.put(state, :requests_processed, requests_processed)}
     else
       {:close, state}
     end
   end
+
+  defp do_websocket_upgrade(upgrade_opts, state),
+    do: {:switch, Bandit.WebSocket.Handler, Map.put(state, :upgrade_opts, upgrade_opts)}
 
   def handle_info({:plug_conn, :sent}, {socket, state}),
     do: {:noreply, {socket, state}, socket.read_timeout}

--- a/lib/bandit/http1/socket.ex
+++ b/lib/bandit/http1/socket.ex
@@ -385,7 +385,7 @@ defmodule Bandit.HTTP1.Socket do
     @spec request_error!(term()) :: no_return()
     @spec request_error!(term(), atom()) :: no_return()
     defp request_error!(reason, status \\ :bad_request) do
-      raise Bandit.HTTP1.Error, message: reason, status: Plug.Conn.Status.code(status)
+      raise Bandit.HTTPError, message: reason, status: Plug.Conn.Status.code(status)
     end
   end
 

--- a/lib/bandit/http1/socket.ex
+++ b/lib/bandit/http1/socket.ex
@@ -376,7 +376,7 @@ defmodule Bandit.HTTP1.Socket do
     def ensure_completed(%@for{} = socket) do
       case read_data(socket, []) do
         {:ok, _data, socket} -> socket
-        {:more, _data, socket} -> ensure_completed(socket)
+        {:more, _data, _socket} -> request_error!("Unable to read remaining data in request body")
       end
     end
 

--- a/lib/bandit/http1/socket.ex
+++ b/lib/bandit/http1/socket.ex
@@ -382,20 +382,36 @@ defmodule Bandit.HTTP1.Socket do
 
     def supported_upgrade?(_socket, protocol), do: protocol == :websocket
 
+    def send_on_error(%@for{} = socket, %Bandit.HTTPError{} = error) do
+      _ = send_error(socket, error.status)
+      %{socket | write_state: :sent}
+    end
+
+    def send_on_error(%@for{} = socket, _error) do
+      _ = send_error(socket, 500)
+      %{socket | write_state: :sent}
+    end
+
+    defp send_error(socket, status) do
+      receive do
+        {:plug_conn, :sent} -> :ok
+      after
+        0 ->
+          try do
+            reason = Plug.Conn.Status.reason_phrase(status)
+            response_line = "#{socket.version} #{status} #{reason}\r\n\r\n"
+            _ = ThousandIsland.Socket.send(socket.socket, response_line)
+            ThousandIsland.Socket.close(socket.socket)
+          rescue
+            _ -> :ok
+          end
+      end
+    end
+
     @spec request_error!(term()) :: no_return()
     @spec request_error!(term(), atom()) :: no_return()
     defp request_error!(reason, status \\ :bad_request) do
-      raise Bandit.HTTPError, message: reason, status: Plug.Conn.Status.code(status)
+      raise Bandit.HTTPError, message: to_string(reason), status: Plug.Conn.Status.code(status)
     end
-  end
-
-  def send_error(%__MODULE__{} = socket, status) do
-    _ =
-      ThousandIsland.Socket.send(
-        socket.socket,
-        "#{socket.version} #{status} #{Plug.Conn.Status.reason_phrase(status)}\r\n\r\n"
-      )
-
-    ThousandIsland.Socket.close(socket.socket)
   end
 end

--- a/lib/bandit/http2/connection.ex
+++ b/lib/bandit/http2/connection.ex
@@ -226,8 +226,8 @@ defmodule Bandit.HTTP2.Connection do
           case Bandit.HTTP2.StreamProcess.start_link(
                  stream,
                  connection.plug,
-                 connection.opts,
-                 connection.telemetry_span
+                 connection.telemetry_span,
+                 connection.opts
                ) do
             {:ok, pid} ->
               streams = Bandit.HTTP2.StreamCollection.insert(connection.streams, stream_id, pid)

--- a/lib/bandit/http2/connection.ex
+++ b/lib/bandit/http2/connection.ex
@@ -42,16 +42,10 @@ defmodule Bandit.HTTP2.Connection do
 
   @spec init(ThousandIsland.Socket.t(), Bandit.Pipeline.plug_def(), map()) :: t()
   def init(socket, plug, opts) do
-    transport_info =
-      case Bandit.TransportInfo.init(socket) do
-        {:ok, transport_info} -> transport_info
-        {:error, reason} -> raise "Unable to obtain transport_info: #{inspect(reason)}"
-      end
-
     connection = %__MODULE__{
       local_settings:
         struct!(Bandit.HTTP2.Settings, Keyword.get(opts.http_2, :default_local_settings, [])),
-      transport_info: transport_info,
+      transport_info: Bandit.TransportInfo.init(socket),
       telemetry_span: ThousandIsland.Socket.telemetry_span(socket),
       plug: plug,
       opts: opts

--- a/lib/bandit/http2/stream.ex
+++ b/lib/bandit/http2/stream.ex
@@ -102,7 +102,7 @@ defmodule Bandit.HTTP2.Stream do
   def deliver_rst_stream(pid, error_code), do: send(pid, {:rst_stream, error_code})
 
   defimpl Bandit.HTTPTransport do
-    def transport_info(stream), do: {:ok, stream.transport_info}
+    def transport_info(stream), do: stream.transport_info
 
     def version(%{}), do: :"HTTP/2"
 

--- a/lib/bandit/http2/stream.ex
+++ b/lib/bandit/http2/stream.ex
@@ -141,14 +141,8 @@ defmodule Bandit.HTTP2.Stream do
 
     defp get_host_and_port!(headers) do
       case Bandit.Headers.get_header(headers, ":authority") do
-        authority when not is_nil(authority) ->
-          case Bandit.Headers.parse_hostlike_header(authority) do
-            {:ok, host, port} -> {host, port}
-            {:error, reason} -> stream_error!(reason)
-          end
-
-        nil ->
-          {nil, nil}
+        authority when not is_nil(authority) -> Bandit.Headers.parse_hostlike_header!(authority)
+        nil -> {nil, nil}
       end
     end
 

--- a/lib/bandit/http_error.ex
+++ b/lib/bandit/http_error.ex
@@ -1,0 +1,6 @@
+defmodule Bandit.HTTPError do
+  # Represents an error suitable for return as an HTTP status. Note that these may be surfaced
+  # from anywhere that such a message is well defined, including within HTTP/1 transport concerns
+  # and also within shared HTTP semantics (ie: within Bandit.Adapter or Bandit.Pipeline)
+  defexception [:message, :status]
+end

--- a/lib/bandit/http_error.ex
+++ b/lib/bandit/http_error.ex
@@ -2,5 +2,5 @@ defmodule Bandit.HTTPError do
   # Represents an error suitable for return as an HTTP status. Note that these may be surfaced
   # from anywhere that such a message is well defined, including within HTTP/1 transport concerns
   # and also within shared HTTP semantics (ie: within Bandit.Adapter or Bandit.Pipeline)
-  defexception [:message, :status]
+  defexception message: nil, status: 400
 end

--- a/lib/bandit/http_transport.ex
+++ b/lib/bandit/http_transport.ex
@@ -8,7 +8,7 @@ defprotocol Bandit.HTTPTransport do
   @typedoc "How the response body is to be delivered"
   @type body_disposition :: :raw | :chunk_encoded | :no_body | :inform
 
-  @spec transport_info(t()) :: {:ok, Bandit.TransportInfo.t()} | {:error, term()}
+  @spec transport_info(t()) :: Bandit.TransportInfo.t()
   def transport_info(transport)
 
   @spec version(t()) :: Plug.Conn.Adapter.http_protocol()

--- a/lib/bandit/http_transport.ex
+++ b/lib/bandit/http_transport.ex
@@ -35,4 +35,7 @@ defprotocol Bandit.HTTPTransport do
 
   @spec supported_upgrade?(t(), atom()) :: boolean()
   def supported_upgrade?(transport, protocol)
+
+  @spec send_on_error(t(), struct()) :: t()
+  def send_on_error(transport, error)
 end

--- a/lib/bandit/pipeline.ex
+++ b/lib/bandit/pipeline.ex
@@ -53,7 +53,7 @@ defmodule Bandit.Pipeline do
         ] ->
           Bandit.Telemetry.stop_span(span, %{}, %{error: error.message})
 
-          if Keyword.get(opts.http_1, :log_protocol_errors, true),
+          if Keyword.get(opts.http, :log_protocol_errors, true),
             do: Logger.error(Exception.format(:error, error, __STACKTRACE__))
 
           Bandit.HTTPTransport.send_on_error(transport, error)
@@ -73,7 +73,7 @@ defmodule Bandit.Pipeline do
         span = Bandit.Telemetry.start_span(:request, measurements, metadata)
         Bandit.Telemetry.stop_span(span, %{}, %{error: error.message})
 
-        if Keyword.get(opts.http_1, :log_protocol_errors, true),
+        if Keyword.get(opts.http, :log_protocol_errors, true),
           do: Logger.error(Exception.format(:error, error, __STACKTRACE__))
 
         Bandit.HTTPTransport.send_on_error(transport, error)

--- a/lib/bandit/pipeline.ex
+++ b/lib/bandit/pipeline.ex
@@ -33,7 +33,7 @@ defmodule Bandit.Pipeline do
           Plug.Conn.headers()
         ) :: {:ok, Plug.Conn.t()} | {:error, String.t()}
   defp build_conn({mod, adapter}, transport, method, request_target, headers) do
-    with {:ok, transport_info} <- Bandit.HTTPTransport.transport_info(transport),
+    with transport_info <- Bandit.HTTPTransport.transport_info(transport),
          {:ok, scheme} <- determine_scheme(transport_info, request_target),
          version <- mod.get_http_protocol(adapter),
          {:ok, host, port} <- determine_host_and_port(scheme, version, request_target, headers),

--- a/lib/bandit/pipeline.ex
+++ b/lib/bandit/pipeline.ex
@@ -132,7 +132,6 @@ defmodule Bandit.Pipeline do
         {:ok, :websocket, conn, {websock, websock_opts, connection_opts}}
 
       {:error, reason} ->
-        _ = %{conn | state: :unset} |> Plug.Conn.send_resp(400, reason)
         {:error, reason}
     end
   end

--- a/lib/bandit/pipeline.ex
+++ b/lib/bandit/pipeline.ex
@@ -9,76 +9,124 @@ defmodule Bandit.Pipeline do
   @type scheme :: String.t() | nil
   @type path :: String.t() | :*
 
-  @spec run(Bandit.HTTPTransport.t(), plug_def(), map()) ::
-          {:ok, Plug.Conn.t()} | {:ok, :websocket, Plug.Conn.t(), tuple()} | {:error, term()}
-  def run(transport, plug, opts) do
-    Logger.reset_metadata()
+  require Logger
 
-    with {:ok, method, request_target, headers, transport} <-
-           Bandit.HTTPTransport.read_headers(transport),
-         adapter <-
-           {Bandit.Adapter, Bandit.Adapter.init(self(), transport, method, headers, opts)},
-         {:ok, conn} <- build_conn(adapter, transport, method, request_target, headers),
-         conn <- call_plug(conn, plug),
-         {:ok, :no_upgrade} <- maybe_upgrade(conn) do
-      {:ok, commit_response(conn)}
+  @spec run(
+          Bandit.HTTPTransport.t(),
+          plug_def(),
+          ThousandIsland.Telemetry.t() | Bandit.Telemetry.t(),
+          map()
+        ) ::
+          {:ok, Bandit.HTTPTransport.t()}
+          | {:upgrade, Bandit.HTTPTransport.t(), :websocket, tuple()}
+          | {:error, term()}
+  def run(transport, plug, connection_span, opts) do
+    measurements = %{monotonic_time: Bandit.Telemetry.monotonic_time()}
+    metadata = %{connection_telemetry_span_context: connection_span.telemetry_span_context}
+
+    try do
+      {:ok, method, request_target, headers, transport} =
+        Bandit.HTTPTransport.read_headers(transport)
+
+      conn = build_conn!(transport, method, request_target, headers, opts)
+      span = Bandit.Telemetry.start_span(:request, measurements, Map.put(metadata, :conn, conn))
+
+      try do
+        conn
+        |> call_plug!(plug)
+        |> maybe_upgrade!()
+        |> case do
+          {:no_upgrade, conn} ->
+            %Plug.Conn{adapter: {_mod, adapter}} = conn = commit_response!(conn)
+            Bandit.Telemetry.stop_span(span, adapter.metrics, %{conn: conn})
+            {:ok, adapter.transport}
+
+          {:upgrade, %Plug.Conn{adapter: {_mod, adapter}} = conn, protocol, opts} ->
+            Bandit.Telemetry.stop_span(span, adapter.metrics, %{conn: conn})
+            {:upgrade, adapter.transport, protocol, opts}
+        end
+      rescue
+        error in [
+          Bandit.HTTPError,
+          Bandit.HTTP2.Errors.StreamError,
+          Bandit.HTTP2.Errors.ConnectionError
+        ] ->
+          Bandit.Telemetry.stop_span(span, %{}, %{error: error.message})
+
+          if Keyword.get(opts.http_1, :log_protocol_errors, true),
+            do: Logger.error(Exception.format(:error, error, __STACKTRACE__))
+
+          Bandit.HTTPTransport.send_on_error(transport, error)
+          {:error, error}
+
+        error ->
+          Bandit.Telemetry.span_exception(span, :exit, error, __STACKTRACE__)
+          Bandit.HTTPTransport.send_on_error(transport, error)
+          reraise error, __STACKTRACE__
+      end
+    rescue
+      error in [
+        Bandit.HTTPError,
+        Bandit.HTTP2.Errors.StreamError,
+        Bandit.HTTP2.Errors.ConnectionError
+      ] ->
+        span = Bandit.Telemetry.start_span(:request, measurements, metadata)
+        Bandit.Telemetry.stop_span(span, %{}, %{error: error.message})
+
+        if Keyword.get(opts.http_1, :log_protocol_errors, true),
+          do: Logger.error(Exception.format(:error, error, __STACKTRACE__))
+
+        Bandit.HTTPTransport.send_on_error(transport, error)
+        {:error, error}
     end
   end
 
-  @spec build_conn(
-          Plug.Conn.adapter(),
+  @spec build_conn!(
           Bandit.HTTPTransport.t(),
           Plug.Conn.method(),
           request_target(),
-          Plug.Conn.headers()
-        ) :: {:ok, Plug.Conn.t()} | {:error, String.t()}
-  defp build_conn({mod, adapter}, transport, method, request_target, headers) do
-    with transport_info <- Bandit.HTTPTransport.transport_info(transport),
-         {:ok, scheme} <- determine_scheme(transport_info, request_target),
-         version <- mod.get_http_protocol(adapter),
-         {:ok, host, port} <- determine_host_and_port(scheme, version, request_target, headers),
-         {path, query} <- determine_path_and_query(request_target) do
-      uri = %URI{scheme: scheme, host: host, port: port, path: path, query: query}
-      %Bandit.TransportInfo{peername: {remote_ip, _port}} = transport_info
-      {:ok, Plug.Conn.Adapter.conn({mod, adapter}, method, uri, remote_ip, headers)}
-    end
+          Plug.Conn.headers(),
+          map()
+        ) :: Plug.Conn.t()
+  defp build_conn!(transport, method, request_target, headers, opts) do
+    adapter = Bandit.Adapter.init(self(), transport, method, headers, opts)
+    transport_info = Bandit.HTTPTransport.transport_info(transport)
+    scheme = determine_scheme(transport_info, request_target)
+    version = Bandit.HTTPTransport.version(transport)
+    {host, port} = determine_host_and_port!(scheme, version, request_target, headers)
+    {path, query} = determine_path_and_query(request_target)
+    uri = %URI{scheme: scheme, host: host, port: port, path: path, query: query}
+    %{address: peer_addr} = Bandit.TransportInfo.peer_data(transport_info)
+    Plug.Conn.Adapter.conn({Bandit.Adapter, adapter}, method, uri, peer_addr, headers)
   end
 
-  @spec determine_scheme(Bandit.TransportInfo.t(), request_target()) ::
-          {:ok, String.t()} | {:error, String.t()}
+  @spec determine_scheme(Bandit.TransportInfo.t(), request_target()) :: String.t() | nil
   defp determine_scheme(%Bandit.TransportInfo{secure?: secure?}, {scheme, _, _, _}) do
     case {scheme, secure?} do
-      {nil, true} -> {:ok, "https"}
-      {nil, false} -> {:ok, "http"}
-      {scheme, _} -> {:ok, scheme}
+      {nil, true} -> "https"
+      {nil, false} -> "http"
+      {scheme, _} -> scheme
     end
   end
 
-  @spec determine_host_and_port(
-          scheme :: binary(),
-          version :: atom(),
-          request_target(),
-          Plug.Conn.headers()
-        ) ::
-          {:ok, Plug.Conn.host(), Plug.Conn.port_number()} | {:error, String.t()}
-  defp determine_host_and_port(scheme, version, {_, nil, nil, _}, headers) do
-    with host_header when is_binary(host_header) <- Bandit.Headers.get_header(headers, "host"),
-         {:ok, host, port} <- Bandit.Headers.parse_hostlike_header(host_header) do
-      {:ok, host, port || URI.default_port(scheme)}
-    else
-      nil ->
-        case version do
-          :"HTTP/1.0" -> {:ok, "", URI.default_port(scheme)}
-          _ -> {:error, "No host header"}
-        end
+  @spec determine_host_and_port!(binary(), atom(), request_target(), Plug.Conn.headers()) ::
+          {Plug.Conn.host(), Plug.Conn.port_number()}
+  defp determine_host_and_port!(scheme, version, {_, nil, nil, _}, headers) do
+    case {Bandit.Headers.get_header(headers, "host"), version} do
+      {nil, :"HTTP/1.0"} ->
+        {"", URI.default_port(scheme)}
 
-      error ->
-        error
+      {nil, _} ->
+        request_error!("Unable to obtain host and port: No host header")
+
+      {host_header, _} ->
+        {host, port} = Bandit.Headers.parse_hostlike_header!(host_header)
+        {host, port || URI.default_port(scheme)}
     end
   end
 
-  defp determine_host_and_port(scheme, _version, {_, host, port, _}, _headers),
-    do: {:ok, to_string(host), port || URI.default_port(scheme)}
+  defp determine_host_and_port!(scheme, _version, {_, host, port, _}, _headers),
+    do: {to_string(host), port || URI.default_port(scheme)}
 
   @spec determine_path_and_query(request_target()) :: {String.t(), nil | String.t()}
   defp determine_path_and_query({_, _, _, :*}), do: {"*", nil}
@@ -97,24 +145,24 @@ defmodule Bandit.Pipeline do
     end
   end
 
-  @spec call_plug(Plug.Conn.t(), plug_def()) :: Plug.Conn.t() | no_return()
-  defp call_plug(%Plug.Conn{} = conn, {plug, plug_opts}) when is_atom(plug) do
+  @spec call_plug!(Plug.Conn.t(), plug_def()) :: Plug.Conn.t() | no_return()
+  defp call_plug!(%Plug.Conn{} = conn, {plug, plug_opts}) when is_atom(plug) do
     case plug.call(conn, plug_opts) do
       %Plug.Conn{} = conn -> conn
       other -> raise("Expected #{plug}.call/2 to return %Plug.Conn{} but got: #{inspect(other)}")
     end
   end
 
-  defp call_plug(%Plug.Conn{} = conn, {plug_fn, plug_opts}) when is_function(plug_fn) do
+  defp call_plug!(%Plug.Conn{} = conn, {plug_fn, plug_opts}) when is_function(plug_fn) do
     case plug_fn.(conn, plug_opts) do
       %Plug.Conn{} = conn -> conn
       other -> raise("Expected Plug function to return %Plug.Conn{} but got: #{inspect(other)}")
     end
   end
 
-  @spec maybe_upgrade(Plug.Conn.t()) ::
-          {:ok, :no_upgrade} | {:ok, :websocket, Plug.Conn.t(), tuple()} | {:error, any()}
-  defp maybe_upgrade(
+  @spec maybe_upgrade!(Plug.Conn.t()) ::
+          {:no_upgrade, Plug.Conn.t()} | {:upgrade, Plug.Conn.t(), :websocket, tuple()}
+  defp maybe_upgrade!(
          %Plug.Conn{
            state: :upgraded,
            adapter:
@@ -129,17 +177,17 @@ defmodule Bandit.Pipeline do
            websocket_opts
          ) do
       {:ok, conn, connection_opts} ->
-        {:ok, :websocket, conn, {websock, websock_opts, connection_opts}}
+        {:upgrade, conn, :websocket, {websock, websock_opts, connection_opts}}
 
       {:error, reason} ->
-        {:error, reason}
+        request_error!(reason)
     end
   end
 
-  defp maybe_upgrade(_conn), do: {:ok, :no_upgrade}
+  defp maybe_upgrade!(conn), do: {:no_upgrade, conn}
 
-  @spec commit_response(Plug.Conn.t()) :: Plug.Conn.t() | no_return()
-  defp commit_response(conn) do
+  @spec commit_response!(Plug.Conn.t()) :: Plug.Conn.t() | no_return()
+  defp commit_response!(conn) do
     case conn do
       %Plug.Conn{state: :unset} ->
         raise(Plug.Conn.NotSentError)
@@ -159,5 +207,15 @@ defmodule Bandit.Pipeline do
       %Plug.Conn{} ->
         conn
     end
+    |> then(fn %Plug.Conn{adapter: {mod, adapter}} = conn ->
+      transport = Bandit.HTTPTransport.ensure_completed(adapter.transport)
+      %{conn | adapter: {mod, %{adapter | transport: transport}}}
+    end)
+  end
+
+  @spec request_error!(term()) :: no_return()
+  @spec request_error!(term(), atom()) :: no_return()
+  defp request_error!(reason, status \\ :bad_request) do
+    raise Bandit.HTTPError, message: reason, status: Plug.Conn.Status.code(status)
   end
 end

--- a/lib/bandit/telemetry.ex
+++ b/lib/bandit/telemetry.ex
@@ -21,6 +21,9 @@ defmodule Bandit.Telemetry do
       * `telemetry_span_context`: A unique identifier for this span
       * `connection_telemetry_span_context`: The span context of the Thousand Island `:connection`
         span which contains this request
+      * `conn`: The `Plug.Conn` representing this connection. Not present in cases where `error`
+        is also set and the nature of error is such that Bandit was unable to successfully build
+        the conn
 
   This span is ended by the following event:
 
@@ -51,8 +54,8 @@ defmodule Bandit.Telemetry do
       * `connection_telemetry_span_context`: The span context of the Thousand Island `:connection`
         span which contains this request
       * `conn`: The `Plug.Conn` representing this connection. Not present in cases where `error`
-        is also set
-      * `stream_id`: The stream ID of the request, if part of an HTTP/2 connection
+        is also set and the nature of error is such that Bandit was unable to successfully build
+        the conn
       * `error`: The error that caused the span to end, if it ended in error
 
   The following events may be emitted within this span:
@@ -70,6 +73,9 @@ defmodule Bandit.Telemetry do
       * `telemetry_span_context`: A unique identifier for this span
       * `connection_telemetry_span_context`: The span context of the Thousand Island `:connection`
         span which contains this request
+      * `conn`: The `Plug.Conn` representing this connection. Not present in cases where `error`
+        is also set and the nature of error is such that Bandit was unable to successfully build
+        the conn
       * `kind`: The kind of unexpected condition, typically `:exit`
       * `exception`: The exception which caused this unexpected termination
       * `stacktrace`: The stacktrace of the location which caused this unexpected termination
@@ -92,8 +98,6 @@ defmodule Bandit.Telemetry do
       This event contains the following metadata:
 
       * `telemetry_span_context`: A unique identifier for this span
-      * `origin_telemetry_span_context`: The span context of the Bandit `:request` span from which
-        this connection originated
       * `connection_telemetry_span_context`: The span context of the Thousand Island `:connection`
         span which contains this request
 

--- a/lib/bandit/transport_info.ex
+++ b/lib/bandit/transport_info.ex
@@ -11,18 +11,19 @@ defmodule Bandit.TransportInfo do
           peercert: :public_key.der_encoded() | nil
         }
 
-  @spec init(ThousandIsland.Socket.t()) :: {:ok, t()} | {:error, term()}
+  @spec init(ThousandIsland.Socket.t()) :: t()
   def init(socket) do
     with {:ok, sockname} <- ThousandIsland.Socket.sockname(socket),
          {:ok, peername} <- ThousandIsland.Socket.peername(socket),
          {:ok, peercert} <- peercert(socket) do
-      {:ok,
-       %__MODULE__{
-         secure?: ThousandIsland.Socket.secure?(socket),
-         sockname: sockname,
-         peername: peername,
-         peercert: peercert
-       }}
+      %__MODULE__{
+        secure?: ThousandIsland.Socket.secure?(socket),
+        sockname: sockname,
+        peername: peername,
+        peercert: peercert
+      }
+    else
+      {:error, reason} -> raise "Unable to obtain transport_info: #{inspect(reason)}"
     end
   end
 

--- a/lib/bandit/websocket/connection.ex
+++ b/lib/bandit/websocket/connection.ex
@@ -28,7 +28,7 @@ defmodule Bandit.WebSocket.Connection do
           metrics: map()
         }
 
-  def init(websock, websock_state, connection_opts, socket, origin_telemetry_span_context) do
+  def init(websock, websock_state, connection_opts, socket) do
     compress = Keyword.get(connection_opts, :compress)
 
     connection_telemetry_span_context =
@@ -36,8 +36,7 @@ defmodule Bandit.WebSocket.Connection do
 
     span =
       Bandit.Telemetry.start_span(:websocket, %{compress: compress}, %{
-        connection_telemetry_span_context: connection_telemetry_span_context,
-        origin_telemetry_span_context: origin_telemetry_span_context
+        connection_telemetry_span_context: connection_telemetry_span_context
       })
 
     instance = %__MODULE__{

--- a/lib/bandit/websocket/handler.ex
+++ b/lib/bandit/websocket/handler.ex
@@ -16,20 +16,12 @@ defmodule Bandit.WebSocket.Handler do
 
     connection_opts = Keyword.merge(state.opts.websocket, connection_opts)
 
-    origin_telemetry_span_context = state.origin_telemetry_span_context
-
     state =
       state
       |> Map.take([:handler_module])
       |> Map.put(:buffer, <<>>)
 
-    case Connection.init(
-           websock,
-           websock_opts,
-           connection_opts,
-           socket,
-           origin_telemetry_span_context
-         ) do
+    case Connection.init(websock, websock_opts, connection_opts, socket) do
       {:continue, connection} ->
         case Keyword.get(connection_opts, :timeout) do
           nil -> {:continue, Map.put(state, :connection, connection)}

--- a/test/bandit/headers_test.exs
+++ b/test/bandit/headers_test.exs
@@ -19,25 +19,29 @@ defmodule Bandit.HeadersTest do
 
     test "parses host and port for all valid ports" do
       for port <- @valid_ports do
-        assert {:ok, "banana", ^port} = Headers.parse_hostlike_header("banana:#{port}")
+        assert {"banana", ^port} = Headers.parse_hostlike_header!("banana:#{port}")
       end
     end
 
     test "parses host and port for ipv6 all valid ports" do
       for port <- @valid_ports do
-        assert {:ok, "[::1]", ^port} = Headers.parse_hostlike_header("[::1]:#{port}")
+        assert {"[::1]", ^port} = Headers.parse_hostlike_header!("[::1]:#{port}")
       end
     end
 
     test "returns error for invalid ports" do
       for port <- @invalid_ports do
-        assert {:error, @error_msg} = Headers.parse_hostlike_header("banana:#{port}")
+        assert_raise(Bandit.HTTPError, @error_msg, fn ->
+          Headers.parse_hostlike_header!("banana:#{port}")
+        end)
       end
     end
 
     test "returns error for ipv6 invalid ports" do
       for port <- @invalid_ports do
-        assert {:error, @error_msg} = Headers.parse_hostlike_header("[::1]:#{port}")
+        assert_raise(Bandit.HTTPError, @error_msg, fn ->
+          Headers.parse_hostlike_header!("[::1]:#{port}")
+        end)
       end
     end
   end

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -793,7 +793,7 @@ defmodule HTTP1RequestTest do
           Process.sleep(100)
         end)
 
-      assert errors =~ "HTTP method POST unsupported"
+      assert errors =~ "(Bandit.HTTPError) HTTP method POST unsupported"
     end
 
     test "returns a 400 and errors loudly in cases where an upgrade is indicated but upgrade header is incorrect",
@@ -819,7 +819,8 @@ defmodule HTTP1RequestTest do
           Process.sleep(100)
         end)
 
-      assert errors =~ "'upgrade' header must contain 'websocket', got [\\\"NOPE\\\"]"
+      assert errors =~
+               "(Bandit.HTTPError) 'upgrade' header must contain 'websocket', got [\"NOPE\"]"
     end
 
     test "returns a 400 and errors loudly in cases where an upgrade is indicated but connection header is incorrect",
@@ -845,7 +846,8 @@ defmodule HTTP1RequestTest do
           Process.sleep(100)
         end)
 
-      assert errors =~ "'connection' header must contain 'upgrade', got [\\\"NOPE\\\"]"
+      assert errors =~
+               "(Bandit.HTTPError) 'connection' header must contain 'upgrade', got [\"NOPE\"]"
     end
 
     test "returns a 400 and errors loudly in cases where an upgrade is indicated but key header is incorrect",
@@ -870,7 +872,7 @@ defmodule HTTP1RequestTest do
           Process.sleep(100)
         end)
 
-      assert errors =~ "'sec-websocket-key' header is absent"
+      assert errors =~ "(Bandit.HTTPError) 'sec-websocket-key' header is absent"
     end
 
     test "returns a 400 and errors loudly in cases where an upgrade is indicated but version header is incorrect",
@@ -896,7 +898,8 @@ defmodule HTTP1RequestTest do
           Process.sleep(100)
         end)
 
-      assert errors =~ "'sec-websocket-version' header must equal '13', got [\\\"99\\\"]"
+      assert errors =~
+               "(Bandit.HTTPError) 'sec-websocket-version' header must equal '13', got [\"99\"]"
     end
 
     test "returns a 400 and errors loudly if websocket support is not enabled", context do
@@ -1562,7 +1565,8 @@ defmodule HTTP1RequestTest do
                {[:bandit, :request, :start], %{monotonic_time: integer()},
                 %{
                   connection_telemetry_span_context: reference(),
-                  telemetry_span_context: reference()
+                  telemetry_span_context: reference(),
+                  conn: struct_like(Plug.Conn, [])
                 }}
              ]
     end
@@ -1799,8 +1803,7 @@ defmodule HTTP1RequestTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
-                  error: string(),
-                  status: 400
+                  error: string()
                 }}
              ]
     end
@@ -1820,8 +1823,7 @@ defmodule HTTP1RequestTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
-                  error: "Header read timeout",
-                  status: 408
+                  error: "Header read timeout"
                 }}
              ]
     end
@@ -1841,6 +1843,7 @@ defmodule HTTP1RequestTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
+                  conn: struct_like(Plug.Conn, []),
                   kind: :exit,
                   exception: %RuntimeError{message: "boom"},
                   stacktrace: list()

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -35,7 +35,7 @@ defmodule HTTP1RequestTest do
 
   describe "suppressing protocol error logging" do
     test "errors are not logged if so configured", context do
-      context = http_server(context, http_1_options: [log_protocol_errors: false])
+      context = http_server(context, http_options: [log_protocol_errors: false])
 
       output =
         capture_log(fn ->

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -684,12 +684,18 @@ defmodule HTTP1RequestTest do
          context do
       client = SimpleHTTP1Client.tcp_client(context)
 
-      Transport.send(
-        client,
-        "POST /short_body HTTP/1.1\r\nhost: localhost\r\ncontent-length: 5\r\n\r\nABC"
-      )
+      errors =
+        capture_log(fn ->
+          Transport.send(
+            client,
+            "POST /short_body HTTP/1.1\r\nhost: localhost\r\ncontent-length: 5\r\n\r\nABC"
+          )
 
-      assert {:ok, "200 OK", _, "OK"} = SimpleHTTP1Client.recv_reply(client)
+          assert {:ok, "200 OK", _, "OK"} = SimpleHTTP1Client.recv_reply(client)
+          Process.sleep(1100)
+        end)
+
+      assert errors =~ "(Bandit.HTTPError) Unable to read remaining data in request body"
     end
 
     def short_body(conn) do

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -789,9 +789,7 @@ defmodule HTTP1RequestTest do
             ]
           )
 
-          assert SimpleHTTP1Client.recv_reply(client)
-                 ~> {:ok, "400 Bad Request", list(), "HTTP method POST unsupported"}
-
+          assert SimpleHTTP1Client.recv_reply(client) ~> {:ok, "400 Bad Request", list(), ""}
           Process.sleep(100)
         end)
 
@@ -817,10 +815,7 @@ defmodule HTTP1RequestTest do
             ]
           )
 
-          assert SimpleHTTP1Client.recv_reply(client)
-                 ~> {:ok, "400 Bad Request", list(),
-                  "'upgrade' header must contain 'websocket', got [\"NOPE\"]"}
-
+          assert SimpleHTTP1Client.recv_reply(client) ~> {:ok, "400 Bad Request", list(), ""}
           Process.sleep(100)
         end)
 
@@ -846,10 +841,7 @@ defmodule HTTP1RequestTest do
             ]
           )
 
-          assert SimpleHTTP1Client.recv_reply(client)
-                 ~> {:ok, "400 Bad Request", list(),
-                  "'connection' header must contain 'upgrade', got [\"NOPE\"]"}
-
+          assert SimpleHTTP1Client.recv_reply(client) ~> {:ok, "400 Bad Request", list(), ""}
           Process.sleep(100)
         end)
 
@@ -874,9 +866,7 @@ defmodule HTTP1RequestTest do
             ]
           )
 
-          assert SimpleHTTP1Client.recv_reply(client)
-                 ~> {:ok, "400 Bad Request", list(), "'sec-websocket-key' header is absent"}
-
+          assert SimpleHTTP1Client.recv_reply(client) ~> {:ok, "400 Bad Request", list(), ""}
           Process.sleep(100)
         end)
 
@@ -902,10 +892,7 @@ defmodule HTTP1RequestTest do
             ]
           )
 
-          assert SimpleHTTP1Client.recv_reply(client)
-                 ~> {:ok, "400 Bad Request", list(),
-                  "'sec-websocket-version' header must equal '13', got [\"99\"]"}
-
+          assert SimpleHTTP1Client.recv_reply(client) ~> {:ok, "400 Bad Request", list(), ""}
           Process.sleep(100)
         end)
 

--- a/test/bandit/http2/plug_test.exs
+++ b/test/bandit/http2/plug_test.exs
@@ -669,7 +669,7 @@ defmodule HTTP2PlugTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
-                  stream_id: integer()
+                  conn: struct_like(Plug.Conn, [])
                 }}
              ]
     end
@@ -698,8 +698,7 @@ defmodule HTTP2PlugTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
-                  conn: struct_like(Plug.Conn, []),
-                  stream_id: integer()
+                  conn: struct_like(Plug.Conn, [])
                 }}
              ]
     end
@@ -728,8 +727,7 @@ defmodule HTTP2PlugTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
-                  conn: struct_like(Plug.Conn, []),
-                  stream_id: integer()
+                  conn: struct_like(Plug.Conn, [])
                 }}
              ]
     end
@@ -762,8 +760,7 @@ defmodule HTTP2PlugTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
-                  conn: struct_like(Plug.Conn, []),
-                  stream_id: integer()
+                  conn: struct_like(Plug.Conn, [])
                 }}
              ]
     end
@@ -798,8 +795,7 @@ defmodule HTTP2PlugTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
-                  conn: struct_like(Plug.Conn, []),
-                  stream_id: integer()
+                  conn: struct_like(Plug.Conn, [])
                 }}
              ]
     end
@@ -824,8 +820,7 @@ defmodule HTTP2PlugTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
-                  conn: struct_like(Plug.Conn, []),
-                  stream_id: integer()
+                  conn: struct_like(Plug.Conn, [])
                 }}
              ]
     end
@@ -850,8 +845,7 @@ defmodule HTTP2PlugTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
-                  conn: struct_like(Plug.Conn, []),
-                  stream_id: integer()
+                  conn: struct_like(Plug.Conn, [])
                 }}
              ]
     end
@@ -878,7 +872,6 @@ defmodule HTTP2PlugTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
-                  stream_id: integer(),
                   error: string()
                 }}
              ]
@@ -899,7 +892,7 @@ defmodule HTTP2PlugTest do
                 %{
                   connection_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
-                  stream_id: integer(),
+                  conn: struct_like(Plug.Conn, []),
                   kind: :exit,
                   exception: %RuntimeError{message: "boom"},
                   stacktrace: list()

--- a/test/bandit/http2/protocol_test.exs
+++ b/test/bandit/http2/protocol_test.exs
@@ -2148,7 +2148,7 @@ defmodule HTTP2ProtocolTest do
       ]
 
       SimpleH2Client.send_headers(socket, 1, true, headers)
-      assert SimpleH2Client.recv_rst_stream(socket) == {:ok, 1, 2}
+      assert SimpleH2Client.recv_rst_stream(socket) == {:ok, 1, 1}
     end
 
     test "derives port from host header", context do
@@ -2215,7 +2215,7 @@ defmodule HTTP2ProtocolTest do
       ]
 
       SimpleH2Client.send_headers(socket, 1, true, headers)
-      assert SimpleH2Client.recv_rst_stream(socket) == {:ok, 1, 2}
+      assert SimpleH2Client.recv_rst_stream(socket) == {:ok, 1, 1}
     end
 
     test "derives port from schema default if no port specified in host header", context do

--- a/test/bandit/http2/protocol_test.exs
+++ b/test/bandit/http2/protocol_test.exs
@@ -112,6 +112,27 @@ defmodule HTTP2ProtocolTest do
                "(Bandit.HTTP2.Errors.StreamError) Received trailers with pseudo headers"
     end
 
+    test "stream errors are not logged if so configured", context do
+      context =
+        context
+        |> https_server(http_options: [log_protocol_errors: false])
+        |> Enum.into(context)
+
+      socket = SimpleH2Client.tls_client(context)
+      SimpleH2Client.exchange_prefaces(socket)
+
+      output =
+        capture_log(fn ->
+          # Send trailers with pseudo headers
+          {:ok, ctx} = SimpleH2Client.send_simple_headers(socket, 1, :post, "/echo", context.port)
+          SimpleH2Client.send_headers(socket, 1, true, [{":path", "/foo"}], ctx)
+          assert SimpleH2Client.recv_rst_stream(socket) == {:ok, 1, 1}
+          Process.sleep(100)
+        end)
+
+      assert output == ""
+    end
+
     @tag capture_log: true
     test "it should shut down the connection after read timeout has been reached with no initial data sent",
          context do

--- a/test/bandit/websocket/sock_test.exs
+++ b/test/bandit/websocket/sock_test.exs
@@ -1284,7 +1284,6 @@ defmodule WebSocketWebSockTest do
                 %{monotonic_time: integer(), compress: maybe(boolean())},
                 %{
                   connection_telemetry_span_context: reference(),
-                  origin_telemetry_span_context: reference(),
                   telemetry_span_context: reference()
                 }}
              ]
@@ -1328,7 +1327,6 @@ defmodule WebSocketWebSockTest do
                 },
                 %{
                   connection_telemetry_span_context: reference(),
-                  origin_telemetry_span_context: reference(),
                   telemetry_span_context: reference()
                 }}
              ]
@@ -1354,7 +1352,6 @@ defmodule WebSocketWebSockTest do
                 },
                 %{
                   connection_telemetry_span_context: reference(),
-                  origin_telemetry_span_context: reference(),
                   telemetry_span_context: reference()
                 }}
              ]
@@ -1380,7 +1377,6 @@ defmodule WebSocketWebSockTest do
                 },
                 %{
                   connection_telemetry_span_context: reference(),
-                  origin_telemetry_span_context: reference(),
                   telemetry_span_context: reference()
                 }}
              ]
@@ -1400,7 +1396,6 @@ defmodule WebSocketWebSockTest do
                {[:bandit, :websocket, :stop], %{monotonic_time: integer(), duration: integer()},
                 %{
                   connection_telemetry_span_context: reference(),
-                  origin_telemetry_span_context: reference(),
                   telemetry_span_context: reference()
                 }}
              ]
@@ -1427,7 +1422,6 @@ defmodule WebSocketWebSockTest do
                 },
                 %{
                   connection_telemetry_span_context: reference(),
-                  origin_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
                   error: :nope
                 }}
@@ -1447,7 +1441,6 @@ defmodule WebSocketWebSockTest do
                {[:bandit, :websocket, :stop], %{monotonic_time: integer(), duration: integer()},
                 %{
                   connection_telemetry_span_context: reference(),
-                  origin_telemetry_span_context: reference(),
                   telemetry_span_context: reference(),
                   error: :timeout
                 }}


### PR DESCRIPTION
DRYs up a bunch of logic in `Bandit.HTTP1.Handler` and `Bandit.HTTP2.StreamProcess`, folding it into a common path in `Bandit.Pipeline`