### PR TITLE
Coalesce HTTP/2 response HEADERS+DATA into a single socket write

### DIFF
--- a/lib/bandit/http2/connection.ex
+++ b/lib/bandit/http2/connection.ex
@@ -319,7 +319,7 @@ defmodule Bandit.HTTP2.Connection do
     |> Enum.reduce(connection, fn pending_send, connection ->
       connection = connection |> Map.update!(:pending_sends, &List.delete(&1, pending_send))
       {stream_id, rest, end_stream, on_unblock} = pending_send
-      send_data(stream_id, rest, end_stream, on_unblock, socket, connection)
+      send_data(stream_id, [], rest, end_stream, on_unblock, socket, connection)
     end)
   end
 
@@ -341,50 +341,85 @@ defmodule Bandit.HTTP2.Connection do
           t()
         ) :: t()
   def send_headers(stream_id, headers, end_stream, socket, connection) do
-    with enc_headers <- Enum.map(headers, fn {key, value} -> {:store, key, value} end),
-         {block, send_hpack_state} <- HPAX.encode(enc_headers, connection.send_hpack_state) do
-      %Bandit.HTTP2.Frame.Headers{
-        stream_id: stream_id,
-        end_stream: end_stream,
-        fragment: block
-      }
-      |> send_frame(socket, connection)
-
-      %{connection | send_hpack_state: send_hpack_state}
-    end
+    {headers_iodata, connection} = encode_headers(stream_id, headers, end_stream, connection)
+    _ = ThousandIsland.Socket.send(socket, headers_iodata)
+    connection
   end
 
+  # Sends `data` for a stream, optionally coalescing a leading HEADERS frame (when `headers` is
+  # non-empty) into the same socket write. HEADERS are not flow-controlled; only the DATA obeys the
+  # connection send window, with any remainder queued in pending_sends.
   @spec send_data(
           Bandit.HTTP2.Stream.stream_id(),
+          Plug.Conn.headers(),
           iodata(),
           boolean(),
           fun(),
           ThousandIsland.Socket.t(),
           t()
         ) :: t()
-  def send_data(stream_id, data, end_stream, on_unblock, socket, connection) do
-    with connection_window_size <- connection.send_window_size,
-         max_bytes_to_send <- max(connection_window_size, 0),
-         {data_to_send, bytes_to_send, rest} <- split_data(data, max_bytes_to_send),
-         connection <- %{connection | send_window_size: connection_window_size - bytes_to_send},
-         end_stream_to_send <- end_stream && byte_size(rest) == 0 do
-      if end_stream_to_send || bytes_to_send > 0 do
-        %Bandit.HTTP2.Frame.Data{
+  def send_data(stream_id, headers, data, end_stream, on_unblock, socket, connection) do
+    {prefix_iodata, connection} =
+      if headers == [],
+        do: {[], connection},
+        else: encode_headers(stream_id, headers, false, connection)
+
+    {data_iodata, rest, connection} = split_window(stream_id, data, end_stream, connection)
+
+    if prefix_iodata != [] or data_iodata != [],
+      do: ThousandIsland.Socket.send(socket, [prefix_iodata, data_iodata])
+
+    finish_data(stream_id, rest, end_stream, on_unblock, connection)
+  end
+
+  defp encode_headers(stream_id, headers, end_stream, connection) do
+    enc_headers = Enum.map(headers, fn {key, value} -> {:store, key, value} end)
+    {block, send_hpack_state} = HPAX.encode(enc_headers, connection.send_hpack_state)
+
+    iodata =
+      serialize_frame(
+        %Bandit.HTTP2.Frame.Headers{
           stream_id: stream_id,
-          end_stream: end_stream_to_send,
-          data: data_to_send
-        }
-        |> send_frame(socket, connection)
+          end_stream: end_stream,
+          fragment: block
+        },
+        connection
+      )
+
+    {iodata, %{connection | send_hpack_state: send_hpack_state}}
+  end
+
+  defp split_window(stream_id, data, end_stream, connection) do
+    max_bytes_to_send = max(connection.send_window_size, 0)
+    {data_to_send, bytes_to_send, rest} = split_data(data, max_bytes_to_send)
+    connection = %{connection | send_window_size: connection.send_window_size - bytes_to_send}
+    end_stream_to_send = end_stream && byte_size(rest) == 0
+
+    iodata =
+      if end_stream_to_send || bytes_to_send > 0 do
+        serialize_frame(
+          %Bandit.HTTP2.Frame.Data{
+            stream_id: stream_id,
+            end_stream: end_stream_to_send,
+            data: data_to_send
+          },
+          connection
+        )
+      else
+        []
       end
 
