### PR TITLE
Reject requests with multiple Host headers

### DIFF
--- a/lib/bandit/headers.ex
+++ b/lib/bandit/headers.ex
@@ -13,6 +13,19 @@ defmodule Bandit.Headers do
     end
   end
 
+  # Host is special-cased (rather than using get_header/2) because, per RFC9112§3.2 /
+  # RFC9110§7.2, a request MUST be rejected if it contains more than one host header,
+  # even if the values are identical (unlike content-length, which tolerates duplicates
+  # if they agree).
+  @spec get_host_header(Plug.Conn.headers()) :: {:ok, binary() | nil} | {:error, String.t()}
+  def get_host_header(headers) do
+    case Enum.filter(headers, &(elem(&1, 0) == "host")) do
+      [] -> {:ok, nil}
+      [{"host", value}] -> {:ok, value}
+      _ -> {:error, "multiple host headers (RFC9112§3.2, RFC9110§7.2)"}
+    end
+  end
+
   # Covers IPv6 addresses, like `[::1]:4000` as defined in RFC3986.
   @spec parse_hostlike_header!(host_header :: binary()) ::
           {Plug.Conn.host(), nil | Plug.Conn.port_number()}

--- a/lib/bandit/pipeline.ex
+++ b/lib/bandit/pipeline.ex
@@ -88,16 +88,19 @@ defmodule Bandit.Pipeline do
   @spec determine_host_and_port!(binary(), atom(), request_target(), Plug.Conn.headers()) ::
           {Plug.Conn.host(), Plug.Conn.port_number()}
   defp determine_host_and_port!(scheme, version, {_, nil, nil, _}, headers) do
-    case {Bandit.Headers.get_header(headers, "host"), version} do
-      {nil, :"HTTP/1.0"} ->
+    case {Bandit.Headers.get_host_header(headers), version} do
+      {{:ok, nil}, :"HTTP/1.0"} ->
         {"", URI.default_port(scheme)}
 
-      {nil, _} ->
+      {{:ok, nil}, _} ->
         request_error!("Unable to obtain host and port: No host header")
 
-      {host_header, _} ->
+      {{:ok, host_header}, _} ->
         {host, port} = Bandit.Headers.parse_hostlike_header!(host_header)
         {host, port || URI.default_port(scheme)}
+
+      {{:error, reason}, _} ->
+        request_error!("Unable to obtain host and port: #{reason}")
     end
   end
 

--- a/test/bandit/http1/protocol_test.exs
+++ b/test/bandit/http1/protocol_test.exs
@@ -416,6 +416,32 @@ defmodule HTTP1ProtocolTest do
     end
   end
 
+  describe "Host header validation (RFC9112§3.2, RFC9110§7.2)" do
+    @tag :capture_log
+    test "returns 400 for a request with multiple distinct host headers", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "GET", "/echo_components", [
+        "host: banana",
+        "host: orange"
+      ])
+
+      assert {:ok, "400 Bad Request", _headers, _body} = SimpleHTTP1Client.recv_reply(client)
+    end
+
+    @tag :capture_log
+    test "returns 400 for a request with multiple host headers, even if identical", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "GET", "/echo_components", [
+        "host: banana",
+        "host: banana"
+      ])
+
+      assert {:ok, "400 Bad Request", _headers, _body} = SimpleHTTP1Client.recv_reply(client)
+    end
+  end
+
   describe "request headers (RFC9112§5)" do
     @tag :capture_log
     test "rejects whitespace between a field name and its colon (RFC9112§5.1)", context do


### PR DESCRIPTION
Per RFC9110§7.2: a server MUST respond with 400 to any request that contains more than one Host header field, even if the values are identical - unlike Content-Length, which does tolerate duplicate identical values. Bandit.Headers.get_header/2 (used for Host resolution) is a plain List.keyfind/3, so it silently used the first Host header and ignored any others.

Adds Bandit.Headers.get_host_header/1, mirroring the existing get_content_length/1 pattern of filtering for all matching header entries and erroring if there's more than one. Wires it into Bandit.Pipeline.determine_host_and_port!/4 for the origin-form request target case (the case that actually reads the Host header - absolute-form targets already ignore Host entirely per RFC9112§3.2.2 and are unaffected).

Adds a new "Host header validation" describe block to test/bandit/http1/protocol_test.exs covering both the distinct-values and identical-values duplicate cases.