### PR TITLE
Return FRAME_SIZE_ERROR for HEADERS/DATA frames too short for their flags

### DIFF
--- a/lib/bandit/http2/frame/data.ex
+++ b/lib/bandit/http2/frame/data.ex
@@ -48,6 +48,12 @@ defmodule Bandit.HTTP2.Frame.Data do
      "DATA frame with invalid padding length (RFC9113§6.1)"}
   end
 
+  # A PADDED frame that is too short to even contain the pad length octet (RFC9113§4.2, §6.1)
+  def deserialize(_flags, _stream_id, _payload) do
+    {:error, Bandit.HTTP2.Errors.frame_size_error(),
+     "DATA frame with insufficient padding data (RFC9113§6.1)"}
+  end
+
   defimpl Bandit.HTTP2.Frame.Serializable do
     @end_stream_bit 0
 

--- a/lib/bandit/http2/frame/headers.ex
+++ b/lib/bandit/http2/frame/headers.ex
@@ -104,6 +104,14 @@ defmodule Bandit.HTTP2.Frame.Headers do
      }}
   end
 
+  # A frame whose payload is too short to hold the fields implied by its flags (a PRIORITY
+  # section shorter than 5 octets, or a PADDED frame missing its pad length octet) (RFC9113§4.2,
+  # §6.2)
+  def deserialize(_flags, _stream_id, _payload) do
+    {:error, Bandit.HTTP2.Errors.frame_size_error(),
+     "HEADERS frame with insufficient data for its flags (RFC9113§6.2)"}
+  end
+
   defimpl Bandit.HTTP2.Frame.Serializable do
     @end_stream_bit 0
     @end_headers_bit 2

--- a/test/bandit/http2/frame_deserialization_test.exs
+++ b/test/bandit/http2/frame_deserialization_test.exs
@@ -81,6 +81,13 @@ defmodule HTTP2FrameDeserializationTest do
       assert Frame.deserialize(frame, 16_384) ==
                {{:error, 1, "DATA frame with invalid padding length (RFC9113§6.1)"}, <<>>}
     end
+
+    test "rejects padded frames too short to contain the pad length octet" do
+      frame = <<0, 0, 0, 0, 0x08, 0, 0, 0, 1>>
+
+      assert Frame.deserialize(frame, 16_384) ==
+               {{:error, 6, "DATA frame with insufficient padding data (RFC9113§6.1)"}, <<>>}
+    end
   end
 
   describe "HEADERS frames" do
@@ -187,6 +194,22 @@ defmodule HTTP2FrameDeserializationTest do
 
       assert Frame.deserialize(frame, 16_384) ==
                {{:error, 1, "HEADERS frame with invalid padding length (RFC9113§6.2)"}, <<>>}
+    end
+
+    test "rejects padded frames too short to contain the pad length octet" do
+      frame = <<0, 0, 0, 1, 0x08, 0, 0, 0, 1>>
+
+      assert Frame.deserialize(frame, 16_384) ==
+               {{:error, 6, "HEADERS frame with insufficient data for its flags (RFC9113§6.2)"},
+                <<>>}
+    end
+
+    test "rejects priority frames too short to contain the priority section" do
+      frame = <<0, 0, 4, 1, 0x20, 0, 0, 0, 1, 0, 0, 0, 0>>
+
+      assert Frame.deserialize(frame, 16_384) ==
+               {{:error, 6, "HEADERS frame with insufficient data for its flags (RFC9113§6.2)"},
+                <<>>}
     end
   end
 


### PR DESCRIPTION
## Summary

An HTTP/2 DATA or HEADERS frame whose payload is too short to hold the fields implied by its flags matched no clause in the frame deserializer and raised `FunctionClauseError`. The handler's generic `rescue` then sent a GOAWAY with `INTERNAL_ERROR` and logged a full crash report, instead of the `FRAME_SIZE_ERROR` RFC 9113 §4.2 requires. Fixes #635.

Two attacker-reachable shapes fell through:
- A DATA frame with the PADDED flag set and an empty payload (no pad length octet).
- A HEADERS frame with the PADDED flag set and an empty payload, or the PRIORITY flag set with a payload shorter than the mandatory 5-octet priority section.

RFC 9113 §4.2: "An endpoint MUST send an error code of FRAME_SIZE_ERROR if a frame ... is too small to contain mandatory frame data." The PRIORITY section is a fixed 5 octets (§6.2) and a PADDED frame must contain the Pad Length octet (§6.1/§6.2).

## Fix

Added a total catch-all clause to each parser (`data.ex`, `headers.ex`) returning `FRAME_SIZE_ERROR`. Since Elixir matches clauses in order and these catch-alls have no guard, they only fire when every preceding, more specific clause failed to match — well-formed frames are unaffected.

## Testing

Added tests to `test/bandit/http2/frame_deserialization_test.exs` for all three shapes. Confirmed red/green: reverting the two lib changes reproduces `FunctionClauseError` in exactly the 3 new tests; with the fix, the full suite (759 tests) passes.