### PR TITLE
fix: properly normalize erlang errors before emitting telemetry and logged crash_reason

### DIFF
--- a/lib/bandit/pipeline.ex
+++ b/lib/bandit/pipeline.ex
@@ -209,7 +209,15 @@ defmodule Bandit.Pipeline do
         ) :: {:ok, Bandit.HTTPTransport.t()} | {:error, term()}
   defp handle_error(:error, %Plug.Conn.WrapperError{} = error, _, transport, span, opts, metadata) do
     # Unwrap the inner error and handle it
-    handle_error(error.kind, error.reason, error.stack, transport, span, opts, metadata)
+    handle_error(
+      error.kind,
+      Exception.normalize(:error, error.reason, error.stack),
+      error.stack,
+      transport,
+      span,
+      opts,
+      metadata
+    )
   end
 
   defp handle_error(:error, %type{} = error, stacktrace, transport, span, opts, metadata)

--- a/lib/bandit/pipeline.ex
+++ b/lib/bandit/pipeline.ex
@@ -209,15 +209,7 @@ defmodule Bandit.Pipeline do
         ) :: {:ok, Bandit.HTTPTransport.t()} | {:error, term()}
   defp handle_error(:error, %Plug.Conn.WrapperError{} = error, _, transport, span, opts, metadata) do
     # Unwrap the inner error and handle it
-    handle_error(
-      error.kind,
-      Exception.normalize(:error, error.reason, error.stack),
-      error.stack,
-      transport,
-      span,
-      opts,
-      metadata
-    )
+    handle_error(error.kind, error.reason, error.stack, transport, span, opts, metadata)
   end
 
   defp handle_error(:error, %type{} = error, stacktrace, transport, span, opts, metadata)
@@ -238,6 +230,8 @@ defmodule Bandit.Pipeline do
   end
 
   defp handle_error(kind, reason, stacktrace, transport, span, opts, metadata) do
+    reason = Exception.normalize(kind, reason, stacktrace)
+
     Bandit.Telemetry.span_exception(span, kind, reason, stacktrace)
     status = reason |> Plug.Exception.status() |> Plug.Conn.Status.code()
 

--- a/test/bandit/http1/plug_test.exs
+++ b/test/bandit/http1/plug_test.exs
@@ -112,7 +112,7 @@ defmodule HTTP1PlugTest do
       get "/" do
         # Quiet the compiler
         _ = conn
-        raise "boom"
+        1 = 0
       end
     end
 
@@ -134,9 +134,15 @@ defmodule HTTP1PlugTest do
       SimpleHTTP1Client.send(client, "GET", "/hello_world", ["host: banana"])
       assert SimpleHTTP1Client.connection_closed_for_reading?(client)
 
-      assert_receive {:log, %{level: :error, msg: {:string, msg}}}, 500
+      assert_receive {:log, %{level: :error, msg: {:string, msg}, meta: meta}}, 500
       refute msg =~ "(Plug.Conn.WrapperError)"
-      assert msg =~ "** (RuntimeError) boom"
+      assert msg =~ "** (MatchError)"
+
+      assert %{
+               domain: [:elixir, :bandit],
+               crash_reason: {%MatchError{}, [_ | _] = _stacktrace},
+               conn: %Plug.Conn{}
+             } = meta
     end
   end
 

--- a/test/bandit/http1/plug_test.exs
+++ b/test/bandit/http1/plug_test.exs
@@ -46,19 +46,19 @@ defmodule HTTP1PlugTest do
       assert SimpleHTTP1Client.connection_closed_for_reading?(client)
 
       assert_receive {:log, %{level: :error, msg: {:string, msg}, meta: meta}}, 500
-      assert msg =~ "(RuntimeError) boom"
+      assert msg =~ "(ArithmeticError)"
       assert msg =~ "lib/bandit/pipeline.ex:"
 
       assert %{
                domain: [:elixir, :bandit],
-               crash_reason: {%RuntimeError{message: "boom"}, [_ | _] = _stacktrace},
+               crash_reason: {%ArithmeticError{}, [_ | _] = _stacktrace},
                conn: %Plug.Conn{},
                plug: {__MODULE__, []}
              } = meta
     end
 
     def unknown_crasher(_conn) do
-      raise "boom"
+      1 / 0
     end
 
     @tag :capture_log


### PR DESCRIPTION
Hi there :wave: 

Minor follow up for https://github.com/mtrudel/bandit/commit/a053c1cd95d90756bf1dd6927199f8f2afc5b9fb.

Analogous code in `plug_cowboy`: https://github.com/elixir-plug/plug_cowboy/blob/ced253f035f2a07ebed17cfacb64d4f16357a750/lib/plug/cowboy/handler.ex#L51-L55.

Thanks!