### PR TITLE
Quiet websocket frame deserialization errors

### DIFF
--- a/lib/bandit.ex
+++ b/lib/bandit.ex
@@ -208,6 +208,10 @@ defmodule Bandit do
   * `max_inflate_ratio`: The maximum allowable ratio to allow decompression of received WebSocket
     messages. Intended to prevent 'inflate bomb' attacks where a tiny deflated messages inflates to
     a massive one. Defaults to `25` representing a 25:1 allowable inflation ratio.
+  * `log_protocol_errors`: How to log protocol errors such as malformed frames. `:short` and
+    `:verbose` will log a single-line summary (frame deserialization errors carry no stack
+    trace, so both values behave identically). The value of `false` will disable protocol error
+    logging entirely. Defaults to `:short`
   """
   @type websocket_options :: [
           {:enabled, boolean()}
@@ -217,6 +221,7 @@ defmodule Bandit do
           | {:compress, boolean()}
           | {:deflate_options, deflate_options()}
           | {:max_inflate_ratio, pos_integer()}
+          | {:log_protocol_errors, :short | :verbose | false}
         ]
 
   @typedoc """
@@ -253,7 +258,7 @@ defmodule Bandit do
   @http_keys ~w(compress response_encodings deflate_options zstd_options log_exceptions_with_status_codes log_protocol_errors log_client_closures)a
   @http_1_keys ~w(enabled max_request_line_length max_header_length max_header_count max_requests clear_process_dict gc_every_n_keepalive_requests log_unknown_messages)a
   @http_2_keys ~w(enabled max_header_block_size max_requests max_reset_stream_rate sendfile_chunk_size default_local_settings)a
-  @websocket_keys ~w(enabled max_frame_size max_fragmented_message_size validate_text_frames compress deflate_options max_inflate_ratio primitive_ops_module)a
+  @websocket_keys ~w(enabled max_frame_size max_fragmented_message_size validate_text_frames compress deflate_options max_inflate_ratio primitive_ops_module log_protocol_errors)a
   @thousand_island_keys ThousandIsland.ServerConfig.__struct__()
                         |> Map.from_struct()
                         |> Map.keys()

--- a/lib/bandit/logger.ex
+++ b/lib/bandit/logger.ex
@@ -27,6 +27,17 @@ defmodule Bandit.Logger do
     end
   end
 
+  def maybe_log_websocket_protocol_error(reason, connection) do
+    case Keyword.get(connection.opts, :log_protocol_errors, :short) do
+      false ->
+        :ok
+
+      _short_or_verbose ->
+        logger_metadata = logger_metadata_for(:exit, reason, [], websock: connection.websock)
+        Logger.error(Exception.format_banner(:exit, reason), logger_metadata)
+    end
+  end
+
   def logger_metadata_for(kind, reason, stacktrace, metadata) do
     crash_reason = crash_reason(kind, reason, stacktrace)
 

--- a/lib/bandit/websocket/handler.ex
+++ b/lib/bandit/websocket/handler.ex
@@ -59,7 +59,10 @@ defmodule Bandit.WebSocket.Handler do
         end
 
       {extractor, {:error, reason}} ->
-        {:error, {:deserializing, reason}, %{state | extractor: extractor}}
+        error = {:deserializing, reason}
+        {:error, _reason, connection} = Connection.handle_error(error, socket, state.connection)
+        Bandit.Logger.maybe_log_websocket_protocol_error(error, connection)
+        {:error, {:shutdown, error}, %{state | extractor: extractor, connection: connection}}
 
       {extractor, :more} ->
         {:continue, %{state | extractor: extractor}}

--- a/test/bandit/websocket/protocol_test.exs
+++ b/test/bandit/websocket/protocol_test.exs
@@ -698,6 +698,78 @@ defmodule WebSocketProtocolTest do
     end
   end
 
