### PR TITLE
Fix failing test in elixir 1.19

### DIFF
--- a/test/bandit/http2/plug_test.exs
+++ b/test/bandit/http2/plug_test.exs
@@ -839,7 +839,13 @@ defmodule HTTP2PlugTest do
   end
 
   def ssl_data(conn) do
-    send_resp(conn, 200, conn |> get_ssl_data() |> inspect())
+    body =
+      conn
+      |> get_ssl_data()
+      |> Keyword.take([:protocol, :ciphers])
+      |> inspect(limit: :infinity)
+
+    send_resp(conn, 200, body)
   end
 
   test "silently accepts EXIT messages from normally terminating spawned processes", context do


### PR DESCRIPTION
I don't know for what reason, this started failing in Elixir 1.19. It seems like `Kernel.inspect/1` prints differently by default now, cutting the string short much earlier. `Inspect.Algebra` has implemented changes in its algorithm that seem to affect this.

@mtrudel fixing the CI errors after merging last night's PR.