### PR TITLE
Update version to `1.8`  in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Using Bandit to host your Phoenix application couldn't be simpler:
 1. Add Bandit as a dependency in your Phoenix application's `mix.exs`:
 
     ```elixir
-    {:bandit, "~> 1.0"}
+    {:bandit, "~> 1.8"}
     ```
 2. Add the following `adapter:` line to your endpoint configuration in `config/config.exs`, as in the following example:
 
@@ -233,7 +233,7 @@ by adding `bandit` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:bandit, "~> 1.0"}
+    {:bandit, "~> 1.8"}
   ]
 end
 ```


### PR DESCRIPTION
Very minor PR but when swapping out `Plug.Cowboy` for `Bandit` we were only pulling in version `1.6.11` when the including `{:bandit, "~> 1.0"}` in our `mix.exs`:
<img width="1167" height="299" alt="Screenshot 2025-08-21 at 09 49 42" src="https://github.com/user-attachments/assets/471fd111-8d27-4d98-9ec4-ae6d8ba61d68" />


However `{:bandit, "~> 1.8"}` ensured we had the correct version:
<img width="1176" height="304" alt="Screenshot 2025-08-21 at 09 50 54" src="https://github.com/user-attachments/assets/e9238693-c5e8-4642-95e0-d10a267f64b0" />


I haven't updated it in the `lib/bandit/phoenix_adapter.ex` documentation as the latest version of Phoenix seems to use `1.6.7`:
https://github.com/phoenixframework/phoenix/blob/v1.8.0/mix.lock#L2