### PR TITLE
Tolerate a leading empty line before the request line

### DIFF
--- a/lib/bandit/http1/socket.ex
+++ b/lib/bandit/http1/socket.ex
@@ -102,6 +102,11 @@ defmodule Bandit.HTTP1.Socket do
           socket = %{socket | buffer: rest, version: version}
           {method, request_target, socket}
 
+        {:ok, {:http_error, "\r\n"}, rest} ->
+          # RFC9112§2.2: servers SHOULD ignore at least one empty line (CRLF) received
+          # prior to the request line
+          do_read_request_line!(%{socket | buffer: rest}, request_target)
+
         {:ok, {:http_error, reason}, _rest} ->
           request_error!("Request line HTTP error: #{inspect(reason)}")
 

--- a/test/bandit/http1/protocol_test.exs
+++ b/test/bandit/http1/protocol_test.exs
@@ -36,6 +36,12 @@ defmodule HTTP1ProtocolTest do
       Transport.send(client, "GET / http/1.1\r\nhost: localhost\r\n\r\n")
       assert {:ok, "400 Bad Request", _headers, <<>>} = SimpleHTTP1Client.recv_reply(client)
     end
+
+    test "tolerates a single leading empty line before the request line", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+      Transport.send(client, "\r\nGET /echo_components HTTP/1.1\r\nhost: localhost\r\n\r\n")
+      assert {:ok, "200 OK", _headers, _body} = SimpleHTTP1Client.recv_reply(client)
+    end
   end
 
   describe "method coverage (RFC9110§9.3)" do


### PR DESCRIPTION
RFC9112§2.2: "a server that is expecting to receive and parse a request-line SHOULD ignore at least one empty line (CRLF) received prior to the request-line." Bandit previously rejected any request prefixed with a blank line with a 400.

:erlang.decode_packet/3 surfaces a leading blank line as {:http_error, "\r\n"} rather than a parsed request line. Detect that specific case and retry parsing against the remaining buffer instead of treating it as a malformed request line - genuinely malformed request lines (e.g. "GARBAGE") produce a different reason and are still rejected as before.

Adds "tolerates a single leading empty line before the request line" to the "invalid requests" describe block in
test/bandit/http1/protocol_test.exs.