### PR TITLE
Deflate support on chunked responses

### DIFF
--- a/lib/bandit/compression.ex
+++ b/lib/bandit/compression.ex
@@ -1,6 +1,15 @@
 defmodule Bandit.Compression do
   @moduledoc false
 
+  defstruct method: nil, bytes_in: 0, lib_context: nil
+
+  @typedoc "A struct containing the context for response compression"
+  @type t :: %__MODULE__{
+          method: :deflate | :gzip | :identity,
+          bytes_in: non_neg_integer(),
+          lib_context: term()
+        }
+
   @spec negotiate_content_encoding(nil | binary(), boolean()) :: String.t() | nil
   def negotiate_content_encoding(nil, _), do: nil
   def negotiate_content_encoding(_, false), do: nil
@@ -11,27 +20,94 @@ defmodule Bandit.Compression do
     |> Enum.find(&(&1 in ~w(deflate gzip x-gzip)))
   end
 
-  @spec compress(iolist(), String.t(), Bandit.deflate_options()) :: iodata()
-  def compress(response, "deflate", opts) do
-    deflate_context = :zlib.open()
+  def new(adapter, headers) do
+    response_content_encoding_header = Bandit.Headers.get_header(headers, "content-encoding")
 
-    try do
-      :ok =
-        :zlib.deflateInit(
-          deflate_context,
-          Keyword.get(opts, :level, :default),
-          :deflated,
-          Keyword.get(opts, :window_bits, 15),
-          Keyword.get(opts, :mem_level, 8),
-          Keyword.get(opts, :strategy, :default)
-        )
+    response_has_strong_etag =
+      case Bandit.Headers.get_header(headers, "etag") do
+        nil -> false
+        "\W" <> _rest -> false
+        _strong_etag -> true
+      end
 
-      :zlib.deflate(deflate_context, response, :sync)
-    after
-      :zlib.close(deflate_context)
+    response_indicates_no_transform =
+      case Bandit.Headers.get_header(headers, "cache-control") do
+        nil -> false
+        header -> "no-transform" in Plug.Conn.Utils.list(header)
+      end
+
+    headers =
+      if Keyword.get(adapter.opts.http, :compress, true),
+        do: [{"vary", "accept-encoding"} | headers],
+        else: headers
+
+    if not is_nil(adapter.content_encoding) && is_nil(response_content_encoding_header) &&
+         !response_has_strong_etag && !response_indicates_no_transform do
+      deflate_options = Keyword.get(adapter.opts.http, :deflate_options, [])
+
+      case start_stream(adapter.content_encoding, deflate_options) do
+        {:ok, context} -> {[{"content-encoding", adapter.content_encoding} | headers], context}
+        {:error, :unsupported_encoding} -> {headers, %__MODULE__{method: :identity}}
+      end
+    else
+      {headers, %__MODULE__{method: :identity}}
     end
   end
 
-  def compress(response, "x-gzip", _opts), do: compress(response, "gzip", [])
-  def compress(response, "gzip", _opts), do: :zlib.gzip(response)
+  defp start_stream("deflate", opts) do
+    deflate_context = :zlib.open()
+
+    :zlib.deflateInit(
+      deflate_context,
+      Keyword.get(opts, :level, :default),
+      :deflated,
+      Keyword.get(opts, :window_bits, 15),
+      Keyword.get(opts, :mem_level, 8),
+      Keyword.get(opts, :strategy, :default)
+    )
+
+    {:ok, %__MODULE__{method: :deflate, lib_context: deflate_context}}
+  end
+
+  defp start_stream("x-gzip", _opts), do: {:ok, %__MODULE__{method: :gzip}}
+  defp start_stream("gzip", _opts), do: {:ok, %__MODULE__{method: :gzip}}
+  defp start_stream(_encoding, _opts), do: {:error, :unsupported_encoding}
+
+  def compress_chunk(chunk, %__MODULE__{method: :deflate} = context) do
+    result = :zlib.deflate(context.lib_context, chunk, :sync)
+
+    context =
+      context
+      |> Map.update!(:bytes_in, &(&1 + IO.iodata_length(chunk)))
+
+    {result, context}
+  end
+
+  def compress_chunk(chunk, %__MODULE__{method: :gzip, lib_context: nil} = context) do
+    result = :zlib.gzip(chunk)
+
+    context =
+      context
+      |> Map.update!(:bytes_in, &(&1 + IO.iodata_length(chunk)))
+      |> Map.put(:lib_context, :done)
+
+    {result, context}
+  end
+
+  def compress_chunk(chunk, %__MODULE__{method: :identity} = context) do
+    {chunk, context}
+  end
+
+  def close(%__MODULE__{} = context) do
+    if context.method == :deflate, do: :zlib.close(context.lib_context)
+
+    if context.method == :identity do
+      %{}
+    else
+      %{
+        resp_compression_method: to_string(context.method),
+        resp_uncompressed_body_bytes: context.bytes_in
+      }
+    end
+  end
 end

