### PR TITLE
Support top-level :inet and :inet6 options in Phoenix

### DIFF
--- a/lib/bandit/phoenix_adapter.ex
+++ b/lib/bandit/phoenix_adapter.ex
@@ -74,8 +74,7 @@ defmodule Bandit.PhoenixAdapter do
     plug = resolve_plug(config[:code_reloader], endpoint)
 
     for scheme <- [:http, :https], opts = config[scheme] do
-      opts
-      |> Keyword.merge(plug: plug, display_plug: endpoint, scheme: scheme, otp_app: otp_app)
+      ([plug: plug, display_plug: endpoint, scheme: scheme, otp_app: otp_app] ++ opts)
       |> Bandit.child_spec()
       |> Supervisor.child_spec(id: {endpoint, scheme})
     end

--- a/test/bandit/server_test.exs
+++ b/test/bandit/server_test.exs
@@ -37,6 +37,24 @@ defmodule ServerTest do
              "Running ServerTest with Bandit #{Application.spec(:bandit)[:vsn]} at http failed, port #{port} already in use"
   end
 
+  test "special cases :inet option" do
+    logs =
+      capture_log(fn ->
+        start_supervised({Bandit, [{:plug, __MODULE__}, :inet, {:port, 0}, {:ip, :loopback}]})
+      end)
+
+    assert logs =~ "at 127.0.0.1"
+  end
+
+  test "special cases :inet6 option" do
+    logs =
+      capture_log(fn ->
+        start_supervised({Bandit, [{:plug, __MODULE__}, :inet6, {:port, 0}, {:ip, :loopback}]})
+      end)
+
+    assert logs =~ "at ::1"
+  end
+
   test "can run multiple instances of Bandit" do
     start_supervised({Bandit, plug: __MODULE__, port: 4000})
     start_supervised({Bandit, plug: __MODULE__, port: 4001})


### PR DESCRIPTION
Done in to the Phoenix adapter because it's an oddball thing that I don't want Bandit to support at the top level. It's a shim, not a feature.