### PR TITLE
Send any headers already queued in the plug when upgrading websocket

### DIFF
--- a/lib/bandit/websocket/handshake.ex
+++ b/lib/bandit/websocket/handshake.ex
@@ -75,7 +75,8 @@ defmodule Bandit.WebSocket.Handshake do
         {:connection, "Upgrade"},
         {:"sec-websocket-accept", server_key}
       ] ++
-        websocket_extension_header(extensions)
+        websocket_extension_header(extensions) ++
+        conn.resp_headers
 
     inform(conn, 101, headers)
   end


### PR DESCRIPTION
Fixes #457, which was introduced in #428

@peaceful-james is it possible for you to re-test that the original issue from #422 is still fixed with this branch?
