### PR TITLE
Reject header values containing CR, LF, or NUL

### DIFF
--- a/lib/bandit/http1/socket.ex
+++ b/lib/bandit/http1/socket.ex
@@ -144,6 +144,7 @@ defmodule Bandit.HTTP1.Socket do
           do_read_headers!(socket, headers)
 
         {:ok, {:http_header, _, header, _, value}, rest} ->
+          validate_field_value!(value)
           socket = %{socket | buffer: rest}
           headers = [{header |> to_string() |> String.downcase(:ascii), value} | headers]
 
@@ -165,6 +166,17 @@ defmodule Bandit.HTTP1.Socket do
 
         {:error, reason} ->
           request_error!("Header read unknown error: #{inspect(reason)}")
+      end
+    end
+
+    # RFC9110§5.5: field values containing CR, LF, or NUL characters are invalid and
+    # dangerous (a common request-smuggling / response-splitting vector).
+    @spec validate_field_value!(binary()) :: :ok
+    defp validate_field_value!(value) do
+      if String.contains?(value, ["\r", "\n", "\0"]) do
+        request_error!("Field value contains invalid characters (RFC9110§5.5)")
+      else
+        :ok
       end
     end
 

--- a/test/bandit/http1/protocol_test.exs
+++ b/test/bandit/http1/protocol_test.exs
@@ -418,6 +418,32 @@ defmodule HTTP1ProtocolTest do
 
   describe "request headers (RFC9112§5)" do
     @tag :capture_log
+    test "rejects a header value containing a bare CR (RFC9110§5.5)", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      Transport.send(
+        client,
+        "GET /echo_components HTTP/1.1\r\nhost: localhost\r\nx-foo: a\rb\r\n\r\n"
+      )
+
+      assert {:ok, status, _headers, _body} = SimpleHTTP1Client.recv_reply(client)
+      assert status == "400 Bad Request"
+    end
+
+    @tag :capture_log
+    test "rejects a header value containing a NUL byte (RFC9110§5.5)", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      Transport.send(
+        client,
+        "GET /echo_components HTTP/1.1\r\nhost: localhost\r\nx-foo: a\0b\r\n\r\n"
+      )
+
+      assert {:ok, status, _headers, _body} = SimpleHTTP1Client.recv_reply(client)
+      assert status == "400 Bad Request"
+    end
+
+    @tag :capture_log
     test "rejects whitespace between a field name and its colon (RFC9112§5.1)", context do
       client = SimpleHTTP1Client.tcp_client(context)
 


### PR DESCRIPTION
Per RFC9110§5.5: "Field values containing CR, LF, or NUL characters are invalid and dangerous, due to the varied ways that implementations might parse and interpret these characters; a recipient of CR, LF, or NUL within a field value MUST either reject the message or replace each of those characters with SP." These are classic request-smuggling / response-splitting vectors.

:erlang.decode_packet/3 doesn't reject embedded CR/NUL within an otherwise-terminated header line - it passes them through verbatim as part of the field value. Add an explicit check on each parsed header value as it's read.

Adds "rejects a header value containing a bare CR" and "... a NUL byte" to the "request headers" describe block in
test/bandit/http1/protocol_test.exs.