### PR TITLE
Fix: short protocol error logging without stacktrace

### DIFF
--- a/lib/bandit/logger.ex
+++ b/lib/bandit/logger.ex
@@ -15,8 +15,10 @@ defmodule Bandit.Logger do
 
     case logging_verbosity do
       :short ->
+        message = Exception.format_banner(:error, error, stacktrace)
+        # Omit stacktraces from crash metadata for short logs.
         logger_metadata = logger_metadata_for(:error, error, [], metadata)
-        Logger.error(Exception.format_banner(:error, error, []), logger_metadata)
+        Logger.error(message, logger_metadata)
 
       :verbose ->
         logger_metadata = logger_metadata_for(:error, error, stacktrace, metadata)

--- a/lib/bandit/logger.ex
+++ b/lib/bandit/logger.ex
@@ -15,8 +15,9 @@ defmodule Bandit.Logger do
 
     case logging_verbosity do
       :short ->
-        logger_metadata = logger_metadata_for(:error, error, stacktrace, metadata)
-        Logger.error(Exception.format_banner(:error, error, stacktrace), logger_metadata)
+        message = Exception.format_banner(:error, error, [])
+        logger_metadata = logger_metadata_for(:error, error, [], metadata)
+        Logger.error(message, logger_metadata)
 
       :verbose ->
         logger_metadata = logger_metadata_for(:error, error, stacktrace, metadata)

--- a/lib/bandit/logger.ex
+++ b/lib/bandit/logger.ex
@@ -15,9 +15,8 @@ defmodule Bandit.Logger do
 
     case logging_verbosity do
       :short ->
-        message = Exception.format_banner(:error, error, [])
         logger_metadata = logger_metadata_for(:error, error, [], metadata)
-        Logger.error(message, logger_metadata)
+        Logger.error(Exception.format_banner(:error, error, []), logger_metadata)
 
       :verbose ->
         logger_metadata = logger_metadata_for(:error, error, stacktrace, metadata)

--- a/test/bandit/http1/protocol_test.exs
+++ b/test/bandit/http1/protocol_test.exs
@@ -125,7 +125,7 @@ defmodule HTTP1ProtocolTest do
       Transport.send(client, "GET / HTTP/1.1\r\nGARBAGE\r\n\r\n")
       assert {:ok, "400 Bad Request", _headers, <<>>} = SimpleHTTP1Client.recv_reply(client)
 
-      assert_receive {:log, log_event}, 500
+      assert_receive {:log, %{level: :error} = log_event}, 500
 
       assert %{
                meta: %{


### PR DESCRIPTION
Fixes #529
- [x] Avoid stacktraces in short protocol error logs.
- [x] Add tests.