### PR TITLE
Advertise HTTP/1 close at max_requests boundary

### DIFF
--- a/lib/bandit/http1/handler.ex
+++ b/lib/bandit/http1/handler.ex
@@ -6,7 +6,13 @@ defmodule Bandit.HTTP1.Handler do
 
   @impl ThousandIsland.Handler
   def handle_data(data, socket, state) do
-    transport = %Bandit.HTTP1.Socket{socket: socket, buffer: data, opts: state.opts}
+    transport = %Bandit.HTTP1.Socket{
+      socket: socket,
+      buffer: data,
+      opts: state.opts,
+      close_after_response: request_limit_reached?(state)
+    }
+
     connection_span = ThousandIsland.Socket.telemetry_span(socket)
     conn_data = Bandit.SocketHelpers.conn_data(socket)
 
@@ -39,6 +45,12 @@ defmodule Bandit.HTTP1.Handler do
     else
       {:close, state}
     end
+  end
+
+  defp request_limit_reached?(state) do
+    requests_processed = Map.get(state, :requests_processed, 0) + 1
+    request_limit = Keyword.get(state.opts.http_1, :max_requests, 0)
+    request_limit != 0 && requests_processed >= request_limit
   end
 
   defp clear_process_dict do

--- a/lib/bandit/http1/socket.ex
+++ b/lib/bandit/http1/socket.ex
@@ -17,6 +17,7 @@ defmodule Bandit.HTTP1.Socket do
             version: :"HTTP/1.0",
             send_buffer: nil,
             request_connection_header: nil,
+            close_after_response: false,
             keepalive: nil,
             opts: %{}
 
@@ -37,6 +38,7 @@ defmodule Bandit.HTTP1.Socket do
           version: nil | :"HTTP/1.1" | :"HTTP/1.0",
           send_buffer: iolist(),
           request_connection_header: binary(),
+          close_after_response: boolean(),
           keepalive: boolean(),
           opts: %{
             required(:http_1) => Bandit.http_1_options()
@@ -427,6 +429,12 @@ defmodule Bandit.HTTP1.Socket do
       cond do
         status in 100..199 ->
           {headers, socket}
+
+        socket.close_after_response ->
+          headers =
+            [{"connection", "close"} | Enum.reject(headers, &(elem(&1, 0) == "connection"))]
+
+          {headers, %{socket | keepalive: false}}
 
         socket.request_connection_header == "close" || response_connection_header == "close" ->
           {headers, %{socket | keepalive: false}}

--- a/test/bandit/http1/protocol_test.exs
+++ b/test/bandit/http1/protocol_test.exs
@@ -187,13 +187,16 @@ defmodule HTTP1ProtocolTest do
       client = SimpleHTTP1Client.tcp_client(context)
 
       SimpleHTTP1Client.send(client, "GET", "/echo_components", ["host: banana"])
-      assert {:ok, "200 OK", _headers, _} = SimpleHTTP1Client.recv_reply(client)
+      assert {:ok, "200 OK", first_headers, _} = SimpleHTTP1Client.recv_reply(client)
+      refute Keyword.has_key?(first_headers, :connection)
 
       SimpleHTTP1Client.send(client, "GET", "/echo_components", ["host: banana"])
-      assert {:ok, "200 OK", _headers, _} = SimpleHTTP1Client.recv_reply(client)
+      assert {:ok, "200 OK", second_headers, _} = SimpleHTTP1Client.recv_reply(client)
+      refute Keyword.has_key?(second_headers, :connection)
 
       SimpleHTTP1Client.send(client, "GET", "/echo_components", ["host: banana"])
-      assert {:ok, "200 OK", _headers, _} = SimpleHTTP1Client.recv_reply(client)
+      assert {:ok, "200 OK", third_headers, _} = SimpleHTTP1Client.recv_reply(client)
+      assert Keyword.get_values(third_headers, :connection) == ["close"]
 
       assert SimpleHTTP1Client.connection_closed_for_reading?(client)
     end


### PR DESCRIPTION
## Summary

When an HTTP/1 connection reaches `max_requests`, Bandit serves the final allowed response and then closes the socket. That response currently does not advertise `Connection: close`, so a pooled client can reuse the connection before it observes the FIN and receive EOF instead of a response.

This change marks the final allowed request before running the Plug pipeline and forces exactly one `connection: close` header on its final non-informational response. The existing request lifetime remains bounded, `max_requests: 0` remains unlimited, and HTTP/2 behavior is unchanged.

## Verification

- Added a protocol regression test covering responses before and at the `max_requests` boundary
- `mix test`: 702 passed, 1 skipped, 3 excluded
- `mix format --check-formatted`
- `mix credo --strict`
- `mix dialyzer`: 0 errors