### PR TITLE
Start using `:proc_lib.set_label/1` if available

### DIFF
--- a/lib/bandit/clock.ex
+++ b/lib/bandit/clock.ex
@@ -8,6 +8,7 @@ defmodule Bandit.Clock do
   use Task, restart: :permanent
 
   require Logger
+  alias Bandit.Util
 
   @doc """
   Returns the current timestamp according to RFC9110§5.6.7.
@@ -36,6 +37,8 @@ defmodule Bandit.Clock do
 
   @spec init :: no_return()
   def init do
+    Util.set_label(__MODULE__)
+
     __MODULE__ = :ets.new(__MODULE__, [:set, :protected, :named_table, {:read_concurrency, true}])
 
     run()

--- a/lib/bandit/delegating_handler.ex
+++ b/lib/bandit/delegating_handler.ex
@@ -7,8 +7,12 @@ defmodule Bandit.DelegatingHandler do
 
   use ThousandIsland.Handler
 
+  alias Bandit.Util
+
   @impl ThousandIsland.Handler
   def handle_connection(socket, %{handler_module: handler_module} = state) do
+    Util.set_label({__MODULE__, handler_module})
+
     handler_module.handle_connection(socket, state)
     |> handle_bandit_continuation(socket)
   end

--- a/lib/bandit/http2/handler.ex
+++ b/lib/bandit/http2/handler.ex
@@ -9,8 +9,22 @@ defmodule Bandit.HTTP2.Handler do
 
   use ThousandIsland.Handler
 
+  alias Bandit.Util
+
   @impl ThousandIsland.Handler
   def handle_connection(socket, state) do
+    label =
+      case Bandit.SocketHelpers.safe_peer_data(socket) do
+        {:ok, peer_data} ->
+          client_info = "#{:inet.ntoa(peer_data.address)}:#{peer_data.port}"
+          {__MODULE__, client_info}
+
+        {:error, _reason} ->
+          __MODULE__
+      end
+
+    Util.set_label(label)
+
     connection = Bandit.HTTP2.Connection.init(socket, state.plug, state.opts)
     {:continue, Map.merge(state, %{buffer: <<>>, connection: connection})}
   rescue

--- a/lib/bandit/http2/stream_process.ex
+++ b/lib/bandit/http2/stream_process.ex
@@ -9,6 +9,8 @@ defmodule Bandit.HTTP2.StreamProcess do
 
   use GenServer, restart: :temporary
 
+  alias Bandit.Util
+
   @spec start_link(
           Bandit.HTTP2.Stream.t(),
           Bandit.Pipeline.plug_def(),
@@ -25,6 +27,7 @@ defmodule Bandit.HTTP2.StreamProcess do
 
   @impl GenServer
   def handle_continue(:start_stream, {stream, plug, connection_span, conn_data, opts} = state) do
+    Util.set_label({__MODULE__, stream.stream_id})
     _ = Bandit.Pipeline.run(stream, plug, connection_span, conn_data, opts)
     {:stop, :normal, state}
   end

--- a/lib/bandit/initial_handler.ex
+++ b/lib/bandit/initial_handler.ex
@@ -6,6 +6,7 @@ defmodule Bandit.InitialHandler do
 
   use ThousandIsland.Handler
 
+  alias Bandit.Util
   require Logger
 
   @type on_switch_handler ::
@@ -20,6 +21,8 @@ defmodule Bandit.InitialHandler do
   @spec handle_connection(ThousandIsland.Socket.t(), state :: term()) ::
           ThousandIsland.Handler.handler_result() | on_switch_handler()
   def handle_connection(socket, state) do
+    Util.set_label(__MODULE__)
+
     case {state.http_1_enabled, state.http_2_enabled, alpn_protocol(socket), sniff_wire(socket)} do
       {_, _, _, :likely_tls} ->
         Logger.warning("Connection that looks like TLS received on a clear channel",

--- a/lib/bandit/trace.ex
+++ b/lib/bandit/trace.ex
@@ -35,6 +35,7 @@ defmodule Bandit.Trace do
 
   use GenServer
 
+  alias Bandit.Util
   require Logger
 
   @events [
@@ -83,6 +84,7 @@ defmodule Bandit.Trace do
 
   @impl GenServer
   def init(opts) do
+    Util.set_label(__MODULE__)
     _ = :telemetry.attach_many(self(), @events, &__MODULE__.handle_event/4, self())
     {:ok, struct!(%__MODULE__{queue: :queue.new()}, opts)}
   end

--- a/lib/bandit/util.ex
+++ b/lib/bandit/util.ex
@@ -1,0 +1,27 @@
+defmodule Bandit.Util do
+  @moduledoc false
+
+  def labels_supported? do
+    function_exported?(:proc_lib, :get_label, 1) and function_exported?(:proc_lib, :set_label, 1)
+  end
+
+  def get_label(pid) do
+    if function_exported?(:proc_lib, :get_label, 1) do
+      # `apply/3` avoids a compiler warning when OTP doesn't support this
+      # credo:disable-for-next-line
+      apply(:proc_lib, :get_label, [pid])
+    else
+      :undefined
+    end
+  end
+
+  def set_label(label) do
+    if function_exported?(:proc_lib, :set_label, 1) do
+      # `apply/3` avoids a compiler warning when OTP doesn't support this
+      # credo:disable-for-next-line
+      apply(:proc_lib, :set_label, [label])
+    else
+      :ok
+    end
+  end
+end

--- a/lib/bandit/websocket/handler.ex
+++ b/lib/bandit/websocket/handler.ex
@@ -5,11 +5,22 @@ defmodule Bandit.WebSocket.Handler do
   use ThousandIsland.Handler
 
   alias Bandit.Extractor
+  alias Bandit.Util
   alias Bandit.WebSocket.{Connection, Frame}
 
   @impl ThousandIsland.Handler
   def handle_connection(socket, state) do
     {websock, websock_opts, connection_opts} = state.upgrade_opts
+
+    module_name = websock |> to_string() |> String.split(".") |> List.last()
+
+    label =
+      case Bandit.SocketHelpers.safe_peer_data(socket) do
+        {:ok, peer_data} -> "WS[#{module_name}:#{peer_data.port}]"
+        {:error, _reason} -> "WS[#{module_name}]"
+      end
+
+    Util.set_label(label)
 
     connection_opts
     |> Keyword.take([:fullsweep_after, :max_heap_size])

--- a/test/bandit/clock_test.exs
+++ b/test/bandit/clock_test.exs
@@ -2,6 +2,7 @@ defmodule ClockTest do
   use ExUnit.Case, async: false
 
   import ExUnit.CaptureLog
+  alias Bandit.Util
 
   test "clock emits warning if ETS cache isn't available" do
     Application.stop(:bandit)
@@ -15,5 +16,21 @@ defmodule ClockTest do
     assert warnings =~ "Header timestamp couldn't be fetched from ETS cache"
 
     Application.ensure_all_started(:bandit)
+  end
+
+  test "clock process gets labeled" do
+    if Util.labels_supported?() do
+      Process.sleep(100)
+
+      processes = Process.list()
+
+      labeled_processes =
+        for pid <- processes,
+            Util.get_label(pid) == Bandit.Clock do
+          {pid, Bandit.Clock}
+        end
+
+      assert length(labeled_processes) >= 1
+    end
   end
 end

--- a/test/bandit/http1/plug_test.exs
+++ b/test/bandit/http1/plug_test.exs
@@ -175,7 +175,8 @@ defmodule HTTP1PlugTest do
 
     def pdict(conn) do
       existing_pdict =
-        Process.get() |> Keyword.drop(~w[$ancestors $initial_call]a)
+        Process.get()
+        |> Keyword.drop(~w[$ancestors $initial_call $process_label]a)
 
       Process.put(:garbage, :garbage)
       Process.put({:garbage, :test}, :garbage)


### PR DESCRIPTION
Starting in OTP 27.0, `:proc_lib.set_label/1` allows setting labels on processes whether or not they have a registered name. These labels are shown in Observer and in the future may be shown in other tools.

Using such labels has the potential to make a process tree more comprehensible.

Note:
- This is a re-do of https://github.com/mtrudel/bandit/pull/319
- I've been doing related PRs to [elixir](https://github.com/elixir-lang/elixir/pull/14758) and [db_connection](https://github.com/elixir-ecto/db_connection/pull/330/files)
- I'm not sure if these tests are worth the hassle, so I'll happily delete them if not
- I'm totally open to redirection as far as what gets labelled and how 🙂 