### PR TITLE
test: make less likely that test run into :eaddrinuse failure locally

### DIFF
--- a/test/bandit/server_test.exs
+++ b/test/bandit/server_test.exs
@@ -25,7 +25,7 @@ defmodule ServerTest do
   end
 
   test "server logs connection error detail log at startup" do
-    pid = start_supervised!({Bandit, scheme: :http, plug: __MODULE__})
+    pid = start_supervised!({Bandit, scheme: :http, plug: __MODULE__, port: 40_000})
     {:ok, {address, port}} = ThousandIsland.listener_info(pid)
 
     logs =
@@ -56,11 +56,11 @@ defmodule ServerTest do
   end
 
   test "can run multiple instances of Bandit" do
-    start_supervised({Bandit, plug: __MODULE__, port: 4000})
-    start_supervised({Bandit, plug: __MODULE__, port: 4001})
+    start_supervised({Bandit, plug: __MODULE__, port: 40_000})
+    start_supervised({Bandit, plug: __MODULE__, port: 40_001})
 
-    assert 200 == Req.get!("http://localhost:4000/hello").status
-    assert 200 == Req.get!("http://localhost:4001/hello").status
+    assert 200 == Req.get!("http://localhost:40000/hello").status
+    assert 200 == Req.get!("http://localhost:40001/hello").status
   end
 
   def hello(conn) do

--- a/test/bandit/server_test.exs
+++ b/test/bandit/server_test.exs
@@ -25,8 +25,9 @@ defmodule ServerTest do
   end
 
   test "server logs connection error detail log at startup" do
-    pid = start_supervised!({Bandit, scheme: :http, plug: __MODULE__, port: 40_000})
-    {:ok, {address, port}} = ThousandIsland.listener_info(pid)
+    {:ok, {address, port}} =
+      start_supervised!({Bandit, scheme: :http, plug: __MODULE__, port: 0})
+      |> ThousandIsland.listener_info()
 
     logs =
       capture_log(fn ->
@@ -56,11 +57,16 @@ defmodule ServerTest do
   end
 
   test "can run multiple instances of Bandit" do
-    start_supervised({Bandit, plug: __MODULE__, port: 40_000})
-    start_supervised({Bandit, plug: __MODULE__, port: 40_001})
+    {:ok, {_address1, port1}} =
+      start_supervised!({Bandit, plug: __MODULE__, port: 0})
+      |> ThousandIsland.listener_info()
 
-    assert 200 == Req.get!("http://localhost:40000/hello").status
-    assert 200 == Req.get!("http://localhost:40001/hello").status
+    {:ok, {_address2, port2}} =
+      start_supervised!({Bandit, plug: __MODULE__, port: 0})
+      |> ThousandIsland.listener_info()
+
+    assert 200 == Req.get!("http://localhost:#{port1}/hello").status
+    assert 200 == Req.get!("http://localhost:#{port2}/hello").status
   end
 
   def hello(conn) do


### PR DESCRIPTION
Very minor dev ergnomics thing.

When working on previous PRs, I sometimes got eaddrinuse locally while occasionally running bandit test because of having other phoenix apps on default 4000 on the side :slightly_smiling_face: 