### PR TITLE
feat: http2 sendfile streaming

### DIFF
--- a/lib/bandit.ex
+++ b/lib/bandit.ex
@@ -172,6 +172,8 @@ defmodule Bandit do
     Specified as a tuple of `{count, milliseconds}` where `count` is the maximum number of
     RST_STREAM frames allowed within the time window of `milliseconds`. Defaults to `{500, 10_000}`
     (500 resets per 10 seconds). Setting this to `nil` disables rate limiting
+  * `sendfile_chunk_size`: The maximum number of bytes read per sendfile chunk when streaming
+    HTTP/2 responses. Defaults to 1_048_576 (1 MiB)
   * `default_local_settings`: Options to override the default values for local HTTP/2
     settings. Values provided here will override the defaults specified in RFC9113§6.5.2
   """
@@ -180,6 +182,7 @@ defmodule Bandit do
           | {:max_header_block_size, pos_integer()}
           | {:max_requests, pos_integer()}
           | {:max_reset_stream_rate, {pos_integer(), pos_integer()} | nil}
+          | {:sendfile_chunk_size, pos_integer()}
           | {:default_local_settings, keyword()}
         ]
 
@@ -241,7 +244,7 @@ defmodule Bandit do
   @top_level_keys ~w(plug scheme port ip keyfile certfile otp_app cipher_suite display_plug startup_log thousand_island_options http_options http_1_options http_2_options websocket_options)a
   @http_keys ~w(compress response_encodings deflate_options zstd_options log_exceptions_with_status_codes log_protocol_errors log_client_closures)a
   @http_1_keys ~w(enabled max_request_line_length max_header_length max_header_count max_requests clear_process_dict gc_every_n_keepalive_requests log_unknown_messages)a
-  @http_2_keys ~w(enabled max_header_block_size max_requests max_reset_stream_rate default_local_settings)a
+  @http_2_keys ~w(enabled max_header_block_size max_requests max_reset_stream_rate sendfile_chunk_size default_local_settings)a
   @websocket_keys ~w(enabled max_frame_size validate_text_frames compress deflate_options primitive_ops_module)a
   @thousand_island_keys ThousandIsland.ServerConfig.__struct__()
                         |> Map.from_struct()

--- a/lib/bandit/http2/connection.ex
+++ b/lib/bandit/http2/connection.ex
@@ -227,11 +227,15 @@ defmodule Bandit.HTTP2.Connection do
       :new ->
         new_stream!(connection, stream_id)
 
+        sendfile_chunk_size =
+          Keyword.get(connection.opts.http_2, :sendfile_chunk_size, 1_048_576) || 1_048_576
+
         stream =
           Bandit.HTTP2.Stream.init(
             self(),
             stream_id,
-            connection.remote_settings.initial_window_size
+            connection.remote_settings.initial_window_size,
+            sendfile_chunk_size
           )
 
         case Bandit.HTTP2.StreamProcess.start_link(

--- a/lib/bandit/http2/connection.ex
+++ b/lib/bandit/http2/connection.ex
@@ -228,7 +228,7 @@ defmodule Bandit.HTTP2.Connection do
         new_stream!(connection, stream_id)
 
         sendfile_chunk_size =
-          Keyword.get(connection.opts.http_2, :sendfile_chunk_size, 1_048_576) || 1_048_576
+          Keyword.get(connection.opts.http_2, :sendfile_chunk_size, 1_048_576)
 
         stream =
           Bandit.HTTP2.Stream.init(

--- a/test/bandit/http2/protocol_test.exs
+++ b/test/bandit/http2/protocol_test.exs
@@ -271,10 +271,15 @@ defmodule HTTP2ProtocolTest do
       conn |> send_resp(200, String.duplicate("a", 50_000))
     end
 
-    test "sendfile streams in multiple DATA frames when max frame size allows large frames", context do
+    test "sendfile streams in multiple DATA frames when max frame size allows large frames",
+         context do
       size = 1_500_000
+
       tmp_path =
-        Path.join(System.tmp_dir!(), "bandit-sendfile-large-#{System.unique_integer([:positive])}")
+        Path.join(
+          System.tmp_dir!(),
+          "bandit-sendfile-large-#{System.unique_integer([:positive])}"
+        )
 
       File.write!(tmp_path, :binary.copy(<<"a">>, size))
       :persistent_term.put({__MODULE__, :large_sendfile_path}, tmp_path)
@@ -286,6 +291,7 @@ defmodule HTTP2ProtocolTest do
 
       socket = SimpleH2Client.tls_client(context)
       SimpleH2Client.exchange_prefaces(socket)
+
       SimpleH2Client.exchange_client_settings(
         socket,
         <<4::16, 3_000_000::32, 5::16, 2_000_000::32>>

--- a/test/bandit/http2/protocol_test.exs
+++ b/test/bandit/http2/protocol_test.exs
@@ -271,6 +271,43 @@ defmodule HTTP2ProtocolTest do
       conn |> send_resp(200, String.duplicate("a", 50_000))
     end
 
+    test "sendfile streams in multiple DATA frames when max frame size allows large frames", context do
+      size = 1_500_000
+      tmp_path =
+        Path.join(System.tmp_dir!(), "bandit-sendfile-large-#{System.unique_integer([:positive])}")
+
+      File.write!(tmp_path, :binary.copy(<<"a">>, size))
+      :persistent_term.put({__MODULE__, :large_sendfile_path}, tmp_path)
+
+      on_exit(fn ->
+        :persistent_term.erase({__MODULE__, :large_sendfile_path})
+        File.rm(tmp_path)
+      end)
+
+      socket = SimpleH2Client.tls_client(context)
+      SimpleH2Client.exchange_prefaces(socket)
+      SimpleH2Client.exchange_client_settings(
+        socket,
+        <<4::16, 3_000_000::32, 5::16, 2_000_000::32>>
+      )
+
+      SimpleH2Client.send_window_update(socket, 0, 3_000_000)
+      SimpleH2Client.send_simple_headers(socket, 1, :get, "/sendfile_large_chunked", context.port)
+
+      assert {:ok, 1, false, [{":status", "200"} | _], _ctx} =
+               SimpleH2Client.recv_headers(socket)
+
+      assert {:ok, 1, false, first} = SimpleH2Client.recv_body(socket)
+      assert byte_size(first) > 0
+      assert {:ok, 1, true, second} = SimpleH2Client.recv_body(socket)
+      assert byte_size(second) > 0
+    end
+
+    def sendfile_large_chunked(conn) do
+      path = :persistent_term.get({__MODULE__, :large_sendfile_path})
+      send_file(conn, 200, path, 0, :all)
+    end
+
     test "the server preserves existing settings which are NOT sent by the client", context do
       socket = SimpleH2Client.tls_client(context)
       SimpleH2Client.exchange_prefaces(socket)


### PR DESCRIPTION
Hi, 

I noticed that downloads do not stream, causing the entire file to be read from disk before the download can begin. This is fine for small files, but I have many very large files I'm managing that require much faster immediate resolution and send behavior. 

This adds configurable chunking to the sendfile endpoint to resolve the slow download setup, immediately sending headers for the download and starting it. In my testing, downloads started around 5-10x faster with an 8GB file from my remote server. 

Please let me know if I've missed anything or any required changes, I'm relatively new to elixir so I may not have the patterns down yet. 