### PR TITLE
Stop handling . and .. paths specially

### DIFF
--- a/lib/bandit/http2/stream.ex
+++ b/lib/bandit/http2/stream.ex
@@ -160,16 +160,9 @@ defmodule Bandit.HTTP2.Stream do
       |> case do
         nil -> stream_error!("Received empty :path", stream)
         "*" -> :*
-        "/" <> _ = path -> split_path!(path, stream)
+        "/" <> _ = path -> path
         _ -> stream_error!("Path does not start with /", stream)
       end
-    end
-
-    # RFC9113§8.3.1 - path should match the path-absolute production from RFC3986
-    defp split_path!(path, stream) do
-      if path |> String.split("/") |> Enum.all?(&(&1 not in [".", ".."])),
-        do: path,
-        else: stream_error!("Path contains dot segment", stream)
     end
 
     # RFC9113§8.3 - pseudo headers must appear first

--- a/test/bandit/http2/protocol_test.exs
+++ b/test/bandit/http2/protocol_test.exs
@@ -2891,24 +2891,6 @@ defmodule HTTP2ProtocolTest do
 
       headers = [
         {":method", "GET"},
-        {":path", "/../non_absolute_path"},
-        {":scheme", "https"},
-        {"host", "banana:#{context.port}"}
-      ]
-
-      SimpleH2Client.send_headers(socket, 1, true, headers)
-      assert SimpleH2Client.recv_rst_stream(socket) == {:ok, 1, 1}
-
-      assert_receive {:log, %{level: :error, msg: {:string, msg}, meta: %{stream_id: 1}}}, 500
-      assert msg == "** (Bandit.HTTP2.Errors.StreamError) Path contains dot segment"
-    end
-
-    @tag :capture_log
-    test "returns stream error if path has no leading slash", context do
-      socket = SimpleH2Client.setup_connection(context)
-
-      headers = [
-        {":method", "GET"},
         {":path", "path_without_leading_slash"},
         {":scheme", "https"},
         {"host", "banana:#{context.port}"}
@@ -3120,24 +3102,6 @@ defmodule HTTP2ProtocolTest do
 
     @tag :capture_log
     test "returns stream error if a non-absolute path is send", context do
-      socket = SimpleH2Client.setup_connection(context)
-
-      headers = [
-        {":method", "GET"},
-        {":path", "/../non_absolute_path"},
-        {":scheme", "https"},
-        {":authority", "banana:#{context.port}"}
-      ]
-
-      SimpleH2Client.send_headers(socket, 1, true, headers)
-      assert SimpleH2Client.recv_rst_stream(socket) == {:ok, 1, 1}
-
-      assert_receive {:log, %{level: :error, msg: {:string, msg}, meta: %{stream_id: 1}}}, 500
-      assert msg == "** (Bandit.HTTP2.Errors.StreamError) Path contains dot segment"
-    end
-
-    @tag :capture_log
-    test "returns stream error if path has no leading slash", context do
       socket = SimpleH2Client.setup_connection(context)
 
       headers = [


### PR DESCRIPTION
[RFC 9113 says](https://www.rfc-editor.org/rfc/rfc9113.html#name-request-pseudo-header-field) that for the relevant request type, the :path pseudo-header needs to be a valid absolute-path production, optionally followed by ? and a query production (all sourced from https://www.rfc-editor.org/rfc/rfc3986.txt). The absolute-path production specifically allows percent encoded values, as well as . and .. segments. Simply put, any absolute path containing either of them is fully valid per the spec; our current implementation is needlessly prescriptive about this.

Bandit's [explicit primary goal](https://github.com/mtrudel/bandit#project-goals) is to have as little policy as possible beyond that which is required to adhere to the relevant RFCs, and I see no reason why this is an exception.