--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -1275,15 +1275,11 @@ defmodule HTTP1RequestTest do
       assert response.headers["content-encoding"] == ["deflate"]
       assert response.headers["vary"] == ["accept-encoding"]
 
-      deflate_context = :zlib.open()
-      :ok = :zlib.deflateInit(deflate_context)
+      inflate_context = :zlib.open()
+      :ok = :zlib.inflateInit(inflate_context)
+      inflated_body = :zlib.inflate(inflate_context, response.body) |> IO.iodata_to_binary()
 
-      expected =
-        deflate_context
-        |> :zlib.deflate(String.duplicate("a", 10_000), :sync)
-        |> IO.iodata_to_binary()
-
-      assert response.body == expected
+      assert inflated_body == String.duplicate("a", 10_000)
     end
 
     test "writes out a response with gzip encoding if so negotiated", context do
@@ -1320,15 +1316,11 @@ defmodule HTTP1RequestTest do
       assert response.headers["content-encoding"] == ["deflate"]
       assert response.headers["vary"] == ["accept-encoding"]
 
-      deflate_context = :zlib.open()
-      :ok = :zlib.deflateInit(deflate_context)
+      inflate_context = :zlib.open()
+      :ok = :zlib.inflateInit(inflate_context)
+      inflated_body = :zlib.inflate(inflate_context, response.body) |> IO.iodata_to_binary()
 
-      expected =
-        deflate_context
-        |> :zlib.deflate(String.duplicate("a", 10_000), :sync)
-        |> IO.iodata_to_binary()
-
-      assert response.body == expected
+      assert inflated_body == String.duplicate("a", 10_000)
     end
 
     test "writes out an encoded response for an iolist body", context do
@@ -1340,15 +1332,14 @@ defmodule HTTP1RequestTest do
       assert response.headers["content-encoding"] == ["deflate"]
       assert response.headers["vary"] == ["accept-encoding"]
 
-      deflate_context = :zlib.open()
-      :ok = :zlib.deflateInit(deflate_context)
+      inflate_context = :zlib.open()
+      :ok = :zlib.inflateInit(inflate_context)
+      inflated_body = :zlib.inflate(inflate_context, response.body) |> IO.iodata_to_binary()
 
-      expected =
-        deflate_context
-        |> :zlib.deflate(String.duplicate("a", 10_000), :sync)
-        |> IO.iodata_to_binary()
+      assert inflated_body == String.duplicate("a", 10_000)
+    end
 
-      assert response.body == expected
+
     end
 
     test "falls back to no encoding if no encodings provided", context do

--- a/test/bandit/http2/protocol_test.exs
+++ b/test/bandit/http2/protocol_test.exs
@@ -300,8 +300,8 @@ defmodule HTTP2ProtocolTest do
                 {":status", "200"},
                 {"date", _date},
                 {"content-length", "34"},
-                {"vary", "accept-encoding"},
                 {"content-encoding", "deflate"},
+                {"vary", "accept-encoding"},
                 {"cache-control", "max-age=0, private, must-revalidate"}
               ], _ctx} = SimpleH2Client.recv_headers(socket)
 
@@ -334,8 +334,8 @@ defmodule HTTP2ProtocolTest do
                 {":status", "200"},
                 {"date", _date},
                 {"content-length", "46"},
-                {"vary", "accept-encoding"},
                 {"content-encoding", "gzip"},
+                {"vary", "accept-encoding"},
                 {"cache-control", "max-age=0, private, must-revalidate"}
               ], _ctx} = SimpleH2Client.recv_headers(socket)
 
@@ -362,8 +362,8 @@ defmodule HTTP2ProtocolTest do
                 {":status", "200"},
                 {"date", _date},
                 {"content-length", "46"},
-                {"vary", "accept-encoding"},
                 {"content-encoding", "x-gzip"},
+                {"vary", "accept-encoding"},
                 {"cache-control", "max-age=0, private, must-revalidate"}
               ], _ctx} = SimpleH2Client.recv_headers(socket)
 
@@ -390,8 +390,8 @@ defmodule HTTP2ProtocolTest do
                 {":status", "200"},
                 {"date", _date},
                 {"content-length", "34"},
