### PR TITLE
Reject send_file ranges past EOF instead of emitting a negative Content-Length

### DIFF
--- a/lib/bandit/adapter.ex
+++ b/lib/bandit/adapter.ex
@@ -159,7 +159,7 @@ defmodule Bandit.Adapter do
     %File.Stat{type: :regular, size: size} = File.Stat.from_record(fileinfo)
     length = if length == :all, do: size - offset, else: length
 
-    if offset + length <= size do
+    if length >= 0 and offset + length <= size do
       headers = Bandit.Headers.add_content_length(headers, length, status, adapter.method)
       adapter = send_headers(adapter, status, headers, :raw)
 

--- a/test/bandit/http1/plug_test.exs
+++ b/test/bandit/http1/plug_test.exs
@@ -429,6 +429,17 @@ defmodule HTTP1PlugTest do
       assert msg =~ "** (RuntimeError) Cannot read 3000 bytes starting at 1"
     end
 
+    @tag :capture_log
+    test "rejects an :all length with an offset past EOF instead of a negative content-length",
+         context do
+      {:ok, response} = Req.get(context.req, url: "/send_file?offset=100&length=:all")
+      assert response.status == 500
+      refute Map.has_key?(response.headers, "content-length")
+
+      assert_receive {:log, %{level: :error, msg: {:string, msg}}}, 500
+      assert msg =~ "** (RuntimeError) Cannot read -94 bytes starting at 100"
+    end
+
     def send_file(conn) do
       conn = fetch_query_params(conn)
       offset = String.to_integer(conn.params["offset"])

--- a/test/bandit/http2/plug_test.exs
+++ b/test/bandit/http2/plug_test.exs
@@ -517,6 +517,17 @@ defmodule HTTP2PlugTest do
       assert msg =~ "** (RuntimeError) Cannot read 3000 bytes starting at 1"
     end
 
+    @tag :capture_log
+    test "rejects an :all length with an offset past EOF instead of a negative content-length",
+         context do
+      {:ok, response} = Req.get(context.req, url: "/send_file?offset=100&length=:all")
+      assert response.status == 500
+      refute Map.has_key?(response.headers, "content-length")
+
+      assert_receive {:log, %{level: :error, msg: {:string, msg}}}, 500
+      assert msg =~ "** (RuntimeError) Cannot read -94 bytes starting at 100"
+    end
+
     def send_file(conn) do
       conn = fetch_query_params(conn)
       offset = String.to_integer(conn.params["offset"])


### PR DESCRIPTION
## Summary

`Bandit.Adapter.send_file/6` guarded against a negative offset and a non-positive numeric length, but not against `length: :all` combined with an offset past the end of the file. Fixes #636.

When `length == :all` and `offset > size`, the computed `length = size - offset` goes negative, and the bounds check `offset + length <= size` reduces to `size <= size`, which is always true. Bandit then wrote a negative `Content-Length` header to the wire and attempted a sendfile with a negative byte count (`einval`). RFC 9110 §8.6 requires Content-Length to be a non-negative integer.

This is defense in depth: `Plug.Static` validates ranges before calling `send_file`, so this requires a custom plug passing `length: :all` with an offset derived from request input.

## Fix

```diff
-if offset + length <= size do
+if length >= 0 and offset + length <= size do
```

Valid ranges are unaffected since they already satisfy `length >= 0`.

## Testing

Added a test in `test/bandit/http1/plug_test.exs` requesting `offset=100&length=:all` against the 6-byte `sendfile` fixture. Confirmed red: without the fix, Req reports `{:invalid_content_length_header, "-94"}` and the server logs an `einval` TransportError. With the fix, the request is rejected (500) before any bytes are sent, with no content-length header. Full suite (757 tests) passes.