### PR TITLE
Pass stream_id to StreamError exceptions

### DIFF
--- a/lib/bandit/http2/errors.ex
+++ b/lib/bandit/http2/errors.ex
@@ -49,7 +49,7 @@ defmodule Bandit.HTTP2.Errors do
 
   # Represents a stream error as defined in RFC9113§5.4.2
   defmodule StreamError do
-    defexception [:message, :error_code]
+    defexception [:message, :error_code, :stream_id]
   end
 
   # Represents a stream error as defined in RFC9113§5.4.3

--- a/lib/bandit/http2/flow_control.ex
+++ b/lib/bandit/http2/flow_control.ex
@@ -32,7 +32,7 @@ defmodule Bandit.HTTP2.FlowControl do
   end
 
   @spec update_send_window(non_neg_integer(), non_neg_integer()) ::
-          {:ok, non_neg_integer()} | {:error, term()}
+          {:ok, non_neg_integer()} | {:error, String.t()}
   def update_send_window(current_send_window, increment) do
     if current_send_window + increment > @max_window_size do
       {:error, "Invalid WINDOW_UPDATE increment RFC9113§6.9.1"}

--- a/lib/bandit/logger.ex
+++ b/lib/bandit/logger.ex
@@ -28,8 +28,17 @@ defmodule Bandit.Logger do
   end
 
   def logger_metadata_for(kind, reason, stacktrace, metadata) do
-    [domain: [:bandit], crash_reason: crash_reason(kind, reason, stacktrace)]
-    |> Keyword.merge(metadata)
+    crash_reason = crash_reason(kind, reason, stacktrace)
+
+    case reason do
+      %Bandit.HTTP2.Errors.StreamError{stream_id: stream_id} when is_integer(stream_id) ->
+        [stream_id: stream_id, domain: [:bandit], crash_reason: crash_reason]
+        |> Keyword.merge(metadata)
+
+      _ ->
+        [domain: [:bandit], crash_reason: crash_reason]
+        |> Keyword.merge(metadata)
+    end
   end
 
   defp crash_reason(:throw, reason, stacktrace), do: {{:nocatch, reason}, stacktrace}


### PR DESCRIPTION
Splitting from https://github.com/mtrudel/bandit/pull/520, this only adds the stream_id to the StreamError exceptions.