### PR TITLE
Enforce the RFC9112 chunk-size grammar and reject repeated transfer-encoding

### DIFF
--- a/lib/bandit/headers.ex
+++ b/lib/bandit/headers.ex
@@ -26,6 +26,25 @@ defmodule Bandit.Headers do
     end
   end
 
+  # Transfer-encoding is special-cased for the same reason content-length is:
+  # it determines message framing, so resolving it with get_header/2 (which
+  # returns the first match and ignores the rest) lets a request whose framing
+  # is ambiguous be read as though it were not. Per RFC9112§6.1 repeated
+  # transfer-encoding headers combine into one comma-separated value, and
+  # RFC9112§6.3 requires rejecting a request whose final encoding is not
+  # chunked. Since the only encoding accepted here is a bare 'chunked', any
+  # repetition is either unsupported or has chunked in a non-final position,
+  # and can be rejected outright.
+  @spec get_transfer_encoding(Plug.Conn.headers()) ::
+          {:ok, binary() | nil} | {:error, String.t()}
+  def get_transfer_encoding(headers) do
+    case Enum.filter(headers, &(elem(&1, 0) == "transfer-encoding")) do
+      [] -> {:ok, nil}
+      [{"transfer-encoding", value}] -> {:ok, value}
+      _ -> {:error, "multiple transfer-encoding headers (RFC9112§6.1, RFC9112§6.3)"}
+    end
+  end
+
   # Covers IPv6 addresses, like `[::1]:4000` as defined in RFC3986.
   @spec parse_hostlike_header!(host_header :: binary()) ::
           {Plug.Conn.host(), nil | Plug.Conn.port_number()}

--- a/lib/bandit/http1/socket.ex
+++ b/lib/bandit/http1/socket.ex
@@ -62,7 +62,7 @@ defmodule Bandit.HTTP1.Socket do
       {method, request_target, socket} = do_read_request_line!(socket)
       {headers, socket} = do_read_headers!(socket)
       content_length = get_content_length!(headers)
-      body_encoding = safe_downcase(Bandit.Headers.get_header(headers, "transfer-encoding"))
+      body_encoding = get_transfer_encoding!(headers)
       request_connection_header = safe_downcase(Bandit.Headers.get_header(headers, "connection"))
       socket = %{socket | request_connection_header: request_connection_header}
 
@@ -201,6 +201,13 @@ defmodule Bandit.HTTP1.Socket do
       case Bandit.Headers.get_content_length(headers) do
         {:ok, content_length} -> content_length
         {:error, reason} -> request_error!("Content length unknown error: #{inspect(reason)}")
+      end
+    end
+
+    defp get_transfer_encoding!(headers) do
+      case Bandit.Headers.get_transfer_encoding(headers) do
+        {:ok, transfer_encoding} -> safe_downcase(transfer_encoding)
+        {:error, reason} -> request_error!("Transfer encoding unknown error: #{inspect(reason)}")
       end
     end
 
@@ -346,14 +353,39 @@ defmodule Bandit.HTTP1.Socket do
       # Chunk extensions (anything from a ';' onward) are ignored per RFC9112§7.1.1
       [chunk_size | _chunk_ext] = :binary.split(chunk_size_line, ";")
 
-      chunk_size =
-        case Integer.parse(chunk_size, 16) do
-          {chunk_size, ""} -> chunk_size
-          _ -> request_error!("Unable to parse chunk size")
-        end
-
-      {chunk_size, rest}
+      {parse_chunk_size!(chunk_size), rest}
     end
