### PR TITLE
Build iolist for WebSocket frame data

### DIFF
--- a/lib/bandit/websocket/extractor.ex
+++ b/lib/bandit/websocket/extractor.ex
@@ -1,0 +1,94 @@
+defmodule Bandit.WebSocket.Extractor do
+  @moduledoc false
+  # A state machine for efficiently extracting full frames from received packets
+
+  alias Bandit.WebSocket.Frame
+
+  @type t :: %__MODULE__{
+          header: binary(),
+          payload: iodata(),
+          payload_length: non_neg_integer(),
+          required_length: non_neg_integer(),
+          mode: :header_parsing | :payload_parsing,
+          max_frame_size: non_neg_integer()
+        }
+
+  defstruct header: <<>>,
+            payload: [],
+            payload_length: 0,
+            required_length: 0,
+            mode: :header_parsing,
+            max_frame_size: 0
+
+  @spec new(Keyword.t()) :: t()
+  def new(opts) do
+    max_frame_size = Keyword.get(opts, :max_frame_size, 0)
+
+    %__MODULE__{
+      max_frame_size: max_frame_size
+    }
+  end
+
+  @spec push_data(t(), binary()) :: t()
+  def push_data(%__MODULE__{} = state, data) do
+    case state do
+      %{mode: :header_parsing} ->
+        %{state | header: state.header <> data}
+
+      %{mode: :payload_parsing, payload: payload, payload_length: length} ->
+        %{state | payload: [payload, data], payload_length: length + byte_size(data)}
+    end
+  end
+
+  @spec pop_frame(t()) :: {t(), {:ok, Frame.frame()} | {:error, term()} | :more}
+  def pop_frame(state)
+
+  def pop_frame(%__MODULE__{mode: :header_parsing} = state) do
+    case Frame.header_and_payload_length(state.header, state.max_frame_size) do
+      {:ok, {header_length, required_length}} ->
+        state
+        |> transition_to_payload_parsing(header_length, required_length)
+        |> pop_frame()
+
+      {:error, message} ->
+        {state, {:error, message}}
+
+      :more ->
+        {state, :more}
+    end
+  end
+
+  def pop_frame(%__MODULE__{mode: :payload_parsing} = state) do
+    if state.payload_length >= state.required_length do
+      <<payload::binary-size(state.required_length), rest::binary>> =
+        IO.iodata_to_binary(state.payload)
+
+      frame = Frame.deserialize(state.header <> payload)
+      state = transition_to_header_parsing(state, rest)
+
+      {state, frame}
+    else
+      {state, :more}
+    end
+  end
+
+  defp transition_to_payload_parsing(state, header_length, required_length) do
+    payload_length = byte_size(state.header) - header_length
+
+    state
+    |> Map.put(:header, binary_part(state.header, 0, header_length))
+    |> Map.put(:payload, binary_part(state.header, header_length, payload_length))
+    |> Map.put(:payload_length, payload_length)
+    |> Map.put(:required_length, required_length)
+    |> Map.put(:mode, :payload_parsing)
+  end
+
+  defp transition_to_header_parsing(state, rest) do
+    state
+    |> Map.put(:header, rest)
+    |> Map.put(:payload, [])
+    |> Map.put(:payload_length, 0)
+    |> Map.put(:required_length, 0)
+    |> Map.put(:mode, :header_parsing)
+  end
+end

--- a/lib/bandit/websocket/frame.ex
+++ b/lib/bandit/websocket/frame.ex
@@ -3,6 +3,8 @@ defmodule Bandit.WebSocket.Frame do
 
   alias Bandit.WebSocket.Frame
 
+  @behaviour Bandit.Extractor
+
   @typedoc "Indicates an opcode"
   @type opcode ::
           (binary :: 0x2)
@@ -21,6 +23,7 @@ defmodule Bandit.WebSocket.Frame do
           | Frame.Ping.t()
           | Frame.Pong.t()
 
+  @impl Bandit.Extractor
   @spec header_and_payload_length(binary(), non_neg_integer()) ::
           {:ok, {header_length :: integer(), payload_length :: integer()}}
           | {:error, :max_frame_size_exceeded | :client_frame_without_mask}
@@ -69,6 +72,7 @@ defmodule Bandit.WebSocket.Frame do
     end
   end
 
