### PR TITLE
Treat proxy-connection as a connection-specific header in HTTP/2

### DIFF
--- a/lib/bandit/http2/stream.ex
+++ b/lib/bandit/http2/stream.ex
@@ -203,7 +203,7 @@ defmodule Bandit.HTTP2.Stream do
     # specific cases by RFC9113§8.2.2. We check those cases in a separate filter
     defp no_connection_headers!(headers, stream) do
       connection_headers =
-        ~w[connection keep-alive proxy-authenticate proxy-authorization trailers transfer-encoding upgrade]
+        ~w[connection keep-alive proxy-authenticate proxy-authorization proxy-connection trailers transfer-encoding upgrade]
 
       if Enum.any?(headers, fn {key, _value} -> key in connection_headers end),
         do: stream_error!("Received connection-specific header", stream)

--- a/test/bandit/http2/protocol_test.exs
+++ b/test/bandit/http2/protocol_test.exs
@@ -1766,6 +1766,28 @@ defmodule HTTP2ProtocolTest do
       assert msg == "** (Bandit.HTTP2.Errors.StreamError) Received connection-specific header"
     end
 
+    # RFC9113§8.2.2 names Proxy-Connection alongside Connection, Keep-Alive,
+    # Transfer-Encoding and Upgrade.
+    @tag :capture_log
+    test "returns an error if the proxy-connection header is present", context do
+      socket = SimpleH2Client.setup_connection(context)
+
+      headers = [
+        {":method", "HEAD"},
+        {":path", "/"},
+        {":scheme", "https"},
+        {":authority", "localhost:#{context.port}"},
+        {"proxy-connection", "keep-alive"}
+      ]
+
+      SimpleH2Client.send_headers(socket, 1, true, headers)
+
+      assert SimpleH2Client.recv_rst_stream(socket) == {:ok, 1, 1}
+
+      assert_receive {:log, %{level: :error, msg: {:string, msg}, meta: %{stream_id: 1}}}, 500
+      assert msg == "** (Bandit.HTTP2.Errors.StreamError) Received connection-specific header"
+    end
+
     test "accepts TE header with a value of trailer", context do
       socket = SimpleH2Client.setup_connection(context)
 


### PR DESCRIPTION
RFC9113§8.2.2 names `Proxy-Connection` alongside `Connection`, `Keep-Alive`, `Transfer-Encoding` and `Upgrade` as connection-specific, and requires that a message carrying one be treated as malformed. `no_connection_headers!/2` covers the other four but not `proxy-connection`, so a request carrying it is served rather than reset.

The change adds only the omission, plus a test alongside the existing hop-by-hop one.

One observation I did not act on: the same list also carries `proxy-authenticate`, `proxy-authorization` and `trailers`, which RFC9113§8.2.2 does not name — those come from the older RFC2616 hop-by-hop list. Dropping them would make Bandit accept requests it rejects today, which is a behaviour change rather than a fix, so I left them alone. Mentioning it in case the divergence is news rather than deliberate.