+
+    # RFC9112§7.1 defines chunk-size as 1*HEXDIG. Integer.parse/2 additionally
+    # accepts a leading '+' or '-', so the grammar has to be checked separately
+    # rather than inferred from the parse succeeding. Without this, '+10' reads
+    # as a sixteen byte chunk, and '-0' parses as zero and is taken for the
+    # terminating chunk, ending the body at a position no conforming parser
+    # would end it at. A negative size reaches read_exactly!/5, which is
+    # guarded on a non-negative length and so raises FunctionClauseError rather
+    # than returning a 400.
+    @spec parse_chunk_size!(binary()) :: non_neg_integer()
+    defp parse_chunk_size!(chunk_size) do
+      with true <- hex_digits?(chunk_size),
+           {chunk_size, ""} <- Integer.parse(chunk_size, 16) do
+        chunk_size
+      else
+        _ -> request_error!("Unable to parse chunk size")
+      end
+    end
+
+    @spec hex_digits?(binary()) :: boolean()
+    defp hex_digits?(<<>>), do: false
+    defp hex_digits?(chunk_size), do: all_hex_digits?(chunk_size)
+
+    @spec all_hex_digits?(binary()) :: boolean()
+    defp all_hex_digits?(<<>>), do: true
+
+    defp all_hex_digits?(<<digit, rest::binary>>)
+         when digit in ?0..?9 or digit in ?a..?f or digit in ?A..?F,
+         do: all_hex_digits?(rest)
+
+    defp all_hex_digits?(_chunk_size), do: false
 
     ##################
     # Internal Reading

--- a/test/bandit/http1/protocol_test.exs
+++ b/test/bandit/http1/protocol_test.exs
@@ -1291,6 +1291,89 @@ defmodule HTTP1ProtocolTest do
       assert msg == "** (Bandit.HTTPError) Malformed chunked encoding request body"
     end
 
+    # RFC9112§7.1: chunk-size = 1*HEXDIG. A sign is not a hex digit.
+    @tag :capture_log
+    test "rejects a chunk size with a leading plus sign", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "POST", "/expect_chunked_body", [
+        "Host: localhost",
+        "Transfer-encoding: chunked"
+      ])
+
+      Transport.send(client, "+10\r\n")
+      assert SimpleHTTP1Client.recv_reply(client) ~> {:ok, "400 Bad Request", list(), ""}
+
+      assert_receive {:log, %{level: :error, msg: {:string, msg}}}, 500
+      assert msg == "** (Bandit.HTTPError) Unable to parse chunk size"
+    end
+
+    # A signed zero must not be read as the terminating chunk. If it is, the
+    # body ends at a byte position no conforming parser would end it at, and
+    # whatever follows is read as a new request on the same connection.
+    @tag :capture_log
+    test "rejects a signed zero chunk size rather than ending the body", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "POST", "/expect_chunked_body", [
+        "Host: localhost",
+        "Transfer-encoding: chunked"
+      ])
+
+      Transport.send(client, "-0\r\n\r\nGET /echo_components HTTP/1.1\r\nHost: localhost\r\n\r\n")
+      assert SimpleHTTP1Client.recv_reply(client) ~> {:ok, "400 Bad Request", list(), ""}
+
+      assert_receive {:log, %{level: :error, msg: {:string, msg}}}, 500
+      assert msg == "** (Bandit.HTTPError) Unable to parse chunk size"
+
+      # The bytes after the signed zero must not have been served as a request
+      # of their own.
+      assert SimpleHTTP1Client.connection_closed_for_reading?(client)
+    end
+
+    # A negative size reaches read_exactly!/5, which is guarded on a
+    # non-negative length, so this raised FunctionClauseError rather than
+    # returning a 400.
+    @tag :capture_log
+    test "rejects a negative chunk size", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "POST", "/expect_chunked_body", [
+        "Host: localhost",
+        "Transfer-encoding: chunked"
+      ])
+
+      Transport.send(client, "-1\r\nAAAA\r\n0\r\n\r\n")
+      assert SimpleHTTP1Client.recv_reply(client) ~> {:ok, "400 Bad Request", list(), ""}
+
+      assert_receive {:log, %{level: :error, msg: {:string, msg}}}, 500
+      assert msg == "** (Bandit.HTTPError) Unable to parse chunk size"
+    end
+
+    # RFC9112§6.1 combines repeated transfer-encoding headers into one
+    # comma-separated value; RFC9112§6.3 then requires rejecting the request,
+    # since chunked is no longer the final encoding.
+    @tag :capture_log
+    test "rejects a request with multiple transfer-encoding headers", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "POST", "/expect_chunked_body", [
+        "Host: localhost",
+        "Transfer-encoding: chunked",
+        "Transfer-encoding: identity"
+      ])
+
+      Transport.send(client, "0\r\n\r\nGET /echo_components HTTP/1.1\r\nHost: localhost\r\n\r\n")
+      assert SimpleHTTP1Client.recv_reply(client) ~> {:ok, "400 Bad Request", list(), ""}
+
+      assert_receive {:log, %{level: :error, msg: {:string, msg}}}, 500
+
+      assert msg ==
+               "** (Bandit.HTTPError) Transfer encoding unknown error: \"multiple transfer-encoding headers (RFC9112§6.1, RFC9112§6.3)\""
+
+      assert SimpleHTTP1Client.connection_closed_for_reading?(client)
+    end
+
     @tag :capture_log
     test "handles trailers (by throwing them on the floor", context do
       client = SimpleHTTP1Client.tcp_client(context)