-      if byte_size(rest) == 0 do
-        on_unblock.()
-        connection
-      else
-        pending_sends = [{stream_id, rest, end_stream, on_unblock} | connection.pending_sends]
-        %{connection | pending_sends: pending_sends}
-      end
-    end
+    {iodata, rest, connection}
+  end
+
+  defp finish_data(_stream_id, <<>>, _end_stream, on_unblock, connection) do
+    on_unblock.()
+    connection
+  end
+
+  defp finish_data(stream_id, rest, end_stream, on_unblock, connection) do
+    pending_sends = [{stream_id, rest, end_stream, on_unblock} | connection.pending_sends]
+    %{connection | pending_sends: pending_sends}
   end
 
   defp split_data(data, desired_length) do
@@ -462,12 +497,10 @@ defmodule Bandit.HTTP2.Connection do
   end
 
   defp send_frame(frame, socket, connection) do
-    _ =
-      ThousandIsland.Socket.send(
-        socket,
-        Bandit.HTTP2.Frame.serialize(frame, connection.remote_settings.max_frame_size)
-      )
-
+    _ = ThousandIsland.Socket.send(socket, serialize_frame(frame, connection))
     :ok
   end
+
+  defp serialize_frame(frame, connection),
+    do: Bandit.HTTP2.Frame.serialize(frame, connection.remote_settings.max_frame_size)
 end

--- a/lib/bandit/http2/connection.ex
+++ b/lib/bandit/http2/connection.ex
@@ -366,8 +366,11 @@ defmodule Bandit.HTTP2.Connection do
 
     {data_iodata, rest, connection} = split_window(stream_id, data, end_stream, connection)
 
-    if prefix_iodata != [] or data_iodata != [],
-      do: ThousandIsland.Socket.send(socket, [prefix_iodata, data_iodata])
+    if !Bandit.SocketHelpers.iodata_empty?(prefix_iodata) ||
+         !Bandit.SocketHelpers.iodata_empty?(data_iodata) do
+      _ = ThousandIsland.Socket.send(socket, [prefix_iodata, data_iodata])
+      :ok
+    end
 
     finish_data(stream_id, rest, end_stream, on_unblock, connection)
   end

--- a/lib/bandit/http2/handler.ex
+++ b/lib/bandit/http2/handler.ex
@@ -74,7 +74,7 @@ defmodule Bandit.HTTP2.Handler do
     {:reply, Bandit.SocketHelpers.ssl_data(socket), {socket, state}}
   end
 
-  def handle_call({{:send_data, data, end_stream}, stream_id}, from, {socket, state}) do
+  def handle_call({{:send_data, headers, data, end_stream}, stream_id}, from, {socket, state}) do
     # In 'normal' cases where there is sufficient space in the send windows for this message to be
     # sent, Connection will call `unblock` synchronously in the `Connection.send_data` call below.
     # In cases where there is not enough space in the connection window, Connection will call
@@ -92,6 +92,7 @@ defmodule Bandit.HTTP2.Handler do
     connection =
       Bandit.HTTP2.Connection.send_data(
         stream_id,
+        headers,
         data,
         end_stream,
         unblock,

--- a/lib/bandit/http2/stream.ex
+++ b/lib/bandit/http2/stream.ex
@@ -47,6 +47,7 @@ defmodule Bandit.HTTP2.Stream do
             send_window_size: nil,
             sendfile_chunk_size: nil,
             bytes_remaining: nil,
+            pending_headers: nil,
             read_timeout: 15_000
 
   @typedoc "An HTTP/2 stream identifier"
@@ -67,6 +68,7 @@ defmodule Bandit.HTTP2.Stream do
           send_window_size: non_neg_integer(),
           sendfile_chunk_size: pos_integer(),
           bytes_remaining: non_neg_integer() | nil,
+          pending_headers: nil | Plug.Conn.headers(),
           read_timeout: timeout()
         }
 
@@ -369,6 +371,14 @@ defmodule Bandit.HTTP2.Stream do
 
     # Stream API - Sending
 
+    # `:raw` always precedes a body (via send_data/sendfile), so buffer the headers and let
+    # send_data flush them with the first DATA frame in a single write (cf. HTTP/1 send_buffer).
+    def send_headers(%@for{state: state} = stream, status, headers, :raw)
+        when state in [:open, :remote_closed] do
+      headers = [{":status", to_string(status)} | split_cookies(headers)]
+      %{stream | pending_headers: headers}
+    end
+
     def send_headers(%@for{state: state} = stream, status, headers, body_disposition)
         when state in [:open, :remote_closed] do
       # We need to map body_disposition into the state model of HTTP/2. This turns out to be really
@@ -406,12 +416,18 @@ defmodule Bandit.HTTP2.Stream do
 
       max_bytes_to_send = max(stream.send_window_size, 0)
       {data_to_send, bytes_to_send, rest} = split_data(data, max_bytes_to_send)
+      end_stream_to_send = end_stream && byte_size(rest) == 0
 
       stream =
