### PR TITLE
Always close HTTP/1 connection in any case where an error comes out of the plug

### DIFF
--- a/lib/bandit/pipeline.ex
+++ b/lib/bandit/pipeline.ex
@@ -236,12 +236,9 @@ defmodule Bandit.Pipeline do
     if status in Keyword.get(opts.http, :log_exceptions_with_status_codes, 500..599) do
       logger_metadata = Bandit.Logger.logger_metadata_for(kind, reason, stacktrace, metadata)
       Logger.error(Exception.format(kind, reason, stacktrace), logger_metadata)
-
-      Bandit.HTTPTransport.send_on_error(transport, reason)
-      {:error, reason}
-    else
-      Bandit.HTTPTransport.send_on_error(transport, reason)
-      {:ok, transport}
     end
+
+    Bandit.HTTPTransport.send_on_error(transport, reason)
+    {:error, reason}
   end
 end

--- a/test/bandit/http1/plug_test.exs
+++ b/test/bandit/http1/plug_test.exs
@@ -38,27 +38,16 @@ defmodule HTTP1PlugTest do
       {:ok, response} = Req.get(context.req, url: "/unknown_crasher")
       assert response.status == 500
 
-      assert_receive {:log, %{level: :error, msg: {:string, msg}}}, 500
+      assert_receive {:log, %{level: :error, msg: {:string, msg}, meta: meta}}, 500
       assert msg =~ "(RuntimeError) boom"
       assert msg =~ "lib/bandit/pipeline.ex:"
-    end
-
-    @tag :capture_log
-    test "it should provide useful metadata to logger handlers when unknown exceptions are raised",
-         context do
-      {:ok, response} = Req.get(context.req, url: "/unknown_crasher")
-      assert response.status == 500
-
-      assert_receive {:log, log_event}, 500
 
       assert %{
-               meta: %{
-                 domain: [:elixir, :bandit],
-                 crash_reason: {%RuntimeError{message: "boom"}, [_ | _] = _stacktrace},
-                 conn: %Plug.Conn{},
-                 plug: {__MODULE__, []}
-               }
-             } = log_event
+               domain: [:elixir, :bandit],
+               crash_reason: {%RuntimeError{message: "boom"}, [_ | _] = _stacktrace},
+               conn: %Plug.Conn{},
+               plug: {__MODULE__, []}
+             } = meta
     end
 
     def unknown_crasher(_conn) do


### PR DESCRIPTION
Fixes #451 

Previously, Bandit would keep the connection open for errors which it did not log; this was an oversight. 

