### PR TITLE
Respect pre-computed content-length for HEAD responses

### DIFF
--- a/lib/bandit/adapter.ex
+++ b/lib/bandit/adapter.ex
@@ -126,10 +126,8 @@ defmodule Bandit.Adapter do
     compress = Keyword.get(adapter.opts.http, :compress, true)
     headers = if compress, do: [{"vary", "accept-encoding"} | headers], else: headers
 
-    headers =
-      if Bandit.Headers.override_content_length?(headers, status, adapter.method),
-        do: Bandit.Headers.add_content_length(headers, IO.iodata_length(body), status),
-        else: headers
+    length = IO.iodata_length(body)
+    headers = Bandit.Headers.add_content_length(headers, length, status, adapter.method)
 
     metrics =
       adapter.metrics
@@ -159,7 +157,7 @@ defmodule Bandit.Adapter do
     length = if length == :all, do: size - offset, else: length
 
     if offset + length <= size do
-      headers = Bandit.Headers.add_content_length(headers, length, status)
+      headers = Bandit.Headers.add_content_length(headers, length, status, adapter.method)
       adapter = send_headers(adapter, status, headers, :raw)
 
       {socket, bytes_actually_written} =

--- a/lib/bandit/adapter.ex
+++ b/lib/bandit/adapter.ex
@@ -125,7 +125,11 @@ defmodule Bandit.Adapter do
 
     compress = Keyword.get(adapter.opts.http, :compress, true)
     headers = if compress, do: [{"vary", "accept-encoding"} | headers], else: headers
-    headers = Bandit.Headers.add_content_length(headers, IO.iodata_length(body), status)
+
+    headers =
+      if Bandit.Headers.override_content_length?(headers, status, adapter.method),
+        do: Bandit.Headers.add_content_length(headers, IO.iodata_length(body), status),
+        else: headers
 
     metrics =
       adapter.metrics

--- a/lib/bandit/headers.ex
+++ b/lib/bandit/headers.ex
@@ -95,7 +95,7 @@ defmodule Bandit.Headers do
         ) ::
           Plug.Conn.headers()
 
-  # For HEAD responses, respect existing the content-length header (if set)
+  # For HEAD responses, respect the existing content-length header (if set)
   # EXCEPT if the status code forbids a content-length header.
   # If content-length is not set, the server will not send a content-length header.
   def add_content_length(headers, 0, status, "HEAD") do

--- a/lib/bandit/headers.ex
+++ b/lib/bandit/headers.ex
@@ -87,36 +87,41 @@ defmodule Bandit.Headers do
 
   defp parse_integer(rest, total), do: {total, rest}
 
-  @spec add_content_length(Plug.Conn.headers(), non_neg_integer(), Plug.Conn.int_status()) ::
+  @spec add_content_length(
+          headers :: Plug.Conn.headers(),
+          length :: non_neg_integer(),
+          status :: Plug.Conn.int_status(),
+          method :: Plug.Conn.method()
+        ) ::
           Plug.Conn.headers()
-  def add_content_length(headers, length, status) do
-    headers = Enum.reject(headers, &(elem(&1, 0) == "content-length"))
 
-    if add_content_length?(status),
+  # For HEAD responses, respect existing the content-length header (if set)
+  # EXCEPT if the status code forbids a content-length header.
+  # If content-length is not set, the server will not send a content-length header.
+  def add_content_length(headers, 0, status, "HEAD") do
+    if send_content_length?(status),
+      do: headers,
+      else: drop_content_length(headers)
+  end
+
+  # For non-HEAD responses, override the existing content-length header.
+  def add_content_length(headers, length, status, _method) do
+    headers = drop_content_length(headers)
+
+    if send_content_length?(status),
       do: [{"content-length", to_string(length)} | headers],
       else: headers
   end
 
-  # Respect the content-length header (if set) for valid HEAD responses
-  # so that the handler can avoid rendering the body to specify its length.
-  @spec override_content_length?(
-          headers :: Plug.Conn.headers(),
-          status :: Plug.Conn.int_status(),
-          method :: Plug.Conn.method()
-        ) ::
-          boolean()
-
-  def override_content_length?(headers, status, "HEAD") do
-    value = get_header(headers, "content-length")
-    is_nil(value) or not add_content_length?(status)
+  @spec drop_content_length(Plug.Conn.headers()) :: Plug.Conn.headers()
+  defp drop_content_length(headers) do
+    Enum.reject(headers, &(elem(&1, 0) == "content-length"))
   end
 
