### PR TITLE
test: fixes tests in Elixir 1.18

### DIFF
--- a/test/support/req_helpers.ex
+++ b/test/support/req_helpers.ex
@@ -4,13 +4,13 @@ defmodule ReqHelpers do
   defmacro __using__(_) do
     quote location: :keep do
       def req_http1_client(context) do
-        name = Module.concat(context.case, context.test)
+        name = Module.concat(context.module, context.test)
         start_finch(name)
         [req: build_req(base_url: context.base, finch: name)]
       end
 
       def req_h2_client(context) do
-        name = Module.concat(context.case, context.test)
+        name = Module.concat(context.module, context.test)
         start_finch(name, protocols: [:http2])
         [req: build_req(base_url: context.base, finch: name)]
       end


### PR DESCRIPTION
ex_unit context `:case` no longer available since:
https://github.com/elixir-lang/elixir/commit/ecac839810905f2da826c5cca01cb4e0e9fc5a95