### PR TITLE
Fixup POST pipeline support

### DIFF
--- a/test/bandit/http1/request_test.exs
+++ b/test/bandit/http1/request_test.exs
@@ -1025,29 +1025,6 @@ defmodule HTTP1RequestTest do
       raise "Shouldn't get here"
     end
 
-    test "handles the case where the declared content length is less than what is sent",
-         context do
-      output =
-        capture_log(fn ->
-          client = SimpleHTTP1Client.tcp_client(context)
-
-          Transport.send(
-            client,
-            "POST /long_body HTTP/1.1\r\nhost: localhost\r\ncontent-length: 3\r\n\r\nABCDE"
-          )
-
-          assert {:ok, "400 Bad Request", _, ""} = SimpleHTTP1Client.recv_reply(client)
-          Process.sleep(100)
-        end)
-
-      assert output =~ "(Bandit.HTTPError) Excess body read"
-    end
-
-    def long_body(conn) do
-      Plug.Conn.read_body(conn)
-      raise "should not get here"
-    end
-
     test "reading request body multiple times works as expected", context do
       response = Req.post!(context.req, url: "/multiple_body_read", body: "OK")
 


### PR DESCRIPTION
Previously this field represented the bytes still to read off the wire, as opposed to the bytes still required per the request's content length. This made it hard to support cases where we *wanted* to maintain a buffer
of pipelined requests after the current request's body (previously, we just errored loudly on this in the assumption that it represented an intentionally misbehaving client).

Fix this by using an `undefined_content_length` parameter on HTTP/1 requests that instead represents the pending bytes *on this request* so that we can more easily handle the case where the socket buffer contains bytes belonging to the subsequent request.

@woylie relevant to your interests 