### PR TITLE
fix: keep websocket read timeout tied to reads

### DIFF
--- a/lib/bandit/websocket/handler.ex
+++ b/lib/bandit/websocket/handler.ex
@@ -24,6 +24,7 @@ defmodule Bandit.WebSocket.Handler do
       state
       |> Map.take([:handler_module])
       |> Map.put(:extractor, Extractor.new(Frame, primitive_ops_module, connection_opts))
+      |> Map.put(:last_read_at, monotonic_now())
 
     case Connection.init(websock, websock_opts, connection_opts, socket) do
       {:continue, connection} ->
@@ -41,7 +42,7 @@ defmodule Bandit.WebSocket.Handler do
   def handle_data(data, socket, state) do
     state.extractor
     |> Extractor.push_data(data)
-    |> pop_frame(socket, state)
+    |> pop_frame(socket, %{state | last_read_at: monotonic_now()})
   end
 
   defp pop_frame(extractor, socket, state) do
@@ -83,15 +84,26 @@ defmodule Bandit.WebSocket.Handler do
   def handle_timeout(socket, state), do: Connection.handle_timeout(socket, state.connection)
 
   def handle_info({:plug_conn, :sent}, {socket, state}),
-    do: {:noreply, {socket, state}, socket.read_timeout}
+    do: {:noreply, {socket, state}, read_timeout(socket, state)}
 
   def handle_info(msg, {socket, state}) do
     case Connection.handle_info(msg, socket, state.connection) do
       {:continue, connection_state} ->
-        {:noreply, {socket, %{state | connection: connection_state}}, socket.read_timeout}
+        state = %{state | connection: connection_state}
+        {:noreply, {socket, state}, read_timeout(socket, state)}
 
       {:error, reason, connection_state} ->
         {:stop, reason, {socket, %{state | connection: connection_state}}}
     end
   end
+
+  defp read_timeout(%{read_timeout: timeout}, %{last_read_at: last_read_at})
+       when is_integer(timeout) do
+    elapsed = monotonic_now() - last_read_at
+    max(timeout - elapsed, 0)
+  end
+
+  defp read_timeout(socket, _state), do: socket.read_timeout
+
+  defp monotonic_now, do: System.monotonic_time(:millisecond)
 end

--- a/test/bandit/websocket/sock_test.exs
+++ b/test/bandit/websocket/sock_test.exs
@@ -1551,5 +1551,33 @@ defmodule WebSocketWebSockTest do
                error: :timeout
              }
     end
+
+    defmodule PeriodicPushWebSock do
+      use NoopWebSock
+
+      def handle_in(_data, state), do: {:push, {:text, :erlang.pid_to_list(self())}, state}
+      def handle_info(:push, state), do: {:push, {:text, "tick"}, state}
+    end
+
+    test "local websocket messages do not extend the read timeout", context do
+      context = http_server(context, thousand_island_options: [read_timeout: 100])
+      TelemetryHelpers.attach_all_events(PeriodicPushWebSock) |> on_exit()
+
+      client = SimpleWebSocketClient.tcp_client(context)
+      SimpleWebSocketClient.http1_handshake(client, PeriodicPushWebSock)
+      SimpleWebSocketClient.send_text_frame(client, "whoami")
+      {:ok, pid} = SimpleWebSocketClient.recv_text_frame(client)
+      pid = pid |> String.to_charlist() |> :erlang.list_to_pid()
+
+      for _ <- 1..2 do
+        Process.sleep(25)
+        Process.send(pid, :push, [])
+        assert SimpleWebSocketClient.recv_text_frame(client) == {:ok, "tick"}
+      end
+
+      assert_receive {:telemetry, [:bandit, :websocket, :stop], _measurements,
+                      %{error: :timeout}},
+                     500
+    end
   end
 end


### PR DESCRIPTION
## Summary
- track the timestamp of the last inbound WebSocket data
- keep Thousand Island read timeout scheduling relative to inbound reads, not local `handle_info/2` pushes
- add a regression test where periodic local pushes still end in a read timeout

## Tests
- `mix test test/bandit/websocket/sock_test.exs`