+  describe "protocol error logging" do
+    defmodule MonitoredWebSock do
+      use NoopWebSock
+
+      def init(opts) do
+        WebSocketProtocolTest.send(self())
+        {:ok, opts}
+      end
+
+      def terminate(reason, _state), do: WebSocketProtocolTest.send(reason)
+    end
+
+    @tag :capture_log
+    test "frame deserialization errors are short logged by default", context do
+      ref = make_ref() |> inspect() |> String.to_atom()
+
+      :logger.add_handler(ref, LoggerHelpers, %{config: %{pid: self(), websock: MonitoredWebSock}})
+
+      client = SimpleWebSocketClient.tcp_client(context)
+      SimpleWebSocketClient.http1_handshake(client, MonitoredWebSock)
+      assert_receive connection_pid when is_pid(connection_pid), 500
+      monitor_ref = Process.monitor(connection_pid)
+
+      # Send a text frame with the RSV2 flag set, which is not allowed by RFC6455§5.2
+      SimpleWebSocketClient.send_text_frame(client, "OK", 0xA)
+
+      # Get the error that terminate saw, to ensure we're closing for the expected reason
+      assert_receive {:error, "Received unsupported RSV flags 2"}, 500
+
+      # Validate that the server has started the shutdown handshake from RFC6455§7.1.2
+      assert SimpleWebSocketClient.recv_connection_close_frame(client) == {:ok, <<1002::16>>}
+
+      # Verify that the server didn't send any extraneous frames
+      assert SimpleWebSocketClient.connection_closed_for_reading?(client)
+
+      # Verify that the error is logged in a controlled manner
+      assert_receive {:log, %{level: :error, msg: {:string, msg}}}, 500
+      assert msg == "** (exit) {:deserializing, \"Received unsupported RSV flags 2\"}"
+
+      # Verify that the connection process exits quietly, without a crash report
+      assert_receive {:DOWN, ^monitor_ref, :process, ^connection_pid,
+                      {:shutdown, {:deserializing, "Received unsupported RSV flags 2"}}},
+                     500
+    end
+
+    @tag :capture_log
+    test "frame deserialization errors are not logged if so configured", context do
+      context = http_server(context, websocket_options: [log_protocol_errors: false])
+
+      ref = make_ref() |> inspect() |> String.to_atom()
+
+      :logger.add_handler(ref, LoggerHelpers, %{config: %{pid: self(), websock: MonitoredWebSock}})
+
+      client = SimpleWebSocketClient.tcp_client(context)
+      SimpleWebSocketClient.http1_handshake(client, MonitoredWebSock)
+      assert_receive connection_pid when is_pid(connection_pid), 500
+      monitor_ref = Process.monitor(connection_pid)
+
+      # Send a text frame with the RSV2 flag set, which is not allowed by RFC6455§5.2
+      SimpleWebSocketClient.send_text_frame(client, "OK", 0xA)
+
+      assert_receive {:error, "Received unsupported RSV flags 2"}, 500
+      assert SimpleWebSocketClient.recv_connection_close_frame(client) == {:ok, <<1002::16>>}
+
+      assert_receive {:DOWN, ^monitor_ref, :process, ^connection_pid,
+                      {:shutdown, {:deserializing, "Received unsupported RSV flags 2"}}},
+                     500
+
+      refute_receive {:log, %{level: :error}}
+    end
+  end
+
   describe "timeout conditions" do
     test "server sends a 1002 if no frames sent at all", context do
       client = SimpleWebSocketClient.tcp_client(context)


### PR DESCRIPTION
When a client sends bytes that fail frame deserialization (invalid RSV flags, unknown opcodes, oversized frames), the websocket handler currently returns `{:error, {:deserializing, reason}, state}` and the connection process stops with that reason. Since it is not shutdown-shaped, OTP emits a "GenServer terminating" crash report for a condition entirely outside the server's control. In practice this is mostly scanners and fuzzers hitting public websocket endpoints with garbage; on hex.pm these crash reports were noisy enough that we filter them out of error tracking (hexpm/hexpm#1693).

This mirrors how HTTP protocol errors are already treated. The handler now calls `Connection.handle_error/3` inline, so the close frame (1002, or 1009 for oversized frames), websock `terminate/2`, and telemetry are unchanged. It then logs a one-line `** (exit) {:deserializing, ...}` summary governed by a new `log_protocol_errors` websocket option (defaulting to `:short`, with `false` disabling it, mirroring the option of the same name in `http_options`), and exits with `{:shutdown, {:deserializing, reason}}` so no crash report is emitted.

Related: #222 reported the same crash report shape for RSV flag errors, though that case looked like a real client negotiation problem rather than garbage traffic.