### PR TITLE
Stream a length-delimited body from send_chunked when Content-Length is set

### DIFF
--- a/lib/bandit/adapter.ex
+++ b/lib/bandit/adapter.ex
@@ -164,7 +164,21 @@ defmodule Bandit.Adapter do
     start_time = Bandit.Telemetry.monotonic_time()
     metrics = Map.put(adapter.metrics, :resp_start_time, start_time)
 
-    {headers, compression_context} = Bandit.Compression.new(adapter, status, headers, false, true)
+    # When the caller declares a content-length up front, stream a
+    # length-delimited body instead of chunked transfer-encoding. The HTTP/1
+    # transport already does this (the `:chunk_encoded when has_content_length`
+    # path writes raw bytes via the `:chunk_streaming` write state), and HTTP/2
+    # carries the length in its header block with no framing change. Response
+    # compression would rewrite the body and invalidate the declared length, so
+    # it is disabled in this mode — the caller owns the exact bytes and must send
+    # precisely `content-length` of them via chunk/2.
+    {headers, compression_context} =
+      if is_nil(Bandit.Headers.get_header(headers, "content-length")) do
+        Bandit.Compression.new(adapter, status, headers, false, true)
+      else
+        {headers, %Bandit.Compression{method: :identity}}
+      end
+
     adapter = %{adapter | metrics: metrics, compression_context: compression_context}
     send(adapter.owner_pid, @already_sent)
     {:ok, nil, send_headers(adapter, status, headers, :chunk_encoded)}

--- a/test/bandit/http1/protocol_test.exs
+++ b/test/bandit/http1/protocol_test.exs
@@ -1655,6 +1655,41 @@ defmodule HTTP1ProtocolTest do
       |> send_resp(200, String.duplicate("a", 10_000))
     end
 
+    test "send_chunked streams length-delimited (no chunked encoding) when content-length is set",
+         context do
+      response = Req.get!(context.req, url: "/send_known_length_stream")
+
+      assert response.status == 200
+      assert response.headers["content-length"] == ["10000"]
+      assert response.headers["transfer-encoding"] == nil
+      assert response.body == String.duplicate("a", 10_000)
+    end
+
+    test "length-delimited send_chunked is not compressed even when negotiated", context do
+      # Compression would rewrite the body and break the declared content-length,
+      # so it must be disabled in this mode.
+      response =
+        Req.get!(context.req,
+          url: "/send_known_length_stream",
+          headers: [{"accept-encoding", "deflate"}]
+        )
+
+      assert response.status == 200
+      assert response.headers["content-length"] == ["10000"]
+      assert response.headers["content-encoding"] == nil
+      assert response.headers["transfer-encoding"] == nil
+      assert response.body == String.duplicate("a", 10_000)
+    end
+
+    def send_known_length_stream(conn) do
+      conn = conn |> put_resp_header("content-length", "10000") |> send_chunked(200)
+
+      Enum.reduce(1..10, conn, fn _i, conn ->
+        {:ok, conn} = chunk(conn, String.duplicate("a", 1_000))
+        conn
+      end)
+    end
+
     def send_big_body_chunked(conn) do
       conn = send_chunked(conn, 200)
 


### PR DESCRIPTION
## Summary

Allow `send_chunked/3` to stream a **length-delimited** body (declared `Content-Length`, no `Transfer-Encoding: chunked`) when the caller sets a `content-length` response header before calling it. This lets a Plug stream a body whose size is known up front without buffering it all in memory or writing a temp file — while still giving the client a real `Content-Length`.

## Motivation

Plug's only streaming send primitive is `send_chunked/2` + `chunk/2`, which forces `Transfer-Encoding: chunked`. Chunked and `Content-Length` are mutually exclusive, so there's currently no way to **stream** a response while **declaring its length**.

That matters whenever the body size is known but the body is produced incrementally and is too large to pass to `send_resp/3` as one buffer, e.g.:

- a precomputed/derivable-size archive (uncompressed tar/zip) assembled on the fly,
- a response proxied from an upstream that sent a `Content-Length`,
- any generated payload whose length you can compute cheaply but whose bytes you'd rather not hold in memory.

Without a declared length the client gets an indeterminate response — no download progress bar, and some intermediaries handle chunked less gracefully than length-delimited bodies.

## How it works

Most of the machinery is already in Bandit:

- The HTTP/1 transport already supports this. `send_headers(.., :chunk_encoded)` with a `content-length` header present takes the `:chunk_streaming` write state, which writes raw, length-delimited bytes (no chunk framing) — see `Bandit.HTTP1.Socket` (`:chunk_encoded when has_content_length` → `:chunk_streaming`).
- HTTP/2 carries the length in its header block and frames data the same either way, so no framing change is needed.

The only thing standing in the way was response compression: `send_chunked/3` unconditionally runs `Bandit.Compression.new/5`, and if an encoding is negotiated it rewrites the body — which invalidates the `Content-Length` the caller declared.

## Change

In `send_chunked/3`, when a `content-length` response header is present, skip compression negotiation (use the identity coder) and let the existing `:chunk_encoded` path stream length-delimited. The caller owns the bytes and is responsible for sending exactly `content-length` of them via `chunk/2`. ~16 lines, no new public API.

## Backwards compatibility

No behavior change unless the caller explicitly sets `content-length` before `send_chunked` — previously a contradictory combination (you'd get chunked encoding *and* a stray `content-length` header). Existing chunked responses, compression negotiation, and all other paths are untouched.

## Tests

Added HTTP/1 protocol tests:
- `send_chunked` streams length-delimited (no `transfer-encoding`) when `content-length` is set, and the body matches.
- The length-delimited path is not compressed even when the client negotiates an encoding (so the declared length stays valid).

Full suite green locally (`704 passed, 1 skipped`).

## Open question

I inferred the mode from the presence of a `content-length` header because it reuses the transport's existing `:chunk_streaming` path with zero new surface. If you'd prefer an explicit signal instead — e.g. an option on `send_chunked` or a distinct adapter callback — I'm happy to rework it. Wanted to start from the smallest possible change.