-                {"vary", "accept-encoding"},
                 {"content-encoding", "deflate"},
+                {"vary", "accept-encoding"},
                 {"cache-control", "max-age=0, private, must-revalidate"}
               ], _ctx} = SimpleH2Client.recv_headers(socket)
 
@@ -424,8 +424,8 @@ defmodule HTTP2ProtocolTest do
                 {":status", "200"},
                 {"date", _date},
                 {"content-length", "34"},
-                {"vary", "accept-encoding"},
                 {"content-encoding", "deflate"},
+                {"vary", "accept-encoding"},
                 {"cache-control", "max-age=0, private, must-revalidate"}
               ], _ctx} = SimpleH2Client.recv_headers(socket)
 
@@ -512,8 +512,8 @@ defmodule HTTP2ProtocolTest do
                 {":status", "200"},
                 {"date", _date},
                 {"content-length", "46"},
-                {"vary", "accept-encoding"},
                 {"content-encoding", "gzip"},
+                {"vary", "accept-encoding"},
                 {"cache-control", "max-age=0, private, must-revalidate"},
                 {"etag", "W/\"1234\""}
               ], _ctx} = SimpleH2Client.recv_headers(socket)

--- a/test/bandit/http2/protocol_test.exs
+++ b/test/bandit/http2/protocol_test.exs
@@ -305,15 +305,13 @@ defmodule HTTP2ProtocolTest do
                 {"cache-control", "max-age=0, private, must-revalidate"}
               ], _ctx} = SimpleH2Client.recv_headers(socket)
 
-      deflate_context = :zlib.open()
-      :ok = :zlib.deflateInit(deflate_context)
+      {:ok, 1, true, body} = SimpleH2Client.recv_body(socket)
 
-      expected =
-        deflate_context
-        |> :zlib.deflate(String.duplicate("a", 10_000), :sync)
-        |> IO.iodata_to_binary()
+      inflate_context = :zlib.open()
+      :ok = :zlib.inflateInit(inflate_context)
+      inflated_body = :zlib.inflate(inflate_context, body) |> IO.iodata_to_binary()
 
-      assert SimpleH2Client.recv_body(socket) == {:ok, 1, true, expected}
+      assert inflated_body == String.duplicate("a", 10_000)
     end
 
     test "writes out a response with gzip encoding if so negotiated", context do
@@ -395,15 +393,13 @@ defmodule HTTP2ProtocolTest do
                 {"cache-control", "max-age=0, private, must-revalidate"}
               ], _ctx} = SimpleH2Client.recv_headers(socket)
 
-      deflate_context = :zlib.open()
-      :ok = :zlib.deflateInit(deflate_context)
+      {:ok, 1, true, body} = SimpleH2Client.recv_body(socket)
 
-      expected =
-        deflate_context
-        |> :zlib.deflate(String.duplicate("a", 10_000), :sync)
-        |> IO.iodata_to_binary()
+      inflate_context = :zlib.open()
+      :ok = :zlib.inflateInit(inflate_context)
+      inflated_body = :zlib.inflate(inflate_context, body) |> IO.iodata_to_binary()
 
-      assert SimpleH2Client.recv_body(socket) == {:ok, 1, true, expected}
+      assert inflated_body == String.duplicate("a", 10_000)
     end
 
     test "writes out a response with deflate encoding for an iolist body", context do
@@ -429,15 +425,13 @@ defmodule HTTP2ProtocolTest do
                 {"cache-control", "max-age=0, private, must-revalidate"}
               ], _ctx} = SimpleH2Client.recv_headers(socket)
 
-      deflate_context = :zlib.open()
-      :ok = :zlib.deflateInit(deflate_context)
+      {:ok, 1, true, body} = SimpleH2Client.recv_body(socket)
 
-      expected =
-        deflate_context
-        |> :zlib.deflate(String.duplicate("a", 10_000), :sync)
-        |> IO.iodata_to_binary()
+      inflate_context = :zlib.open()
+      :ok = :zlib.inflateInit(inflate_context)
+      inflated_body = :zlib.inflate(inflate_context, body) |> IO.iodata_to_binary()
 
-      assert SimpleH2Client.recv_body(socket) == {:ok, 1, true, expected}
+      assert inflated_body == String.duplicate("a", 10_000)
     end
 
     test "does no encoding if content-encoding header already present in response", context do


### PR DESCRIPTION
Adds support for deflating chunked responses. Consists of a refactor to first break apart the existing compression routines such that the constituent stages can be called separately throughout the lifecycle of a chunked response, and then using these new routines within chunked responses.

Only deflate is supported on responses