### PR TITLE
Fix crash on unrecognized chunk extensions

### DIFF
--- a/lib/bandit/http1/socket.ex
+++ b/lib/bandit/http1/socket.ex
@@ -312,8 +312,17 @@ defmodule Bandit.HTTP1.Socket do
     end
 
     defp do_parse_chunk_size(buffer, chunk_size_size) do
-      <<chunk_size::binary-size(^chunk_size_size), "\r\n", rest::binary>> = buffer
-      chunk_size = String.to_integer(chunk_size, 16)
+      <<chunk_size_line::binary-size(^chunk_size_size), "\r\n", rest::binary>> = buffer
+
+      # Chunk extensions (anything from a ';' onward) are ignored per RFC9112§7.1.1
+      [chunk_size | _chunk_ext] = :binary.split(chunk_size_line, ";")
+
+      chunk_size =
+        case Integer.parse(chunk_size, 16) do
+          {chunk_size, ""} -> chunk_size
+          _ -> request_error!("Unable to parse chunk size")
+        end
+
       {chunk_size, rest}
     end
 

--- a/test/bandit/http1/protocol_test.exs
+++ b/test/bandit/http1/protocol_test.exs
@@ -1278,6 +1278,19 @@ defmodule HTTP1ProtocolTest do
       assert {:ok, status, _headers, _body} = SimpleHTTP1Client.recv_reply(client)
       assert status in ["400 Bad Request", "501 Not Implemented"]
     end
+
+    test "ignores unrecognized chunk extensions", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "POST", "/expect_tiny_chunked_body", [
+        "host: localhost",
+        "transfer-encoding: chunked"
+      ])
+
+      Transport.send(client, "3;ext=value\r\n123\r\n")
+      Transport.send(client, "0\r\n\r\n")
+      assert SimpleHTTP1Client.recv_reply(client) ~> {:ok, "200 OK", list(), "OK"}
+    end
   end
 
   describe "response body — chunked transfer-encoding (RFC9112§7.1)" do


### PR DESCRIPTION
Bandit.HTTP1.Socket.do_parse_chunk_size/2 passed the entire chunk-size line to String.to_integer/2, including any chunk extension (the "chunk-ext" grammar in "chunk-size [ chunk-ext ] CRLF"). A request with a chunk-size line like "3;ext=value" would crash with an ArgumentError
- a 500 response and a stack trace - instead of a clean response, because "3;ext=value" isn't valid hex.

Per RFC9112§7.1.1, recipients MUST ignore unrecognized chunk extensions, so this splits on ';' and only parses the chunk-size portion. Also switches from String.to_integer/2 (raises on invalid input) to Integer.parse/2 with an explicit match on a fully-consumed parse, so a genuinely malformed chunk-size line now raises a normal Bandit.HTTPError (400) instead of crashing the connection process.

Adds "ignores unrecognized chunk extensions" to the "transfer-encoding edge cases" describe block in
test/bandit/http1/protocol_test.exs to cover this.