### PR TITLE
Skip body draining when Connection: close is set

### DIFF
--- a/lib/bandit/http1/socket.ex
+++ b/lib/bandit/http1/socket.ex
@@ -429,6 +429,7 @@ defmodule Bandit.HTTP1.Socket do
     end
 
     def ensure_completed(%@for{read_state: :read} = socket), do: socket
+    def ensure_completed(%@for{keepalive: false} = socket), do: socket
 
     def ensure_completed(%@for{} = socket) do
       case read_data(socket, []) do

--- a/test/bandit/http1/protocol_test.exs
+++ b/test/bandit/http1/protocol_test.exs
@@ -242,6 +242,43 @@ defmodule HTTP1ProtocolTest do
       |> send_resp(200, "OK")
     end
 
+    test "connection: close skips body draining when plug does not read body", context do
+      # Use a longer read timeout so we can verify the connection closes quickly
+      # (i.e., doesn't wait for the timeout to drain the body)
+      context =
+        context
+        |> http_server(thousand_island_options: [read_timeout: 500])
+        |> Enum.into(context)
+
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      # Send headers with a large content-length but don't send any body data
+      Transport.send(
+        client,
+        "POST /close_connection_with_unread_body HTTP/1.1\r\nhost: localhost\r\ncontent-length: 10000000\r\n\r\n"
+      )
+
+      # The plug returns immediately with Connection: close without reading the body
+      # With the fix, this should return quickly without waiting for body read timeout
+      start_time = System.monotonic_time(:millisecond)
+      assert {:ok, "200 OK", headers, _body} = SimpleHTTP1Client.recv_reply(client)
+      assert Enum.any?(headers, fn {k, v} -> k == :connection && String.downcase(v) == "close" end)
+      elapsed = System.monotonic_time(:millisecond) - start_time
+
+      # Should complete well before the 500ms read timeout
+      assert elapsed < 200, "Expected quick response but took #{elapsed}ms"
+
+      # Connection should be closed
+      assert SimpleHTTP1Client.connection_closed_for_reading?(client)
+    end
+
+    def close_connection_with_unread_body(conn) do
+      # Return immediately with Connection: close without reading the body
+      conn
+      |> put_resp_header("connection", "close")
+      |> send_resp(200, "OK")
+    end
+
     test "keepalive mixed-case header connections are respected in HTTP/1.0", context do
       client = SimpleHTTP1Client.tcp_client(context)
 


### PR DESCRIPTION
## Summary

When a response includes a `Connection: close` header (either from the request or response), there's no need to drain the unread request body since the connection will be closed anyway and won't be reused.

This change adds a clause to `ensure_completed` that returns early when `keepalive` is false, avoiding the body read timeout that would otherwise occur when returning early errors for requests with large bodies.

## Problem

When a plug returns an early error (e.g., 401 Unauthorized) with `Connection: close` for a request with a large body that hasn't been read, Bandit currently waits for the body read timeout before closing the connection. This causes unnecessary delays and "Body read timeout" errors.

Example scenario:
1. Client sends a POST request with a 10MB body (file upload)
2. Server returns 401 Unauthorized immediately without reading the body
3. Server sets `Connection: close` header
4. **Before this fix**: Bandit waits 60 seconds (default timeout) trying to drain the body, then raises `Bandit.HTTPError: Body read timeout`
5. **After this fix**: Bandit closes the connection immediately

## Changes

- Added a new clause to `ensure_completed/1` in `Bandit.HTTP1.Socket` that skips body draining when `keepalive: false`
- Added a test that verifies the connection closes quickly when `Connection: close` is set with an unread body

## Test Plan

- [x] New test added: `connection: close skips body draining when plug does not read body`
- [x] All existing HTTP/1 tests pass (156 tests)
- [x] Full test suite passes (661 tests)