### PR TITLE
Improve error handling from plug-surfaced errors

### DIFF
--- a/lib/bandit.ex
+++ b/lib/bandit.ex
@@ -101,12 +101,16 @@ defmodule Bandit do
     [RFC9110§8.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4). Defaults to true
   * `deflate_options`: A keyword list of options to set on the deflate library. A complete list can
     be found at `t:deflate_options/0`
+  * `log_exceptions_with_status_codes`: Which exceptions to log. Bandit will log only those
+    exceptions whose status codes (as determined by `Plug.Exception.status/1`) match the specified
+    list or range. Defaults to `500..599`
   * `log_protocol_errors`: Whether or not to log protocol errors such as malformed requests.
     Defaults to `true`
   """
   @type http_options :: [
           {:compress, boolean()}
           | {:deflate_opions, deflate_options()}
+          | {:log_exceptions_with_status_codes, list() | Range.t()}
           | {:log_protocol_errors, boolean()}
         ]
 
@@ -204,7 +208,7 @@ defmodule Bandit do
   end
 
   @top_level_keys ~w(plug scheme port ip keyfile certfile otp_app cipher_suite display_plug startup_log thousand_island_options http_options http_1_options http_2_options websocket_options)a
-  @http_keys ~w(compress deflate_options log_protocol_errors)a
+  @http_keys ~w(compress deflate_options log_exceptions_with_status_codes log_protocol_errors)a
   @http_1_keys ~w(enabled max_request_line_length max_header_length max_header_count max_requests gc_every_n_keepalive_requests log_unknown_messages)a
   @http_2_keys ~w(enabled max_header_block_size max_requests default_local_settings)a
   @websocket_keys ~w(enabled max_frame_size validate_text_frames compress)a

--- a/lib/bandit/http1/socket.ex
+++ b/lib/bandit/http1/socket.ex
@@ -382,30 +382,20 @@ defmodule Bandit.HTTP1.Socket do
 
     def supported_upgrade?(_socket, protocol), do: protocol == :websocket
 
-    def send_on_error(%@for{} = socket, %Bandit.HTTPError{} = error) do
-      socket = maybe_send_error(socket, error.status)
-      %{socket | write_state: :sent}
-    end
-
     def send_on_error(%@for{} = socket, error) do
-      socket = maybe_send_error(socket, Plug.Exception.status(error))
-      %{socket | write_state: :sent}
-    end
-
-    defp maybe_send_error(socket, error) do
       receive do
-        {:plug_conn, :sent} -> socket
+        {:plug_conn, :sent} -> %{socket | write_state: :sent}
       after
         0 ->
-          status = error |> Plug.Conn.Status.code()
+          status = error |> Plug.Exception.status() |> Plug.Conn.Status.code()
           send_headers(socket, status, [], :no_body)
       end
     end
 
     @spec request_error!(term()) :: no_return()
-    @spec request_error!(term(), atom()) :: no_return()
-    defp request_error!(reason, status \\ :bad_request) do
-      raise Bandit.HTTPError, message: to_string(reason), status: Plug.Conn.Status.code(status)
+    @spec request_error!(term(), Plug.Conn.status()) :: no_return()
+    defp request_error!(reason, plug_status \\ :bad_request) do
+      raise Bandit.HTTPError, message: to_string(reason), plug_status: plug_status
     end
   end
 end

--- a/lib/bandit/http2/stream.ex
+++ b/lib/bandit/http2/stream.ex
@@ -504,11 +504,6 @@ defmodule Bandit.HTTP2.Stream do
 
     def supported_upgrade?(_stream, _protocol), do: false
 
-    def send_on_error(%@for{} = stream, %Bandit.HTTPError{}) do
-      do_send(stream, {:send_rst_stream, Bandit.HTTP2.Errors.protocol_error()})
-      %{stream | state: :closed}
-    end
-
     def send_on_error(%@for{} = stream, %Bandit.HTTP2.Errors.StreamError{} = error) do
       do_send(stream, {:send_rst_stream, error.error_code})
       %{stream | state: :closed}

--- a/lib/bandit/http_error.ex
+++ b/lib/bandit/http_error.ex
@@ -2,5 +2,5 @@ defmodule Bandit.HTTPError do
   # Represents an error suitable for return as an HTTP status. Note that these may be surfaced
   # from anywhere that such a message is well defined, including within HTTP/1 transport concerns
   # and also within shared HTTP semantics (ie: within Bandit.Adapter or Bandit.Pipeline)
-  defexception message: nil, status: 400
+  defexception message: nil, plug_status: :bad_request
 end

--- a/lib/bandit/pipeline.ex
+++ b/lib/bandit/pipeline.ex
@@ -214,8 +214,8 @@ defmodule Bandit.Pipeline do
   end
 
   @spec request_error!(term()) :: no_return()
-  @spec request_error!(term(), atom()) :: no_return()
-  defp request_error!(reason, status \\ :bad_request) do
-    raise Bandit.HTTPError, message: reason, status: Plug.Conn.Status.code(status)
+  @spec request_error!(term(), Plug.Conn.status()) :: no_return()
+  defp request_error!(reason, plug_status \\ :bad_request) do
+    raise Bandit.HTTPError, message: reason, plug_status: plug_status
   end
 end

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -65,10 +65,26 @@ defmodule HTTP1RequestTest do
       raise "boom"
     end
 
-    test "it should return the code and log when known exceptions are raised", context do
+    test "it should return the code and not log when known exceptions are raised", context do
       output =
         capture_log(fn ->
           {:ok, response} = Req.get(context.req, url: "/known_crasher")
+          assert response.status == 418
+          Process.sleep(100)
+        end)
+
+      assert output == ""
+    end
+
+    test "it should log known exceptions if so configured", context do
+      context =
+        context
+        |> http_server(http_options: [log_exceptions_with_status_codes: 100..599])
+        |> Enum.into(context)
+
+      output =
+        capture_log(fn ->
+          {:ok, response} = Req.get(context.req, url: "/known_crasher", base_url: context.base)
           assert response.status == 418
           Process.sleep(100)
         end)
@@ -121,6 +137,15 @@ defmodule HTTP1RequestTest do
       SimpleHTTP1Client.send(client, "GET", "/echo_components", ["host: banana"])
       assert {:ok, "200 OK", _headers, _} = SimpleHTTP1Client.recv_reply(client)
 
+      assert SimpleHTTP1Client.connection_closed_for_reading?(client)
+    end
+
+    test "closes connection after exception is raised (for safety)", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "GET", "/known_crasher", ["host: banana"])
+
+      assert {:ok, "418 I'm a teapot", _headers, _} = SimpleHTTP1Client.recv_reply(client)
       assert SimpleHTTP1Client.connection_closed_for_reading?(client)
     end
 

--- a/test/bandit/http2/protocol_test.exs
+++ b/test/bandit/http2/protocol_test.exs
@@ -2309,7 +2309,7 @@ defmodule HTTP2ProtocolTest do
       assert Jason.decode!(body)["host"] == "banana"
     end
 
-    test "resets stream if no host header set", context do
+    test "sends 400 if no host header set", context do
       output =
         capture_log(fn ->
           socket = SimpleH2Client.setup_connection(context)
@@ -2321,7 +2321,7 @@ defmodule HTTP2ProtocolTest do
           ]
 
           SimpleH2Client.send_headers(socket, 1, true, headers)
-          assert SimpleH2Client.recv_rst_stream(socket) == {:ok, 1, 1}
+          assert {:ok, 1, true, [{":status", "400"} | _], _} = SimpleH2Client.recv_headers(socket)
           Process.sleep(100)
         end)
 
@@ -2380,7 +2380,7 @@ defmodule HTTP2ProtocolTest do
       assert Jason.decode!(body)["port"] == 1234
     end
 
-    test "resets stream if port cannot be parsed from host header", context do
+    test "sends 400 if port cannot be parsed from host header", context do
       output =
         capture_log(fn ->
           socket = SimpleH2Client.setup_connection(context)
@@ -2393,7 +2393,7 @@ defmodule HTTP2ProtocolTest do
           ]
 
           SimpleH2Client.send_headers(socket, 1, true, headers)
-          assert SimpleH2Client.recv_rst_stream(socket) == {:ok, 1, 1}
+          assert {:ok, 1, true, [{":status", "400"} | _], _} = SimpleH2Client.recv_headers(socket)
           Process.sleep(100)
         end)
 

--- a/test/bandit/http2/protocol_test.exs
+++ b/test/bandit/http2/protocol_test.exs
@@ -1765,31 +1765,6 @@ defmodule HTTP2ProtocolTest do
       assert SimpleH2Client.recv_goaway_and_close(socket) == {:ok, 1, 0}
     end
 
-    test "sends RST_FRAME with error if stream task crashes", context do
-      output =
-        capture_log(fn ->
-          socket = SimpleH2Client.setup_connection(context)
-
-          SimpleH2Client.send_simple_headers(socket, 1, :get, "/crasher", context.port)
-          SimpleH2Client.recv_headers(socket)
-          SimpleH2Client.recv_body(socket)
-
-          assert SimpleH2Client.recv_rst_stream(socket) == {:ok, 1, 2}
-          assert SimpleH2Client.connection_alive?(socket)
-          Process.sleep(100)
-        end)
-
-      assert output =~ "(RuntimeError) boom"
-    end
-
-    def crasher(conn) do
-      conn
-      |> send_chunked(200)
-      |> chunk("OK")
-
-      raise "boom"
-    end
-
     test "sends RST_FRAME with internal error if we don't set a response with a closed client",
          context do
       socket = SimpleH2Client.setup_connection(context)

--- a/test/support/safe_error.ex
+++ b/test/support/safe_error.ex
@@ -1,0 +1,8 @@
+defmodule SafeError do
+  defexception(message: nil)
+
+  defimpl Plug.Exception do
+    def status(_), do: :im_a_teapot
+    def actions(_), do: []
+  end
+end


### PR DESCRIPTION
* [x] HTTP/1 stack respects `Plug.Exception` error implementations
* [x] HTTP/2 stack respects `Plug.Exception` error implementations 
* [x] `Bandit.HTTPError` error codes implemented using `Plug.Exception` conventions
* [x] Logging made conditional on an exception's `Plug.Exception` sourced status code
* [x] Ensure HTTP/1 connections are closed on error for safety