### PR DESCRIPTION
RFC9112§7.1 defines `chunk-size` as `1*HEXDIG`. `Integer.parse/2` additionally accepts a leading `+` or `-`, and the grammar was only ever checked by whether that parse succeeded, so signed values are read as valid chunk sizes.

Three consequences, all reproducible against 1.12.4:

| chunk size | today | expected |
|---|---|---|
| `+10` | read as a 16 byte chunk | 400 |
| `-0` | parsed as `0`, taken for the terminating chunk | 400 |
| `-1` | `FunctionClauseError` in `read_exactly!/5` | 400 |

`-0` is the one worth a second look. It ends the body at a byte position no conforming parser would end it at, so anything after it is read as a new request on the same connection:

```
POST /echo HTTP/1.1
Host: localhost
Transfer-Encoding: chunked

-0

GET /somewhere-else HTTP/1.1
Host: localhost

```

That is one request written to the socket and two responses back. Note this is specific to 1.12.x: before the chunked reader was reworked in #585 and #621 a zero-length chunk did not have a dedicated terminating branch, so `-0` hit the generic path and raised. The rework is correct on its own terms; it just gave the pre-existing grammar leniency somewhere to land.

`-1` never reaches a size check at all — `read_exactly!/5` is guarded on a non-negative length, so it matches no clause and the connection dies with a stack trace instead of a 400.

The fix checks the grammar explicitly rather than inferring it from the parse.

---

Separately, and in the same code path: `transfer-encoding` is resolved with `get_header/2`, which returns the first match and ignores the rest. Message framing is decided by two headers and only one of them, `content-length`, got the exhaustive treatment in f2ca636. So:

```
POST /echo HTTP/1.1
Transfer-Encoding: chunked
Transfer-Encoding: identity
```

is served as though it said plain `chunked`. Per RFC9112§6.1 repeated headers combine into one comma-separated value, and RFC9112§6.3 then requires rejecting the request because chunked is no longer the final encoding. Since the only encoding accepted here is a bare `chunked`, any repetition is either unsupported or has chunked in a non-final position, so rejecting outright loses nothing. Reversing the two lines already returns 400 today, via the unsupported encoding path.

---

**On why this is a pull request and not a security advisory.**

`-0` produces a genuine request boundary disagreement, so I went looking for an exploit path before writing this up, and did not find one. I replayed all of the above through nginx 1.27, HAProxy 3.0, Caddy 2, Traefik 3.3 and Envoy 1.32, each proxying to the same origin over a pooled upstream connection, followed by benign requests on fresh client connections to check for an orphaned response left queued for a later client. All five reject every case at the edge; nothing reached the origin and nothing leaked. With Bandit directly exposed the same attacker sends both requests anyway, so there is no gain.

So: conformance defects and one unhandled crash, no demonstrated impact. Happy to move this to the security channel instead if you read the impact differently — I would rather ask than assume.

---

Each case has a test. Reverting `lib/` on this branch and running `test/bandit/http1/protocol_test.exs` gives 4 failures; with the change the file is 158/158.
