### PR TITLE
Send 1000 on {:shutdown, :disconnected}

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -54,7 +54,7 @@
           #
           {Credo.Check.Refactor.Apply, []},
           {Credo.Check.Refactor.CondStatements, []},
-          {Credo.Check.Refactor.CyclomaticComplexity, [max_complexity: 15]},
+          {Credo.Check.Refactor.CyclomaticComplexity, [max_complexity: 16]},
           {Credo.Check.Refactor.FunctionArity, []},
           {Credo.Check.Refactor.LongQuoteBlocks, []},
           {Credo.Check.Refactor.MatchInCondition, []},

--- a/lib/bandit/websocket/connection.ex
+++ b/lib/bandit/websocket/connection.ex
@@ -211,6 +211,9 @@ defmodule Bandit.WebSocket.Connection do
           other -> other
         end
 
+      {:stop, {:shutdown, :disconnected}, websock_state} ->
+        do_stop(1000, :normal, socket, %{connection | websock_state: websock_state})
+
       {:stop, {:shutdown, :restart}, websock_state} ->
         do_stop(1012, :normal, socket, %{connection | websock_state: websock_state})
 

--- a/test/bandit/websocket/sock_test.exs
+++ b/test/bandit/websocket/sock_test.exs
@@ -200,6 +200,19 @@ defmodule WebSocketWebSockTest do
       assert SimpleWebSocketClient.connection_closed_for_reading?(client)
     end
 
+    defmodule InitCloseWithDisconnectedWebSock do
+      use NoopWebSock
+      def init(_opts), do: {:stop, {:shutdown, :disconnected}, :init}
+    end
+
+    test "can close a connection by returning an {:shutdown, :disconnected} tuple", context do
+      client = SimpleWebSocketClient.tcp_client(context)
+      SimpleWebSocketClient.http1_handshake(client, InitCloseWithDisconnectedWebSock)
+
+      assert SimpleWebSocketClient.recv_connection_close_frame(client) == {:ok, <<1000::16>>}
+      assert SimpleWebSocketClient.connection_closed_for_reading?(client)
+    end
+
     defmodule InitCloseWithCodeAndNilDetailWebSock do
       use NoopWebSock
       def init(_opts), do: {:stop, :normal, {5555, nil}, :init}
@@ -482,6 +495,21 @@ defmodule WebSocketWebSockTest do
       SimpleWebSocketClient.send_text_frame(client, "OK")
 
       assert SimpleWebSocketClient.recv_connection_close_frame(client) == {:ok, <<1012::16>>}
+      assert SimpleWebSocketClient.connection_closed_for_reading?(client)
+    end
+
+    defmodule HandleInCloseWithDisconnectedWebSock do
+      use NoopWebSock
+      def handle_in(_data, state), do: {:stop, {:shutdown, :disconnected}, state}
+    end
+
+    test "can close a connection by returning an {:shutdown, :disconnected} tuple", context do
+      client = SimpleWebSocketClient.tcp_client(context)
+      SimpleWebSocketClient.http1_handshake(client, HandleInCloseWithDisconnectedWebSock)
+
+      SimpleWebSocketClient.send_text_frame(client, "OK")
+
+      assert SimpleWebSocketClient.recv_connection_close_frame(client) == {:ok, <<1000::16>>}
       assert SimpleWebSocketClient.connection_closed_for_reading?(client)
     end
 
@@ -814,6 +842,22 @@ defmodule WebSocketWebSockTest do
       assert SimpleWebSocketClient.connection_closed_for_reading?(client)
     end
 
+    defmodule HandleControlCloseWithDisconnectedWebSock do
+      use NoopWebSock
+      def handle_control(_data, state), do: {:stop, {:shutdown, :disconnected}, state}
+    end
+
+    test "can close a connection by returning an {:shutdown, :disconnected} tuple", context do
+      client = SimpleWebSocketClient.tcp_client(context)
+      SimpleWebSocketClient.http1_handshake(client, HandleControlCloseWithDisconnectedWebSock)
+
+      SimpleWebSocketClient.send_ping_frame(client, "OK")
+      _ = SimpleWebSocketClient.recv_pong_frame(client)
+
+      assert SimpleWebSocketClient.recv_connection_close_frame(client) == {:ok, <<1000::16>>}
+      assert SimpleWebSocketClient.connection_closed_for_reading?(client)
+    end
+
     defmodule HandleControlCloseWithCodeAndNilDetailWebSock do
       use NoopWebSock
       def handle_control(_data, state), do: {:stop, :normal, {5555, nil}, state}
@@ -1111,6 +1155,25 @@ defmodule WebSocketWebSockTest do
       Process.send(pid, "OK", [])
 
       assert SimpleWebSocketClient.recv_connection_close_frame(client) == {:ok, <<1012::16>>}
+      assert SimpleWebSocketClient.connection_closed_for_reading?(client)
+    end
+
+    defmodule HandleInfoCloseWithDisconnectedWebSock do
+      use NoopWebSock
+      def handle_in(_data, state), do: {:push, {:text, :erlang.pid_to_list(self())}, state}
+      def handle_info(_data, state), do: {:stop, {:shutdown, :disconnected}, state}
+    end
+
+    test "can close a connection by returning an {:shutdown, :disconnected} tuple", context do
+      client = SimpleWebSocketClient.tcp_client(context)
+      SimpleWebSocketClient.http1_handshake(client, HandleInfoCloseWithDisconnectedWebSock)
+
+      SimpleWebSocketClient.send_text_frame(client, "whoami")
+      {:ok, pid} = SimpleWebSocketClient.recv_text_frame(client)
+      pid = pid |> String.to_charlist() |> :erlang.list_to_pid()
+      Process.send(pid, "OK", [])
+
+      assert SimpleWebSocketClient.recv_connection_close_frame(client) == {:ok, <<1000::16>>}
       assert SimpleWebSocketClient.connection_closed_for_reading?(client)
     end
 


### PR DESCRIPTION
## Background
We currently use Cowboy in our production system and tried switching to Bandit. This turned out to not be possible, as we started getting errors on client side, due to sockets being closed with code 1011.
After some investigation we found that this is because we broadcast "disconnect" to the id socket channel, in order to disconnect all user's sockets (as in [this](https://hexdocs.pm/phoenix/Phoenix.Socket.html#module-examples) example). In Bandit this goes to catch-all `{:stop, reason, websock_state}`, while in Cowboy, this goes through adapter [here](https://github.com/phoenixframework/websock_adapter/blob/1b0b2370e5e08b1474576bba34c991b6b5dbe977/lib/websock_adapter/cowboy_adapter.ex#L92) and so is then interpreted as a normal stop reason.
This is also very easy to reproduce by just generating two new phoenix apps with a single channel, one using cowboy and one using bandit. Then have a client join the channel, have an `:after_join` self-sent message trigger a disconnect, and observe the code on the client.

## Proposed change
We'd like to add `{:shutdown, :disconnected}` as one of the cases with 1000 code on close, as we believe this would fall under "socket being closed because it's purpose has been fulfilled" as defined in the [RFC](https://www.rfc-editor.org/rfc/rfc6455.html#section-7.4.1) and definitely doesn't fit 1011's "server is terminating the connection because it encountered an unexpected condition that prevented it from fulfilling the request".