### PR TITLE
Initialize the per-stream receive window from the advertised initial_window_size

### DIFF
--- a/lib/bandit/http2/connection.ex
+++ b/lib/bandit/http2/connection.ex
@@ -250,6 +250,7 @@ defmodule Bandit.HTTP2.Connection do
             self(),
             stream_id,
             connection.remote_settings.initial_window_size,
+            connection.local_settings.initial_window_size,
             sendfile_chunk_size
           )
 

--- a/lib/bandit/http2/stream.ex
+++ b/lib/bandit/http2/stream.ex
@@ -72,11 +72,18 @@ defmodule Bandit.HTTP2.Stream do
           read_timeout: timeout()
         }
 
-  def init(connection_pid, stream_id, initial_send_window_size, sendfile_chunk_size) do
+  def init(
+        connection_pid,
+        stream_id,
+        initial_send_window_size,
+        initial_recv_window_size,
+        sendfile_chunk_size
+      ) do
     %__MODULE__{
       connection_pid: connection_pid,
       stream_id: stream_id,
       send_window_size: initial_send_window_size,
+      recv_window_size: initial_recv_window_size,
       sendfile_chunk_size: sendfile_chunk_size
     }
   end

--- a/test/bandit/http2/protocol_test.exs
+++ b/test/bandit/http2/protocol_test.exs
@@ -2434,6 +2434,42 @@ defmodule HTTP2ProtocolTest do
       assert SimpleH2Client.recv_body(socket) == {:ok, 3, true, "OK"}
     end
 
+    test "seeds the stream receive window from a configured initial_window_size", context do
+      context =
+        context
+        |> https_server(http_2_options: [default_local_settings: [initial_window_size: 1_000_000]])
+        |> Enum.into(context)
+
+      socket = SimpleH2Client.setup_connection(context)
+
+      # Warm up and drain the connection-level window update (which is unaffected by
+      # initial_window_size) by fully closing out a first stream
+      SimpleH2Client.send_simple_headers(socket, 1, :post, "/echo", context.port)
+      SimpleH2Client.send_body(socket, 1, true, "OK")
+
+      {:ok, 0, _} = SimpleH2Client.recv_window_update(socket)
+
+      assert {:ok, 1, false, [{":status", "200"} | _], ctx} = SimpleH2Client.recv_headers(socket)
+      assert SimpleH2Client.recv_body(socket) == {:ok, 1, true, "OK"}
+
+      # With the connection window already refreshed well above the 2^30 update threshold, send
+      # a second stream's body as a non-final DATA frame (so its own window update, which is
+      # skipped when a DATA frame ends the stream, is actually emitted) followed by an empty
+      # end_stream frame. This isolates a stream-level update. With the fix, it is seeded from
+      # the advertised initial_window_size (1_000_000) rather than the hardcoded default of
+      # 65_535, so the client's send window (which started at the advertised value) lands at
+      # exactly 2^31-1 rather than being pushed past it.
+      SimpleH2Client.send_simple_headers(socket, 3, :post, "/echo", context.port)
+      SimpleH2Client.send_body(socket, 3, false, "OK")
+      SimpleH2Client.send_body(socket, 3, true, "")
+
+      expected_adjustment = (1 <<< 31) - 1 - 1_000_000 + 2
+      {:ok, 3, ^expected_adjustment} = SimpleH2Client.recv_window_update(socket)
+
+      assert SimpleH2Client.successful_response?(socket, 3, false, ctx)
+      assert SimpleH2Client.recv_body(socket) == {:ok, 3, true, "OK"}
+    end
+
     @tag :slow
     test "does not issue a subsequent update until receive window goes below 2^30", context do
       socket = SimpleH2Client.setup_connection(context)

--- a/test/bandit/http2/protocol_test.exs
+++ b/test/bandit/http2/protocol_test.exs
@@ -2437,7 +2437,9 @@ defmodule HTTP2ProtocolTest do
     test "seeds the stream receive window from a configured initial_window_size", context do
       context =
         context
-        |> https_server(http_2_options: [default_local_settings: [initial_window_size: 1_000_000]])
+        |> https_server(
+          http_2_options: [default_local_settings: [initial_window_size: 1_000_000]]
+        )
         |> Enum.into(context)
 
       socket = SimpleH2Client.setup_connection(context)


### PR DESCRIPTION
## Summary

Each HTTP/2 stream tracked its receive window from a hardcoded 65535, but the connection advertises `local_settings.initial_window_size` to the client in its SETTINGS frame. Fixes #638.

RFC 9113 §6.5.2 (`SETTINGS_INITIAL_WINDOW_SIZE`): "this setting affects the window size of all streams." A server configuring `initial_window_size` via the documented `default_local_settings` option is telling the client what per-stream send window to use — the server's own receive-window accounting must agree with that value, or the two sides diverge. When they diverge, the first WINDOW_UPDATE the server sends can push the client's send window past 2^31-1, which RFC 9113 §6.9.1 requires a conformant client to treat as a connection error.

## Fix

Pass the connection's local `initial_window_size` into `Stream.init` and seed `recv_window_size` from it, mirroring how `send_window_size` is already seeded from the client's advertised value. `Stream.init` has no callers outside `connection.ex`, so the arity change is contained and a no-op for the default configuration (65535).

## Testing

Added a test in `test/bandit/http2/protocol_test.exs` configuring `default_local_settings: [initial_window_size: 1_000_000]`. Isolating the stream-level (as opposed to connection-level) WINDOW_UPDATE required following the same technique as the neighboring "manages connection and stream receive windows separately" test — a non-final DATA frame, since the per-stream update is skipped when a DATA frame ends the stream.

Confirmed red/green: reverting the two lib changes reproduces the pre-fix adjustment (`2147418114`, computed from the hardcoded 65535 base) instead of the expected value computed from 1_000_000. With the fix, the full suite (757 tests) passes.