+  @impl Bandit.Extractor
   @spec deserialize(binary()) :: {:ok, frame()} | {:error, term()}
   def deserialize(
         <<fin::1, compressed::1, rsv::2, opcode::4, 1::1, 127::7, length::64, mask::32,

--- a/lib/bandit/websocket/handler.ex
+++ b/lib/bandit/websocket/handler.ex
@@ -4,7 +4,8 @@ defmodule Bandit.WebSocket.Handler do
 
   use ThousandIsland.Handler
 
-  alias Bandit.WebSocket.{Connection, Extractor}
+  alias Bandit.Extractor
+  alias Bandit.WebSocket.{Connection, Frame}
 
   @impl ThousandIsland.Handler
   def handle_connection(socket, state) do
@@ -19,7 +20,7 @@ defmodule Bandit.WebSocket.Handler do
     state =
       state
       |> Map.take([:handler_module])
-      |> Map.put(:extractor, Extractor.new(connection_opts))
+      |> Map.put(:extractor, Extractor.new(Frame, connection_opts))
 
     case Connection.init(websock, websock_opts, connection_opts, socket) do
       {:continue, connection} ->

--- a/lib/bandit/websocket/handler.ex
+++ b/lib/bandit/websocket/handler.ex
@@ -4,7 +4,7 @@ defmodule Bandit.WebSocket.Handler do
 
   use ThousandIsland.Handler
 
-  alias Bandit.WebSocket.{Connection, Frame}
+  alias Bandit.WebSocket.{Connection, Extractor}
 
   @impl ThousandIsland.Handler
   def handle_connection(socket, state) do
@@ -19,7 +19,7 @@ defmodule Bandit.WebSocket.Handler do
     state =
       state
       |> Map.take([:handler_module])
-      |> Map.put(:buffer, <<>>)
+      |> Map.put(:extractor, Extractor.new(connection_opts))
 
     case Connection.init(websock, websock_opts, connection_opts, socket) do
       {:continue, connection} ->
@@ -35,29 +35,31 @@ defmodule Bandit.WebSocket.Handler do
 
   @impl ThousandIsland.Handler
   def handle_data(data, socket, state) do
-    (state.buffer <> data)
-    |> Stream.unfold(
-      &Frame.deserialize(&1, Keyword.get(state.connection.opts, :max_frame_size, 0))
-    )
-    |> Enum.reduce_while({:continue, state}, fn
-      {:ok, frame}, {:continue, state} ->
+    state.extractor
+    |> Extractor.push_data(data)
+    |> pop_frame(socket, state)
+  end
+
+  defp pop_frame(extractor, socket, state) do
+    case Extractor.pop_frame(extractor) do
+      {extractor, {:ok, frame}} ->
         case Connection.handle_frame(frame, socket, state.connection) do
           {:continue, connection} ->
-            {:cont, {:continue, %{state | connection: connection, buffer: <<>>}}}
+            pop_frame(extractor, socket, %{state | extractor: extractor, connection: connection})
 
           {:close, connection} ->
-            {:halt, {:close, %{state | connection: connection, buffer: <<>>}}}
+            {:close, %{state | extractor: extractor, connection: connection}}
 
           {:error, reason, connection} ->
-            {:halt, {:error, reason, %{state | connection: connection, buffer: <<>>}}}
+            {:error, reason, %{state | extractor: extractor, connection: connection}}
         end
 
-      {:more, rest}, {:continue, state} ->
-        {:halt, {:continue, %{state | buffer: rest}}}
+      {extractor, {:error, reason}} ->
+        {:error, {:deserializing, reason}, %{state | extractor: extractor}}
 
-      {:error, message}, {:continue, state} ->
-        {:halt, {:error, {:deserializing, message}, state}}
-    end)
+      {extractor, :more} ->
+        {:continue, %{state | extractor: extractor}}
+    end
   end
 
   @impl ThousandIsland.Handler

--- a/test/bandit/websocket/protocol_test.exs
+++ b/test/bandit/websocket/protocol_test.exs
@@ -108,7 +108,7 @@ defmodule WebSocketProtocolTest do
     end
 
     test "over-sized frames are rejected", context do
-      _output =
+      output =
         capture_log(fn ->
           context = http_server(context, websocket_options: [max_frame_size: 2_000_000])
           client = SimpleWebSocketClient.tcp_client(context)
@@ -116,9 +116,11 @@ defmodule WebSocketProtocolTest do
 
           payload = String.duplicate("0123456789", 200_001)
           SimpleWebSocketClient.send_text_frame(client, payload)
+          Process.sleep(100)
         end)
 
       assert_receive {:error, :max_frame_size_exceeded}
+      assert output =~ "{:deserializing, :max_frame_size_exceeded}"
     end
   end
 

--- a/test/bandit/websocket/protocol_test.exs
+++ b/test/bandit/websocket/protocol_test.exs
@@ -108,19 +108,17 @@ defmodule WebSocketProtocolTest do
     end
 
     test "over-sized frames are rejected", context do
-      output =
+      _output =
         capture_log(fn ->
           context = http_server(context, websocket_options: [max_frame_size: 2_000_000])
           client = SimpleWebSocketClient.tcp_client(context)
-          SimpleWebSocketClient.http1_handshake(client, EchoWebSock)
+          SimpleWebSocketClient.http1_handshake(client, TerminateWebSock)
 
           payload = String.duplicate("0123456789", 200_001)
           SimpleWebSocketClient.send_text_frame(client, payload)
-          assert SimpleWebSocketClient.recv_connection_close_frame(client) == {:ok, <<1009::16>>}
-          Process.sleep(100)
         end)
 
-      assert output =~ "{:deserializing, :max_frame_size_exceeded}"
+      assert_receive {:error, :max_frame_size_exceeded}
     end
   end
 


### PR DESCRIPTION
Fixes #389

This is a significant refactor of the initial proposed solution, but the core idea is the same: when parsing a frame, gather enough bytes to parse the header, and then start receiving the payload data into an iolist until the number of payload bytes is satisfied.