### PR TITLE
accept hpax 1.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule Bandit.MixProject do
       {:thousand_island, "~> 1.0"},
       {:plug, "~> 1.14"},
       {:websock, "~> 0.5"},
-      {:hpax, "~> 0.2.0"},
+      {:hpax, "~> 0.2.0 or ~> 1.0"},
       {:telemetry, "~> 0.4 or ~> 1.0"},
       {:req, "~> 0.3", only: [:dev, :test]},
       {:machete, ">= 0.0.0", only: [:dev, :test]},


### PR DESCRIPTION
Hi 👋

`hpax` 1.0.0 upgrade just removes a warning when compiling in Elixir 1.17:

```elixir
warning: 62..@dynamic_table_start + length - 1 inside guards requires an explicit step, please write 62..@dynamic_table_start + length - 1//1 or 62..@dynamic_table_start + length - 1//-1 instead
  lib/hpax/table.ex:160: HPAX.Table.lookup_by_index/2
```

Thanks!