### PR TITLE
Cache HTTP/1 connection data

### DIFF
--- a/lib/bandit/http1/handler.ex
+++ b/lib/bandit/http1/handler.ex
@@ -8,13 +8,22 @@ defmodule Bandit.HTTP1.Handler do
   def handle_data(data, socket, state) do
     transport = %Bandit.HTTP1.Socket{socket: socket, buffer: data, opts: state.opts}
     connection_span = ThousandIsland.Socket.telemetry_span(socket)
-    conn_data = Bandit.SocketHelpers.conn_data(socket)
+    {conn_data, state} = conn_data(socket, state)
 
     case Bandit.Pipeline.run(transport, state.plug, connection_span, conn_data, state.opts) do
       {:ok, transport} -> maybe_keepalive(transport, state)
       {:error, _reason} -> {:close, state}
       {:upgrade, _transport, :websocket, opts} -> do_websocket_upgrade(opts, state)
     end
+  end
+
+  defp conn_data(_socket, %{bandit_conn_data: conn_data} = state) do
+    {conn_data, state}
+  end
+
+  defp conn_data(socket, state) do
+    conn_data = Bandit.SocketHelpers.conn_data(socket)
+    {conn_data, Map.put(state, :bandit_conn_data, conn_data)}
   end
 
   defp maybe_keepalive(transport, state) do

--- a/lib/bandit/http1/handler.ex
+++ b/lib/bandit/http1/handler.ex
@@ -5,25 +5,26 @@ defmodule Bandit.HTTP1.Handler do
   use ThousandIsland.Handler
 
   @impl ThousandIsland.Handler
+  def handle_connection(socket, state) do
+    {:continue, Map.put(state, :conn_data, Bandit.SocketHelpers.conn_data(socket))}
+  end
+
+  @impl ThousandIsland.Handler
   def handle_data(data, socket, state) do
     transport = %Bandit.HTTP1.Socket{socket: socket, buffer: data, opts: state.opts}
     connection_span = ThousandIsland.Socket.telemetry_span(socket)
-    {conn_data, state} = conn_data(socket, state)
 
-    case Bandit.Pipeline.run(transport, state.plug, connection_span, conn_data, state.opts) do
+    case Bandit.Pipeline.run(
+           transport,
+           state.plug,
+           connection_span,
+           state.conn_data,
+           state.opts
+         ) do
       {:ok, transport} -> maybe_keepalive(transport, state)
       {:error, _reason} -> {:close, state}
       {:upgrade, _transport, :websocket, opts} -> do_websocket_upgrade(opts, state)
     end
-  end
-
-  defp conn_data(_socket, %{bandit_conn_data: conn_data} = state) do
-    {conn_data, state}
-  end
-
-  defp conn_data(socket, state) do
-    conn_data = Bandit.SocketHelpers.conn_data(socket)
-    {conn_data, Map.put(state, :bandit_conn_data, conn_data)}
   end
 
   defp maybe_keepalive(transport, state) do


### PR DESCRIPTION
Assisted-by: Codex CLI : GPT 5.5

Avoid repeated peername lookups on HTTP/1 keep-alive requests by caching immutable conn_data in handler state.

Turns conn_data computation from “once per request” into “once per HTTP/1 connection.”

Benchmarked with 250k keep-alive requests / 10 headers: ~5% faster on average.