### PR TITLE
Fix non-deterministic compile-time code

### DIFF
--- a/lib/bandit.ex
+++ b/lib/bandit.ex
@@ -262,6 +262,7 @@ defmodule Bandit do
   @thousand_island_keys ThousandIsland.ServerConfig.__struct__()
                         |> Map.from_struct()
                         |> Map.keys()
+                        |> Enum.sort()
 
   @doc """
   Starts a Bandit server using the provided arguments. See `t:options/0` for specific options to

--- a/lib/bandit/http2/errors.ex
+++ b/lib/bandit/http2/errors.ex
@@ -38,7 +38,7 @@ defmodule Bandit.HTTP2.Errors do
 
   @spec to_reason(integer()) :: atom()
 
-  for {name, value} <- error_codes do
+  for {name, value} <- Enum.sort(error_codes) do
     @spec unquote(name)() :: unquote(Macro.var(name, Elixir)) :: unquote(value)
     def unquote(name)(), do: unquote(value)
 


### PR DESCRIPTION
The BEAM files for these two modules would change when compiled even
though their corresponding source files were the same. This was due to
maps having an unspecified traversal order. Sorting the map entries or
keys makes their compilation deterministic.

This helps Nerves minimize the number of changes that need to be sent
over the wire for delta firmware updates.
