### PR TITLE
feat: allow logger handler to know about HTTP request details

### DIFF
--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -172,7 +172,10 @@ defmodule HTTP1RequestTest do
       assert %{
                level: :error,
                msg: _msg,
-               meta: %{crash_reason: {%RuntimeError{message: "boom"}, [_ | _] = _stacktrace}}
+               meta: %{
+                 crash_reason: {%RuntimeError{message: "boom"}, [_ | _] = _stacktrace},
+                 conn: %Plug.Conn{}
+               }
              } = log_event
     end
 


### PR DESCRIPTION
Following up #417.

Another piece that helps switch from `plug_cowboy` to `bandit` without losing features in this Error Tracking / Logging area.

In `plug_cowboy`: https://github.com/elixir-plug/plug_cowboy/pull/57.

Example of a logger handler that consumes the `conn` made available as metadata by plug_cowboy:
- `logger_json`: https://hexdocs.pm/logger_json/LoggerJSON.html#module-metadata.