-        if end_stream || bytes_to_send > 0 do
-          end_stream_to_send = end_stream && byte_size(rest) == 0
-          call(stream, {:send_data, data_to_send, end_stream_to_send}, :infinity)
-          %{stream | send_window_size: stream.send_window_size - bytes_to_send}
+        if stream.pending_headers != nil or end_stream or bytes_to_send > 0 do
+          headers = stream.pending_headers || []
+          call(stream, {:send_data, headers, data_to_send, end_stream_to_send}, :infinity)
+
+          %{
+            stream
+            | pending_headers: nil,
+              send_window_size: stream.send_window_size - bytes_to_send
+          }
         else
           stream
         end

--- a/lib/bandit/http2/stream.ex
+++ b/lib/bandit/http2/stream.ex
@@ -556,6 +556,11 @@ defmodule Bandit.HTTP2.Stream do
       stream
     end
 
+    # A TransportError means the client reset the stream (do_recv_rst_stream!). RFC9113§6.4 forbids
+    # sending any further frame except PRIORITY after receiving RST_STREAM, so send no response at
+    # all -- not even an error one, unlike the generic clause below. Mirrors HTTP/1's handling.
+    def send_on_error(%@for{} = stream, %Bandit.TransportError{}), do: %{stream | state: :closed}
+
     def send_on_error(%@for{state: state} = stream, error) when state in [:idle, :open] do
       stream = maybe_send_error(%{stream | state: :open}, error)
       %{stream | state: :local_closed}

--- a/test/bandit/http2/protocol_test.exs
+++ b/test/bandit/http2/protocol_test.exs
@@ -2189,17 +2189,16 @@ defmodule HTTP2ProtocolTest do
       # Should be able to make a normal request
       SimpleH2Client.send_simple_headers(socket, 7, :get, "/slow_body_response", port)
 
-      t1 = for _ <- 1..9, do: SimpleH2Client.recv_frame(socket)
+      t1 = for _ <- 1..6, do: SimpleH2Client.recv_frame(socket)
 
+      # Streams 1/3/5 are reset before the slow handler responds; since HEADERS are coalesced with
+      # the first DATA frame, the reset is seen before any write so each emits only an error HEADERS.
       assert t1
              ~> in_any_order([
                {:ok, :headers, integer(), 1, string()},
                {:ok, :headers, integer(), 3, string()},
                {:ok, :headers, integer(), 5, string()},
                {:ok, :headers, integer(), 7, string()},
-               {:ok, :headers, integer(), 1, string()},
-               {:ok, :headers, integer(), 3, string()},
-               {:ok, :headers, integer(), 5, string()},
                {:ok, :data, integer(), 7, "OK"},
                {:ok, :goaway, 0, 0, <<7::32, 0::32>>}
              ])

--- a/test/bandit/http2/protocol_test.exs
+++ b/test/bandit/http2/protocol_test.exs
@@ -2189,15 +2189,13 @@ defmodule HTTP2ProtocolTest do
       # Should be able to make a normal request
       SimpleH2Client.send_simple_headers(socket, 7, :get, "/slow_body_response", port)
 
-      t1 = for _ <- 1..6, do: SimpleH2Client.recv_frame(socket)
+      t1 = for _ <- 1..3, do: SimpleH2Client.recv_frame(socket)
 
-      # Streams 1/3/5 are reset before the slow handler responds; since HEADERS are coalesced with
-      # the first DATA frame, the reset is seen before any write so each emits only an error HEADERS.
+      # Streams 1/3/5 are reset by the client before the slow handler responds. Per RFC9113§6.4 the
+      # server must not send any frame on a stream after receiving RST_STREAM, so those streams emit
+      # nothing. Only stream 7 (never reset) responds; the GOAWAY is the read-timeout connection close.
       assert t1
              ~> in_any_order([
-               {:ok, :headers, integer(), 1, string()},
-               {:ok, :headers, integer(), 3, string()},
-               {:ok, :headers, integer(), 5, string()},
                {:ok, :headers, integer(), 7, string()},
                {:ok, :data, integer(), 7, "OK"},
                {:ok, :goaway, 0, 0, <<7::32, 0::32>>}


### PR DESCRIPTION
HTTP/2 wrote the HEADERS frame and DATA frame as two separate `ThousandIsland.Socket.send/2` calls (two TLS records) per response. This buffers the headers and flushes them with the first DATA frame in one write — the same trick HTTP/1 already uses via `send_buffer`.

**Result:** 2.0 → 1.0 socket writes per response; **~+30% req/s on small-body HTTP/2 over TLS** (`h2load`, loopback: tiny GET ~149k → ~197k median; 1/10 KiB similar; echo +~15%). This idea comes from https://erlangforums.com/t/livery-high-performance-http-1-1-http-2-http-3-server-for-erlang-otp-27/5693/5.

Second commit: a stream the client RST_STREAMs no longer gets an error response written to it, so Bandit now sends **zero** frames on a reset stream per RFC 9113 §6.4 (matches HTTP/1).