### PR TITLE
Treat Transfer-Encoding on an HTTP/1.0 request as faulty framing

### DIFF
--- a/lib/bandit/http1/socket.ex
+++ b/lib/bandit/http1/socket.ex
@@ -76,6 +76,13 @@ defmodule Bandit.HTTP1.Socket do
           {:ok, method, request_target, headers, socket}
 
         {nil, body_encoding} ->
+          # Per RFC9112§6.1, a server that receives an HTTP/1.0 message with a
+          # Transfer-Encoding header field MUST treat the message as if the framing is
+          # faulty and close the connection after processing the message.
+          if socket.version == :"HTTP/1.0" do
+            request_error!("Transfer-encoding is not valid for HTTP/1.0 requests (RFC9112§6.1)")
+          end
+
           socket = %{socket | read_state: :headers_read, body_encoding: body_encoding}
           {:ok, method, request_target, headers, socket}
 

--- a/test/bandit/http1/protocol_test.exs
+++ b/test/bandit/http1/protocol_test.exs
@@ -1278,6 +1278,24 @@ defmodule HTTP1ProtocolTest do
       assert {:ok, status, _headers, _body} = SimpleHTTP1Client.recv_reply(client)
       assert status in ["400 Bad Request", "501 Not Implemented"]
     end
+
+    @tag :capture_log
+    test "treats a transfer-encoding request from an HTTP/1.0 client as faulty framing",
+         context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(
+        client,
+        "POST",
+        "/expect_incomplete_body",
+        ["host: localhost", "transfer-encoding: chunked"],
+        "1.0"
+      )
+
+      Transport.send(client, "3\r\nabc\r\n0\r\n\r\n")
+      assert {:ok, status, _headers, _body} = SimpleHTTP1Client.recv_reply(client)
+      assert status == "400 Bad Request"
+    end
   end
 
   describe "response body — chunked transfer-encoding (RFC9112§7.1)" do


### PR DESCRIPTION
Per RFC9112§6.1: "A server or client that receives an HTTP/1.0 message with a Transfer-Encoding header field MUST treat the message as if the framing is faulty, even if a Content-Length is present, and close the connection after processing the message." Bandit previously accepted and decoded chunked bodies on HTTP/1.0 requests without complaint, even though HTTP/1.0 has no concept of the chunked transfer coding.

Adds "treats a transfer-encoding request from an HTTP/1.0 client as faulty framing" to the "transfer-encoding edge cases" describe block in test/bandit/http1/protocol_test.exs. Uses the pre-existing /expect_incomplete_body test plug (a POST handler that reads the body and fails loudly if it succeeds) rather than defining a new one, since this validation happens during header parsing itself, before the plug is ever dispatched - the specific plug referenced doesn't matter, only that the request never reaches it.