### PR TITLE
Avoid per-header length/1 and option lookups when reading HTTP/1 headers

### DIFF
--- a/lib/bandit/http1/socket.ex
+++ b/lib/bandit/http1/socket.ex
@@ -146,22 +146,27 @@ defmodule Bandit.HTTP1.Socket do
     defp resolve_request_target!(_request_target, _method),
       do: request_error!("Unsupported request target (RFC9112§3.2)")
 
-    defp do_read_headers!(%@for{} = socket, headers \\ []) do
+    defp do_read_headers!(%@for{} = socket) do
       packet_size = Keyword.get(socket.opts.http_1, :max_header_length, 10_000)
+      max_header_count = Keyword.get(socket.opts.http_1, :max_header_count, 50)
+      do_read_headers!(socket, packet_size, max_header_count, [], 0)
+    end
 
+    defp do_read_headers!(socket, packet_size, max_header_count, headers, header_count) do
       case :erlang.decode_packet(:httph_bin, socket.buffer, packet_size: packet_size) do
         {:more, _len} ->
           chunk = read_available!(socket.socket, socket.socket.read_timeout)
           socket = %{socket | buffer: socket.buffer <> chunk}
-          do_read_headers!(socket, headers)
+          do_read_headers!(socket, packet_size, max_header_count, headers, header_count)
 
         {:ok, {:http_header, _, header, _, value}, rest} ->
           validate_field_value!(value)
           socket = %{socket | buffer: rest}
           headers = [{header |> to_string() |> String.downcase(:ascii), value} | headers]
+          header_count = header_count + 1
 
-          if length(headers) <= Keyword.get(socket.opts.http_1, :max_header_count, 50) do
-            do_read_headers!(socket, headers)
+          if header_count <= max_header_count do
+            do_read_headers!(socket, packet_size, max_header_count, headers, header_count)
           else
             request_error!("Too many headers", :request_header_fields_too_large)
           end


### PR DESCRIPTION
Closes #614.

`do_read_headers!` currently does two redundant things on every header line:
- calls `length(headers)` to check against `max_header_count`, which is O(n²) over the number of headers
- re-fetches `max_header_length` / `max_header_count` from opts via `Keyword.get` on each iteration (2n + 4 lookups per request)

This PR keeps an integer count instead of calling `length/1`, and hoists the two option lookups out of the read loop by splitting the function into an entry clause and a loop clause. 
Boundary behaviour is unchanged: up to `max_header_count` headers are accepted and the next one raises `request_header_fields_too_large`. Test suite passes unmodified.

Measured on Linux (OTP 27 / Elixir 1.18.4, matching the benchmark workflow): the two changes are independent — the counter removes the quadratic term, the hoisting shrinks the linear term — and together give roughly 5-7% on parse time for a 45-header request (4-6% for a typical 10-header request), consistent across CPU-restricted conditions. More
conservative than the numbers I posted in the issue, which came from a noisier setup.

For transparency: the fix itself is mine; the benchmark harness used to verify it (call counts, reduction fitting, wall-clock sweeps) was written with AI assistance. Happy to share the scripts if useful.
