### PR TITLE
Add `response_encodings` option to http_options

### DIFF
--- a/lib/bandit.ex
+++ b/lib/bandit.ex
@@ -99,6 +99,9 @@ defmodule Bandit do
   * `compress`: Whether or not to attempt compression of responses via content-encoding
     negotiation as described in
     [RFC9110§8.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4). Defaults to true
+  * `response_encodings`: A list of compression encodings, expressed in order of preference.
+    Defaults to `~w(deflate gzip x-gzip zstd)`, with `zstd` only being present on platforms which
+    have the zstd library compiled in
   * `deflate_options`: A keyword list of options to set on the deflate library. A complete list can
     be found at `t:deflate_options/0`. Note that these options only affect the behaviour of the
     'deflate' content encoding; 'gzip' does not have any configurable options (this is a
@@ -116,6 +119,7 @@ defmodule Bandit do
   """
   @type http_options :: [
           {:compress, boolean()}
+          | {:response_encodings, list()}
           | {:deflate_options, deflate_options()}
           | {:zstd_options, zstd_options()}
           | {:log_exceptions_with_status_codes, list() | Range.t()}
@@ -235,7 +239,7 @@ defmodule Bandit do
   end
 
   @top_level_keys ~w(plug scheme port ip keyfile certfile otp_app cipher_suite display_plug startup_log thousand_island_options http_options http_1_options http_2_options websocket_options)a
-  @http_keys ~w(compress deflate_options log_exceptions_with_status_codes log_protocol_errors log_client_closures)a
+  @http_keys ~w(compress response_encodings deflate_options log_exceptions_with_status_codes log_protocol_errors log_client_closures)a
   @http_1_keys ~w(enabled max_request_line_length max_header_length max_header_count max_requests clear_process_dict gc_every_n_keepalive_requests log_unknown_messages)a
   @http_2_keys ~w(enabled max_header_block_size max_requests max_reset_stream_rate default_local_settings)a
   @websocket_keys ~w(enabled max_frame_size validate_text_frames compress deflate_options primitive_ops_module)a

--- a/lib/bandit/adapter.ex
+++ b/lib/bandit/adapter.ex
@@ -39,7 +39,7 @@ defmodule Bandit.Adapter do
     content_encoding =
       Bandit.Compression.negotiate_content_encoding(
         Bandit.Headers.get_header(headers, "accept-encoding"),
-        Keyword.get(opts.http, :compress, true)
+        opts.http
       )
 
     %__MODULE__{


### PR DESCRIPTION
Follow on from #514 
Fixes #554 
