### PR TITLE
Echo connection: close when the client requests closure

### DIFF
--- a/lib/bandit/http1/socket.ex
+++ b/lib/bandit/http1/socket.ex
@@ -437,6 +437,17 @@ defmodule Bandit.HTTP1.Socket do
           {headers, %{socket | keepalive: false}}
 
         socket.request_connection_header == "close" || response_connection_header == "close" ->
+          # Per RFC9112§9.6, a party that intends to close the connection SHOULD send a
+          # 'close' connection option in its final message. If the response hasn't already
+          # declared this itself, do so now (this happens when the client, not the plug,
+          # is the one that asked for the connection to close).
+          headers =
+            if response_connection_header == "close" do
+              headers
+            else
+              [{"connection", "close"} | Enum.reject(headers, &(elem(&1, 0) == "connection"))]
+            end
+
           {headers, %{socket | keepalive: false}}
 
         socket.version == :"HTTP/1.1" ->

--- a/test/bandit/http1/protocol_test.exs
+++ b/test/bandit/http1/protocol_test.exs
@@ -2110,6 +2110,19 @@ defmodule HTTP1ProtocolTest do
       assert SimpleHTTP1Client.connection_closed_for_reading?(client)
     end
 
+    test "closes the connection when an HTTP/1.1 client explicitly requests it", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "GET", "/echo_components", [
+        "host: localhost",
+        "connection: close"
+      ])
+
+      assert {:ok, "200 OK", headers, _body} = SimpleHTTP1Client.recv_reply(client)
+      assert Keyword.get_values(headers, :connection) == ["close"]
+      assert SimpleHTTP1Client.connection_closed_for_reading?(client)
+    end
+
     test "handles pipeline requests", context do
       client = SimpleHTTP1Client.tcp_client(context)
 


### PR DESCRIPTION
Per RFC9112§9.6: "a party that intends to close the connection SHOULD send a 'close' connection option in its final message, so the other side knows unambiguously not to expect further use of the connection". This was already done when Bandit itself decided to close (max_requests reached) or when the plug set connection: close on the response - but not when the *client* sent Connection: close on an HTTP/1.1 request. In that case Bandit correctly closed the connection afterward, it just never told the client so via the response headers.

Adds "closes the connection when an HTTP/1.1 client explicitly requests it" to the "connection persistence / keepalive" describe block in test/bandit/http1/protocol_test.exs.