### PR TITLE
Change precedence of compression orders

### DIFF
--- a/lib/bandit.ex
+++ b/lib/bandit.ex
@@ -100,7 +100,7 @@ defmodule Bandit do
     negotiation as described in
     [RFC9110§8.4](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.4). Defaults to true
   * `response_encodings`: A list of compression encodings, expressed in order of preference.
-    Defaults to `~w(deflate gzip x-gzip zstd)`, with `zstd` only being present on platforms which
+    Defaults to `~w(zstd gzip x-gzip deflate)`, with `zstd` only being present on platforms which
     have the zstd library compiled in
   * `deflate_options`: A keyword list of options to set on the deflate library. A complete list can
     be found at `t:deflate_options/0`. Note that these options only affect the behaviour of the

--- a/lib/bandit/compression.ex
+++ b/lib/bandit/compression.ex
@@ -10,10 +10,10 @@ defmodule Bandit.Compression do
           lib_context: term()
         }
 
-  @accepted_encodings ~w(deflate gzip x-gzip)
+  @accepted_encodings ~w(gzip x-gzip deflate)
 
   if Code.ensure_loaded?(:zstd) do
-    @accepted_encodings @accepted_encodings ++ ["zstd"]
+    @accepted_encodings ~w(zstd) ++ @accepted_encodings
   end
 
   @spec negotiate_content_encoding(nil | binary(), keyword()) :: String.t() | nil


### PR DESCRIPTION
Demote deflate, promote zstd in compression choices.

Relates to #557 