-  def override_content_length?(_headers, _status, _method), do: true
-
   # Per RFC9110§8.6
-  @spec add_content_length?(Plug.Conn.int_status()) :: boolean()
-  defp add_content_length?(status) when status in 100..199, do: false
-  defp add_content_length?(204), do: false
-  defp add_content_length?(304), do: false
-  defp add_content_length?(_), do: true
+  @spec send_content_length?(Plug.Conn.int_status()) :: boolean()
+  defp send_content_length?(status) when status in 100..199, do: false
+  defp send_content_length?(204), do: false
+  defp send_content_length?(304), do: false
+  defp send_content_length?(_), do: true
 end

--- a/lib/bandit/headers.ex
+++ b/lib/bandit/headers.ex
@@ -97,6 +97,22 @@ defmodule Bandit.Headers do
       else: headers
   end
 
+  # Respect the content-length header (if set) for valid HEAD responses
+  # so that the handler can avoid rendering the body to specify its length.
+  @spec override_content_length?(
+          headers :: Plug.Conn.headers(),
+          status :: Plug.Conn.int_status(),
+          method :: Plug.Conn.method()
+        ) ::
+          boolean()
+
+  def override_content_length?(headers, status, "HEAD") do
+    value = get_header(headers, "content-length")
+    is_nil(value) or not add_content_length?(status)
+  end
+
+  def override_content_length?(_headers, _status, _method), do: true
+
   # Per RFC9110§8.6
   @spec add_content_length?(Plug.Conn.int_status()) :: boolean()
   defp add_content_length?(status) when status in 100..199, do: false

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -1360,12 +1360,35 @@ defmodule HTTP1RequestTest do
       assert Bandit.Headers.get_header(headers, :"content-length") == "10000"
     end
 
+    test "respects provided content-length headers for HEAD responses", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+      SimpleHTTP1Client.send(client, "HEAD", "/head_preserve_content_length", ["host: localhost"])
+
+      assert {:ok, "200 OK", headers, ""} = SimpleHTTP1Client.recv_reply(client, true)
+      assert Bandit.Headers.get_header(headers, :"content-length") == "10001"
+    end
+
+    def head_preserve_content_length(conn) do
+      conn
+      |> put_resp_header("content-length", "10001")
+      |> send_resp(200, "")
+    end
+
     test "replaces any incorrect provided content-length headers", context do
       response = Req.get!(context.req, url: "/send_incorrect_content_length")
 
       assert response.status == 200
       assert response.headers["content-length"] == ["10000"]
       assert response.body == String.duplicate("a", 10_000)
+    end
+
+    test "replaces any incorrect provided content-length headers for HEAD responses", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "HEAD", "/send_incorrect_content_length", ["host: localhost"])
+
+      assert {:ok, "200 OK", headers, ""} = SimpleHTTP1Client.recv_reply(client, true)
+      assert Bandit.Headers.get_header(headers, :"content-length") == "10000"
     end
 
     def send_incorrect_content_length(conn) do
@@ -1406,6 +1429,14 @@ defmodule HTTP1RequestTest do
       assert response.status == 200
       assert response.body == ""
       assert response.headers["content-length"] == ["0"]
+    end
+
+    test "writes out a response omitting content-length for HEAD 200 responses", context do
+      response = Req.head!(context.req, url: "/send_200")
+
+      assert response.status == 200
+      assert response.body == ""
+      assert response.headers["content-length"] == nil
     end
 
     def send_200(conn) do

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -1443,6 +1443,20 @@ defmodule HTTP1RequestTest do
       send_resp(conn, 200, "")
     end
 
+    test "writes out a response with zero content-length for HEAD 200 responses", context do
+      response = Req.head!(context.req, url: "/send_200_zero_content_length")
+
+      assert response.status == 200
+      assert response.body == ""
+      assert response.headers["content-length"] == ["0"]
+    end
+
+    def send_200_zero_content_length(conn) do
+      conn
+      |> put_resp_header("content-length", "0")
+      |> send_resp(200, "")
+    end
+
     test "writes out a response with zero content-length for 301 responses", context do
       response = Req.get!(context.req, url: "/send_301")
 

--- a/test/bandit/http2/plug_test.exs
+++ b/test/bandit/http2/plug_test.exs
@@ -214,11 +214,10 @@ defmodule HTTP2PlugTest do
     response = Req.head!(context.req, url: "/header_write_test")
 
     assert response.status == 200
