### PR TITLE
Add changelog link to package metadata

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,10 @@ defmodule Bandit.MixProject do
       package: [
         maintainers: ["Mat Trudel"],
         licenses: ["MIT"],
-        links: %{"GitHub" => "https://github.com/mtrudel/bandit"},
+        links: %{
+          "GitHub" => "https://github.com/mtrudel/bandit",
+          "Changelog" => "https://hexdocs.pm/bandit/changelog.html"
+        },
         files: ["lib", "mix.exs", "README*", "LICENSE*", "CHANGELOG*"]
       ],
       docs: docs()


### PR DESCRIPTION
## Summary
• Adds changelog link to hexdocs for easier access from package page
• Complements existing changelog configuration in docs extras