### PR TITLE
fix(websocket): do not reset read timeout on outbound "sent" for WS connections

### DIFF
--- a/lib/bandit/websocket/handler.ex
+++ b/lib/bandit/websocket/handler.ex
@@ -83,7 +83,13 @@ defmodule Bandit.WebSocket.Handler do
   def handle_timeout(socket, state), do: Connection.handle_timeout(socket, state.connection)
 
   def handle_info({:plug_conn, :sent}, {socket, state}),
-    do: {:noreply, {socket, state}, socket.read_timeout}
+    # Do not reset the read timeout on outbound "sent" for WS. This ensures that a
+    # silent half-open connection (no inbound client frames/heartbeats) will still
+    # be reaped by the transport read_timeout even if the server continues to
+    # generate outbound traffic (e.g. LV diffs, PubSub). Resetting on send was
+    # keeping such connections alive indefinitely (unlike Cowboy behavior).
+    # See mtrudel/bandit#577.
+    do: {:noreply, {socket, state}}
 
   def handle_info(msg, {socket, state}) do
     case Connection.handle_info(msg, socket, state.connection) do


### PR DESCRIPTION
## Summary
A WebSocket connection that has become silently half-open (server can "send" but receives no FIN/RST or client frames) would stay alive indefinitely in Bandit if the application continued to generate outbound WS traffic for it (e.g. LiveView diffs every 5s via PubSub, or other periodic server pushes).

This did not happen under Cowboy.

## Root cause
In `Bandit.WebSocket.Handler`, `handle_info({:plug_conn, :sent}, ...)` did:
```elixir
{:noreply, {socket, state}, socket.read_timeout}
```
This rescheduled the ThousandIsland transport `read_timeout` on every outbound send.

Since the read_timeout is the mechanism for reaping idle connections (leading to `handle_timeout` -> close), continuous server sends kept pushing the timer out, even with zero client activity.

The WS layer has no separate "last client inbound activity" timer or mandatory ping/pong enforcement to probe the client independently of server traffic.

## Fix
Do not return/reset the `read_timeout` on the `{:plug_conn, :sent}` message for WS handlers. The timeout scheduled from the last actual client read (or initial) can now fire if the client goes silent, allowing the connection (and attached LV transports) to be reaped.

The `sent` reset appears to have been for HTTP/1 keepalive connection reuse; for long-lived WS it defeats client-driven idle detection.

## Validation
- Targeted change only in the WS sent handler.
- Existing ping/pong, close, error, and timeout paths in Connection/Handler unchanged.
- Gate will run compile/test/credo/etc.

Fixes mtrudel/bandit#577