-    assert map_size(response.headers) == 5
+    assert map_size(response.headers) == 4
 
     assert %{
              "date" => [date],
-             "content-length" => ["0"],
              "vary" => ["accept-encoding"],
              "cache-control" => ["max-age=0, private, must-revalidate"],
              "X-Response-Header" => ["Response"]
@@ -239,7 +238,6 @@ defmodule HTTP2PlugTest do
     assert response.status == 200
 
     assert response.headers == %{
-             "content-length" => ["0"],
              "vary" => ["accept-encoding"],
              "cache-control" => ["max-age=0, private, must-revalidate"],
              "date" => ["Tue, 27 Sep 2022 07:17:32 GMT"]
@@ -250,6 +248,43 @@ defmodule HTTP2PlugTest do
     conn
     |> put_resp_header("date", "Tue, 27 Sep 2022 07:17:32 GMT")
     |> send_resp(200, <<>>)
+  end
+
+  test "omitting HEAD response content-length", context do
+    response = Req.head!(context.req, url: "/head_omit_content_length_test")
+
+    assert response.status == 200
+    assert response.headers["content-length"] == nil
+  end
+
+  def head_omit_content_length_test(conn) do
+    conn |> send_resp(200, <<>>)
+  end
+
+  test "respecting user-defined HEAD response content-length", context do
+    response = Req.head!(context.req, url: "/head_preserve_content_length_test")
+
+    assert response.status == 200
+    assert response.headers["content-length"] == ["6"]
+  end
+
+  def head_preserve_content_length_test(conn) do
+    conn
+    |> put_resp_header("content-length", "6")
+    |> send_resp(200, <<>>)
+  end
+
+  test "overriding user-defined HEAD response content-length", context do
+    response = Req.head!(context.req, url: "/head_override_content_length_test")
+
+    assert response.status == 200
+    assert response.headers["content-length"] == ["2"]
+  end
+
+  def head_override_content_length_test(conn) do
+    conn
+    |> put_resp_header("content-length", "6")
+    |> send_resp(200, "OK")
   end
 
   test "sending a body", context do

--- a/test/bandit/http2/plug_test.exs
+++ b/test/bandit/http2/plug_test.exs
@@ -274,7 +274,20 @@ defmodule HTTP2PlugTest do
     |> send_resp(200, <<>>)
   end
 
-  test "overriding user-defined HEAD response content-length", context do
+  test "respecting user-defined HEAD response content-length: 0", context do
+    response = Req.head!(context.req, url: "/head_zero_content_length_test")
+
+    assert response.status == 200
+    assert response.headers["content-length"] == ["0"]
+  end
+
+  def head_zero_content_length_test(conn) do
+    conn
+    |> put_resp_header("content-length", "0")
+    |> send_resp(200, <<>>)
+  end
+
+  test "overriding incorrect user-defined HEAD response content-length", context do
     response = Req.head!(context.req, url: "/head_override_content_length_test")
 
     assert response.status == 200


### PR DESCRIPTION
I have an application that streams extremely large payloads. Due to reasons beyond my control, HEAD requests must respond with HTTP status 200, so my Plug handler sends with:

```elixir
conn
|> Plug.Conn.put_resp_header("content-length", payload_size)
|> Plug.Conn.send_resp(200, "")
```

However, `Bandit.Headers.add_content_length/3` replaces my application's "content-length" header with `content-length: 0`. 

As it stands the only way for me to set "content-length" on a HEAD 200 response seems to be to either wastefully render the full response or allocate a body of "content-length"-size and pass it into `send_resp`, but this is not practical or efficient. It also seems to violate the spirit of [RFC9110 § 9.3.2](https://www.rfc-editor.org/rfc/rfc9110.html#HEAD):

>  A client SHOULD NOT generate content in a HEAD request unless it is made directly to an origin server that has previously indicated, in or out of band, that such a request has a purpose and will be adequately supported.

This patch introduces a simple, reasonably-safe heuristic to preserve the application's intent: if a HEAD response handler sets the content-length response header, treat it as the size of the body that would have been sent; [RFC9110 §8.6](https://www.rfc-editor.org/rfc/rfc9110.html#name-content-length):

>A server MAY send a Content-Length header field in a response to a HEAD request; a server MUST NOT send Content-Length in such a response unless its field value equals the decimal number of octets that would have been sent in the content of a response if the same request had used the GET method. [...] A server MUST NOT send a Content-Length header field in any response with a status code of **1xx (Informational)** or **204 (No Content)**.