### PR TITLE
Handle `throw`ing plug call

### DIFF
--- a/lib/bandit/pipeline.ex
+++ b/lib/bandit/pipeline.ex
@@ -46,15 +46,15 @@ defmodule Bandit.Pipeline do
             {:upgrade, adapter.transport, protocol, opts}
         end
       rescue
-        error -> handle_error(error, __STACKTRACE__, transport, span, opts)
+        error -> handle_error(:error, error, __STACKTRACE__, transport, span, opts)
       catch
         :throw, value ->
-          handle_throw(value, __STACKTRACE__, transport, span, opts)
+          handle_error(:throw, value, __STACKTRACE__, transport, span, opts)
       end
     rescue
       error ->
         span = Bandit.Telemetry.start_span(:request, measurements, metadata)
-        handle_error(error, __STACKTRACE__, transport, span, opts)
+        handle_error(:error, error, __STACKTRACE__, transport, span, opts)
     end
   end
 
@@ -197,13 +197,14 @@ defmodule Bandit.Pipeline do
   end
 
   @spec handle_error(
-          Exception.t(),
+          :error | :throw,
+          Exception.t() | term(),
           Exception.stacktrace(),
           Bandit.HTTPTransport.t(),
           Bandit.Telemetry.t(),
           map()
         ) :: {:ok, Bandit.HTTPTransport.t()} | {:error, term()}
-  defp handle_error(%type{} = error, stacktrace, transport, span, opts)
+  defp handle_error(:error, %type{} = error, stacktrace, transport, span, opts)
        when type in [
               Bandit.HTTPError,
               Bandit.HTTP2.Errors.StreamError,
@@ -228,28 +229,20 @@ defmodule Bandit.Pipeline do
     {:error, error}
   end
 
-  defp handle_error(error, stacktrace, transport, span, opts) do
-    Bandit.Telemetry.span_exception(span, :exit, error, stacktrace)
-    status = error |> Plug.Exception.status() |> Plug.Conn.Status.code()
+  defp handle_error(kind, reason, stacktrace, transport, span, opts) do
+    Bandit.Telemetry.span_exception(span, telemetry_kind(kind), reason, stacktrace)
+    status = reason |> Plug.Exception.status() |> Plug.Conn.Status.code()
 
     if status in Keyword.get(opts.http, :log_exceptions_with_status_codes, 500..599) do
-      Logger.error(Exception.format(:error, error, stacktrace), domain: [:bandit])
-      Bandit.HTTPTransport.send_on_error(transport, error)
-      {:error, error}
+      Logger.error(Exception.format(kind, reason, stacktrace), domain: [:bandit])
+      Bandit.HTTPTransport.send_on_error(transport, reason)
+      {:error, reason}
     else
-      Bandit.HTTPTransport.send_on_error(transport, error)
+      Bandit.HTTPTransport.send_on_error(transport, reason)
       {:ok, transport}
     end
   end
 
-  defp handle_throw(value, stacktrace, transport, span, opts) do
-    Bandit.Telemetry.span_exception(span, :throw, value, stacktrace)
-    status = 500
-
-    if status in Keyword.get(opts.http, :log_exceptions_with_status_codes, 500..599) do
-      Logger.error(Exception.format(:throw, value, stacktrace), domain: [:bandit])
-      Bandit.HTTPTransport.send_on_error(transport, value)
-      {:error, value}
-    end
-  end
+  defp telemetry_kind(:error), do: :exit
+  defp telemetry_kind(kind), do: kind
 end

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -2095,7 +2095,7 @@ defmodule HTTP1RequestTest do
       assert output =~ "(Bandit.HTTPError) Header read timeout"
     end
 
-    test "it should send `exception` events for erroring requests", context do
+    test "it should send `exception` events for raising requests", context do
       output =
         capture_log(fn ->
           {:ok, collector_pid} =
@@ -2120,6 +2120,37 @@ defmodule HTTP1RequestTest do
         end)
 
       assert output =~ "(RuntimeError) boom"
+    end
+
+    def uncaught_throw(_conn) do
+      throw "thrown"
+    end
+
+    test "it should send `exception` events for uncaught throw requests", context do
+      output =
+        capture_log(fn ->
+          {:ok, collector_pid} =
+            start_supervised({Bandit.TelemetryCollector, [[:bandit, :request, :exception]]})
+
+          Req.get!(context.req, url: "/uncaught_throw")
+
+          Process.sleep(100)
+
+          assert Bandit.TelemetryCollector.get_events(collector_pid) |> IO.inspect()
+                 ~> [
+                   {[:bandit, :request, :exception], %{monotonic_time: integer()},
+                    %{
+                      connection_telemetry_span_context: reference(),
+                      telemetry_span_context: reference(),
+                      conn: struct_like(Plug.Conn, []),
+                      kind: :throw,
+                      exception: "thrown",
+                      stacktrace: list()
+                    }}
+                 ]
+        end)
+
+      assert output =~ "(throw) \"thrown\""
     end
   end
 

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -2136,7 +2136,7 @@ defmodule HTTP1RequestTest do
 
           Process.sleep(100)
 
-          assert Bandit.TelemetryCollector.get_events(collector_pid) |> IO.inspect()
+          assert Bandit.TelemetryCollector.get_events(collector_pid)
                  ~> [
                    {[:bandit, :request, :exception], %{monotonic_time: integer()},
                     %{


### PR DESCRIPTION
Hi,

Thanks for writing this great library!

It seems that uncaught `throw`s inside the plug call currently end up with a socket closed the following in the logs

```
[error] GenServer #PID<0.4420.0> terminating
** (stop) bad return value: "something was thrown"
Last message: {:continue, :handle_connection}
```
(no stacktrace)

With the changes in this PR

```
[error] ** (throw) "something was thrown"
    ... PROPER STACKTRACE HERE ...
```

and a corresponding telemetry event, similar to exceptions.

Thoughts?

Haven't looked closely yet, but I think the same can be said of non-normal exits. Will take a look later.