### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/autobahn.yml
+++ b/.github/workflows/autobahn.yml
@@ -42,16 +42,16 @@ jobs:
       AUTOBAHN_CASES: ${{ matrix.case }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Setup Elixir
-      uses: erlef/setup-beam@v1
+      uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
       with:
         elixir-version: ${{ matrix.elixir }}
         otp-version: ${{ matrix.otp }}
     - name: Disable compile warnings
       run: echo "::remove-matcher owner=elixir-mixCompileWarning::"
     - name: Retrieve mix dependencies cache
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       id: mix-cache
       with:
         path: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,11 +15,11 @@ jobs:
     - name: Install nghttp2
       run: sudo apt-get install nghttp2
     - name: Checkout code
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         repository: mtrudel/benchmark
     - name: Setup Elixir
-      uses: erlef/setup-beam@v1
+      uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
       with:
         elixir-version: 1.18.x
         otp-version: 27.1
@@ -30,7 +30,7 @@ jobs:
     - name: Run benchmark against base branch
       run: mix benchmark bandit@${{ github.event.pull_request.base.repo.clone_url }}@${{ github.event.pull_request.base.ref }} bandit@${{ github.event.pull_request.head.repo.clone_url }}@${{ github.event.pull_request.head.sha }}
     - name: Upload results file
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: http-benchmark.csv
         path: http-benchmark.csv

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -8,9 +8,9 @@ on:
 
 jobs:
   test:
-    uses: mtrudel/elixir-ci-actions/.github/workflows/test.yml@main
+    uses: mtrudel/elixir-ci-actions/.github/workflows/test.yml@18c287f5666c0873f6c8c585551b9416694a731c # main
   lint:
-    uses: mtrudel/elixir-ci-actions/.github/workflows/lint.yml@main
+    uses: mtrudel/elixir-ci-actions/.github/workflows/lint.yml@18c287f5666c0873f6c8c585551b9416694a731c # main
     permissions:
       actions: write
   h2spec:

--- a/.github/workflows/h2spec.yml
+++ b/.github/workflows/h2spec.yml
@@ -23,16 +23,16 @@ jobs:
         otp: ${{ fromJSON(inputs.erlangs) }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Setup Elixir
-      uses: erlef/setup-beam@v1
+      uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
       with:
         elixir-version: ${{ matrix.elixir }}
         otp-version: ${{ matrix.otp }}
     - name: Disable compile warnings
       run: echo "::remove-matcher owner=elixir-mixCompileWarning::"
     - name: Retrieve mix dependencies cache
-      uses: actions/cache@v6
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       id: mix-cache
       with:
         path: |

--- a/.github/workflows/hex_publish.yml
+++ b/.github/workflows/hex_publish.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Setup Elixir
-      uses: erlef/setup-beam@v1
+      uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
       with:
         elixir-version: 1.19.x
         otp-version: 28.x

--- a/.github/workflows/manual_benchmark.yml
+++ b/.github/workflows/manual_benchmark.yml
@@ -59,11 +59,11 @@ jobs:
     - name: Install nghttp2
       run: sudo apt-get install nghttp2
     - name: Checkout code
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with: 
         repository: mtrudel/benchmark
     - name: Setup Elixir
-      uses: erlef/setup-beam@v1
+      uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
       with:
         elixir-version: 1.14.x
         otp-version: 25.1
@@ -74,7 +74,7 @@ jobs:
     - name: Run benchmark
       run: mix benchmark --profile ${{ inputs.profile }} --protocol ${{ inputs.protocol }} ${{ inputs.baseline_server }}@${{ inputs.baseline_version }} ${{ inputs.test_server }}@${{ inputs.test_version }}
     - name: Upload results file
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: http-benchmark.csv
         path: http-benchmark.csv


### PR DESCRIPTION
Hi Mat, small drive-by contribution: this pins every action and reusable workflow reference across the workflows to a commit sha, versions kept as comments.

A tag like `@v1` is a movable pointer: whoever controls the action, or anyone who compromises it, can re-point it and your next run executes their code with the job's token. The spot that motivated this is `erlef/setup-beam@v1` in `hex_publish.yml`, which runs with your Hex publish secrets. Same pattern as the tj-actions/changed-files incident (CVE-2025-30066).

Two notes:

- Your `elixir-ci-actions` reusable workflows are pinned to their current main commit too. I know it is your own repo so the risk model is different, if you would rather keep those on `@main` for convenience, say so and I drop that part.
- Dependabot keeps working exactly as today: it understands sha pins with a version comment and will keep opening its bump PRs.

All shas were resolved from the upstream repos and cross checked against their tags: setup-beam `54075bc` is v1.24.1, checkout `3d3c42e` is v7.0.1, cache `55cc834` is v6.1.0, upload-artifact `043fb46` is v7.0.1, elixir-ci-actions `18c287f` is main as of today. No logic changes, only the `uses:` lines.

Found with the Plumber CLI (https://github.com/getplumber/plumber), verified on main. I can also open a PR which adds it to CI so this does not quietly drift back, that one is a bonus, this PR stands on its own.