### PR TITLE
Reject compressed WebSocket control frames regardless of the fin bit

### DIFF
--- a/lib/bandit/websocket/frame/connection_close.ex
+++ b/lib/bandit/websocket/frame/connection_close.ex
@@ -34,7 +34,7 @@ defmodule Bandit.WebSocket.Frame.ConnectionClose do
     {:error, "Cannot have a fragmented connection close frame (RFC6455§5.5)"}
   end
 
-  def deserialize(true, true, _payload) do
+  def deserialize(_fin, true, _payload) do
     {:error, "Cannot have a compressed connection close frame (RFC7692§6.1)"}
   end
 

--- a/lib/bandit/websocket/frame/ping.ex
+++ b/lib/bandit/websocket/frame/ping.ex
@@ -19,7 +19,7 @@ defmodule Bandit.WebSocket.Frame.Ping do
     {:error, "Cannot have a fragmented ping frame (RFC6455§5.5.2)"}
   end
 
-  def deserialize(true, true, _payload) do
+  def deserialize(_fin, true, _payload) do
     {:error, "Cannot have a compressed ping frame (RFC7692§6.1)"}
   end
 

--- a/lib/bandit/websocket/frame/pong.ex
+++ b/lib/bandit/websocket/frame/pong.ex
@@ -19,7 +19,7 @@ defmodule Bandit.WebSocket.Frame.Pong do
     {:error, "Cannot have a fragmented pong frame (RFC6455§5.5.3)"}
   end
 
-  def deserialize(true, true, _payload) do
+  def deserialize(_fin, true, _payload) do
     {:error, "Cannot have a compressed pong frame (RFC7692§6.1)"}
   end
 

--- a/test/bandit/websocket/frame_deserialization_test.exs
+++ b/test/bandit/websocket/frame_deserialization_test.exs
@@ -331,6 +331,13 @@ defmodule WebSocketFrameDeserializationTest do
       assert Frame.deserialize(frame, WebSocketPrimitiveOps) ==
                {:error, "Cannot have a compressed connection close frame (RFC7692§6.1)"}
     end
+
+    test "refuses frame with per-message compressed bit set and fin bit clear" do
+      frame = <<0x0::1, 0x4::3, 0x8::4, 1::1, 0::7, 0x01020304::32>>
+
+      assert Frame.deserialize(frame, WebSocketPrimitiveOps) ==
+               {:error, "Cannot have a compressed connection close frame (RFC7692§6.1)"}
+    end
   end
 
   describe "PING frames" do
@@ -372,6 +379,13 @@ defmodule WebSocketFrameDeserializationTest do
       assert Frame.deserialize(frame, WebSocketPrimitiveOps) ==
                {:error, "Cannot have a compressed ping frame (RFC7692§6.1)"}
     end
+
+    test "refuses frames with per-message compressed bit set and fin bit clear" do
+      frame = <<0x0::1, 0x4::3, 0x9::4, 1::1, 0::7, 0x01020304::32>>
+
+      assert Frame.deserialize(frame, WebSocketPrimitiveOps) ==
+               {:error, "Cannot have a compressed ping frame (RFC7692§6.1)"}
+    end
   end
 
   describe "PONG frames" do
@@ -409,6 +423,13 @@ defmodule WebSocketFrameDeserializationTest do
 
     test "refuses frames with per-message compressed bit set" do
       frame = <<0x1::1, 0x4::3, 0xA::4, 1::1, 0::7, 0x01020304::32>>
+
+      assert Frame.deserialize(frame, WebSocketPrimitiveOps) ==
+               {:error, "Cannot have a compressed pong frame (RFC7692§6.1)"}
+    end
+
+    test "refuses frames with per-message compressed bit set and fin bit clear" do
+      frame = <<0x0::1, 0x4::3, 0xA::4, 1::1, 0::7, 0x01020304::32>>
 
       assert Frame.deserialize(frame, WebSocketPrimitiveOps) ==
                {:error, "Cannot have a compressed pong frame (RFC7692§6.1)"}


### PR DESCRIPTION
## Summary

A WebSocket control frame (close, ping, or pong) that arrives with the RSV1 ("compressed") bit set and the `fin` bit clear matched no clause in the frame deserializers and raised `FunctionClauseError`, crashing the connection process. Fixes #633.

## Root cause

`Bandit.WebSocket.Frame.to_frame/7` passes the RSV1 bit straight through to the per-opcode deserializer. Each control-frame deserializer (`Ping`, `Pong`, `ConnectionClose`) had clauses for `(true, false, _)`, `(false, false, _)`, and `(true, true, _)`, but no clause for `(false, true, _)` — fin clear, compressed set.

RFC 6455 §5.5 requires control frames to be unfragmented (fin MUST be 1); RFC 7692 §6.1 forbids compression on control frames. Both are protocol errors independent of fin, so the existing `(true, true, _)` "compressed" clause is broadened to `(_fin, true, _)`, matching the compressed case for any fin value. The already-existing fragmentation clause (`false, false, _`) is unaffected since it requires `compressed = false`.

## Testing

Added a test per control-frame type (`Ping`, `Pong`, `ConnectionClose`) sending fin=0/compressed=1 bytes and asserting a clean error return instead of a crash.

Confirmed red/green: reverting the three one-line lib changes reproduces `FunctionClauseError` in exactly the 3 new tests; with the fix, the full suite (759 tests) passes.