### PR TITLE
Implement max_concurrent_streams

### DIFF
--- a/lib/bandit/http2/connection.ex
+++ b/lib/bandit/http2/connection.ex
@@ -222,30 +222,39 @@ defmodule Bandit.HTTP2.Connection do
         connection.streams
 
       :new ->
-        if accept_stream?(connection) do
-          stream =
-            Bandit.HTTP2.Stream.init(
-              self(),
+        case new_stream(connection) do
+          :new_stream ->
+            stream =
+              Bandit.HTTP2.Stream.init(
+                self(),
+                stream_id,
+                connection.remote_settings.initial_window_size
+              )
+
+            case Bandit.HTTP2.StreamProcess.start_link(
+                   stream,
+                   connection.plug,
+                   connection.telemetry_span,
+                   connection.conn_data,
+                   connection.opts
+                 ) do
+              {:ok, pid} ->
+                streams = Bandit.HTTP2.StreamCollection.insert(connection.streams, stream_id, pid)
+                with_stream(%{connection | streams: streams}, stream_id, fun)
+
+              _ ->
+                raise "Unable to start stream process"
+            end
+
+          :max_concurrent_streams_exceeded ->
+            stream_error!(
+              "Concurrent stream count exceeded",
               stream_id,
-              connection.remote_settings.initial_window_size
+              Bandit.HTTP2.Errors.refused_stream()
             )
 
-          case Bandit.HTTP2.StreamProcess.start_link(
-                 stream,
-                 connection.plug,
-                 connection.telemetry_span,
-                 connection.conn_data,
-                 connection.opts
-               ) do
-            {:ok, pid} ->
-              streams = Bandit.HTTP2.StreamCollection.insert(connection.streams, stream_id, pid)
-              with_stream(%{connection | streams: streams}, stream_id, fun)
-
-            _ ->
-              raise "Unable to start stream process"
-          end
-        else
-          connection_error!("Connection count exceeded", Bandit.HTTP2.Errors.refused_stream())
+          :max_requests_exceeded ->
+            connection_error!("Connection count exceeded", Bandit.HTTP2.Errors.refused_stream())
         end
 
       :invalid ->
@@ -253,11 +262,22 @@ defmodule Bandit.HTTP2.Connection do
     end
   end
 
-  defp accept_stream?(connection) do
-    max_requests = Keyword.get(connection.opts.http_2, :max_requests, 0)
+  @spec new_stream(t()) :: :new_stream | :max_requests_exceeded | :max_concurrent_streams_exceeded
+  defp new_stream(connection) do
+    max_requests = connection.opts.http_2[:max_requests]
+    max_concurrent_streams = connection.local_settings.max_concurrent_streams
 
-    max_requests == 0 ||
-      Bandit.HTTP2.StreamCollection.stream_count(connection.streams) < max_requests
+    cond do
+      max_requests <= Bandit.HTTP2.StreamCollection.stream_count(connection.streams) ->
+        :max_requests_exceeded
+
+      max_concurrent_streams <=
+          Bandit.HTTP2.StreamCollection.open_stream_count(connection.streams) ->
+        :max_concurrent_streams_exceeded
+
+      true ->
+        :new_stream
+    end
   end
 
   defp check_oversize_fragment!(fragment, connection) do
@@ -399,6 +419,19 @@ defmodule Bandit.HTTP2.Connection do
   @spec connection_error!(term(), Bandit.HTTP2.Errors.error_code()) :: no_return()
   defp connection_error!(message, error_code \\ Bandit.HTTP2.Errors.protocol_error()) do
     raise Bandit.HTTP2.Errors.ConnectionError, message: message, error_code: error_code
+  end
+
+  @spec stream_error!(
+          String.t(),
+          Bandit.HTTP2.Stream.stream_id(),
+          Bandit.HTTP2.Errors.error_code()
+        ) ::
+          no_return()
+  defp stream_error!(message, stream_id, error_code) do
+    raise Bandit.HTTP2.Errors.StreamError,
+      message: message,
+      error_code: error_code,
+      stream_id: stream_id
   end
 
   defp send_frame(frame, socket, connection) do

--- a/lib/bandit/http2/connection.ex
+++ b/lib/bandit/http2/connection.ex
@@ -268,7 +268,8 @@ defmodule Bandit.HTTP2.Connection do
     max_concurrent_streams = connection.local_settings.max_concurrent_streams
 
     cond do
-      max_requests <= Bandit.HTTP2.StreamCollection.stream_count(connection.streams) ->
+      max_requests != 0 and
+          max_requests <= Bandit.HTTP2.StreamCollection.stream_count(connection.streams) ->
         :max_requests_exceeded
 
       max_concurrent_streams <=

--- a/lib/bandit/http2/stream_collection.ex
+++ b/lib/bandit/http2/stream_collection.ex
@@ -70,6 +70,9 @@ defmodule Bandit.HTTP2.StreamCollection do
   @spec stream_count(t()) :: non_neg_integer()
   def stream_count(collection), do: collection.stream_count
 
+  @spec open_stream_count(t()) :: non_neg_integer()
+  def open_stream_count(collection), do: collection.pid_to_id |> map_size()
+
   @spec last_stream_id(t()) :: Bandit.HTTP2.Stream.stream_id()
   def last_stream_id(collection), do: collection.last_stream_id
 end

--- a/test/bandit/http2/protocol_test.exs
+++ b/test/bandit/http2/protocol_test.exs
@@ -234,6 +234,16 @@ defmodule HTTP2ProtocolTest do
       assert_receive {:log, %{level: :error, msg: {:string, msg}}}, 500
       assert msg == "** (Bandit.HTTP2.Errors.ConnectionError) Connection count exceeded"
     end
+
+    @tag :capture_log
+    test "max_requests zero does not put a limit", context do
+      context = https_server(context, http_2_options: [max_requests: 0])
+      socket = SimpleH2Client.setup_connection(context)
+      port = context[:port]
+      SimpleH2Client.send_simple_headers(socket, 1, :get, "/body_response", port)
+      {:ok, 1, false, _, _} = SimpleH2Client.recv_headers(socket)
+      assert SimpleH2Client.recv_body(socket) == {:ok, 1, true, "OK"}
+    end
   end
 
   describe "settings exchange" do

--- a/test/bandit/http2/protocol_test.exs
+++ b/test/bandit/http2/protocol_test.exs
@@ -1,6 +1,7 @@
 defmodule HTTP2ProtocolTest do
   use ExUnit.Case, async: true
   use ServerHelpers
+  use Machete
 
   import Bitwise
 
@@ -3048,6 +3049,101 @@ defmodule HTTP2ProtocolTest do
 
     def unquote(:*)(conn) do
       echo_components(conn)
+    end
+  end
+
+  describe "max_concurrent_streams flag" do
+    test "refuses streams when max_concurrent_streams limit is exceeded", context do
+      context =
+        context
+        |> https_server(http_2_options: [default_local_settings: [max_concurrent_streams: 2]])
+        |> Enum.into(context)
+
+      port = context.port
+
+      socket = setup_connection_with_custom_settings(context)
+
+      {:ok, send_ctx} =
+        SimpleH2Client.send_simple_headers(socket, 1, :get, "/slow_body_response", port)
+
+      {:ok, send_ctx} =
+        SimpleH2Client.send_simple_headers(socket, 3, :get, "/slow_body_response", port, send_ctx)
+
+      {:ok, send_ctx} =
+        SimpleH2Client.send_simple_headers(socket, 5, :get, "/slow_body_response", port, send_ctx)
+
+      t0 = for _ <- 1..3, do: SimpleH2Client.recv_frame(socket)
+
+      # Now fourth stream should be accepted since we're below the limit again
+      SimpleH2Client.send_simple_headers(socket, 7, :get, "/echo", context.port, send_ctx)
+
+      t1 = for _ <- 1..5, do: SimpleH2Client.recv_frame(socket)
+
+      t0
+      |> Enum.concat(t1)
+      |> assert
+      ~> in_any_order([
+        {:ok, :headers, integer(), 1, string()},
+        {:ok, :data, integer(), 1, "OK"},
+        {:ok, :headers, integer(), 3, string()},
+        {:ok, :data, integer(), 3, "OK"},
+        {:ok, :rst_stream, 0, 5, <<7::32>>},
+        {:ok, :headers, integer(), 7, string()},
+        {:ok, :data, integer(), 7, "OK"}
+      ])
+
+      assert Transport.recv(socket, 0) == {:error, :closed}
+    end
+
+    test "allows new streams after previous streams complete", context do
+      context =
+        context
+        |> https_server(http_2_options: [default_local_settings: [max_concurrent_streams: 2]])
+        |> Enum.into(context)
+
+      port = context.port
+
+      socket = setup_connection_with_custom_settings(context)
+
+      {:ok, send_ctx} =
+        SimpleH2Client.send_simple_headers(socket, 1, :get, "/slow_body_response", port)
+
+      {:ok, send_ctx} =
+        SimpleH2Client.send_simple_headers(socket, 3, :get, "/slow_body_response", port, send_ctx)
+
+      t0 = for _ <- 1..2, do: SimpleH2Client.recv_frame(socket)
+
+      SimpleH2Client.send_simple_headers(socket, 5, :get, "/slow_body_response", port, send_ctx)
+
+      t1 = for _ <- 1..5, do: SimpleH2Client.recv_frame(socket)
+
+      t0
+      |> Enum.concat(t1)
+      |> assert
+      ~> in_any_order([
+        {:ok, :headers, integer(), 1, string()},
+        {:ok, :headers, integer(), 3, string()},
+        {:ok, :headers, integer(), 5, string()},
+        {:ok, :data, integer(), 1, "OK"},
+        {:ok, :data, integer(), 3, "OK"},
+        {:ok, :data, integer(), 5, "OK"},
+        {:ok, :goaway, 0, 0, <<5::32, 0::32>>}
+      ])
+
+      assert Transport.recv(socket, 0) == {:error, :closed}
+    end
+
+    def slow_body_response(conn) do
+      Process.sleep(50)
+      conn |> send_resp(200, "OK")
+    end
+
+    # Helper function to set up connection when server has custom settings
+    defp setup_connection_with_custom_settings(context) do
+      socket = SimpleH2Client.tls_client(context)
+      SimpleH2Client.exchange_prefaces(socket, true)
+      SimpleH2Client.exchange_client_settings(socket)
+      socket
     end
   end
 end

--- a/test/support/simple_h2_client.ex
+++ b/test/support/simple_h2_client.ex
@@ -12,9 +12,16 @@ defmodule SimpleH2Client do
     socket
   end
 
-  def exchange_prefaces(socket) do
+  def exchange_prefaces(socket, with_settings \\ false) do
     Transport.send(socket, "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
-    {:ok, <<0, 0, 0, 4, 0, 0, 0, 0, 0>>} = Transport.recv(socket, 9)
+    {:ok, <<length::24, 4, 0, 0, 0, 0, 0>>} = Transport.recv(socket, 9)
+
+    if with_settings and length > 0 do
+      {:ok, _settings_data} = Transport.recv(socket, length)
+    else
+      0 = length
+    end
+
     Transport.send(socket, <<0, 0, 0, 4, 1, 0, 0, 0, 0>>)
   end
 


### PR DESCRIPTION
Splitting from https://github.com/mtrudel/bandit/pull/520, this adds support for https://datatracker.ietf.org/doc/html/rfc9113#SETTINGS_MAX_CONCURRENT_STREAMS just as described in the RFC. Also tried to optimise the code a tiny bit here in isolation.

Note that this is be vulnerable to rapid resets, but that was actually already existing, original code had no limitation in this factor of resource consumption.

When it comes to hot code, this had three conditionals and now still has three conditionals. What this add is three more map lookups that I'm not sure how to reasonably optimise without Knuth screaming behind my ears 🤔

@mtrudel 💪🏽 