### PR TITLE
fix transfer-encoding

### DIFF
--- a/lib/bandit/http1/socket.ex
+++ b/lib/bandit/http1/socket.ex
@@ -60,7 +60,7 @@ defmodule Bandit.HTTP1.Socket do
       {method, request_target, socket} = do_read_request_line!(socket)
       {headers, socket} = do_read_headers!(socket)
       content_length = get_content_length!(headers)
-      body_encoding = Bandit.Headers.get_header(headers, "transfer-encoding")
+      body_encoding = safe_downcase(Bandit.Headers.get_header(headers, "transfer-encoding"))
       request_connection_header = safe_downcase(Bandit.Headers.get_header(headers, "connection"))
       socket = %{socket | request_connection_header: request_connection_header}
 

--- a/test/bandit/http1/protocol_test.exs
+++ b/test/bandit/http1/protocol_test.exs
@@ -1063,6 +1063,25 @@ defmodule HTTP1ProtocolTest do
       send_resp(conn, 200, "OK")
     end
 
+    test "reads a chunked body with a non-lowercase transfer-encoding value", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "POST", "/expect_case_insensitive_chunked_body", [
+        "Host: localhost",
+        "Transfer-encoding: Chunked"
+      ])
+
+      Transport.send(client, "3\r\n123\r\n")
+      Transport.send(client, "0\r\n\r\n")
+      assert SimpleHTTP1Client.recv_reply(client) ~> {:ok, "200 OK", list(), "OK"}
+    end
+
+    def expect_case_insensitive_chunked_body(conn) do
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      assert body == "123"
+      send_resp(conn, 200, "OK")
+    end
+
     test "reads a chunked body properly", context do
       stream =
         Stream.repeatedly(fn -> String.duplicate("0123456789", 100_000) end)


### PR DESCRIPTION
added safe_downcase to headers -> "transfer-encoding" too
(Mac webdav sends "Chunked" instead of "chunked")