### PR TITLE
Honor the close/keep-alive token inside a comma-separated Connection header

### DIFF
--- a/lib/bandit/http1/socket.ex
+++ b/lib/bandit/http1/socket.ex
@@ -508,13 +508,14 @@ defmodule Bandit.HTTP1.Socket do
 
           {headers, %{socket | keepalive: false}}
 
-        socket.request_connection_header == "close" || response_connection_header == "close" ->
+        connection_option?(socket.request_connection_header, "close") ||
+            connection_option?(response_connection_header, "close") ->
           # Per RFC9112§9.6, a party that intends to close the connection SHOULD send a
           # 'close' connection option in its final message. If the response hasn't already
           # declared this itself, do so now (this happens when the client, not the plug,
           # is the one that asked for the connection to close).
           headers =
-            if response_connection_header == "close" do
+            if connection_option?(response_connection_header, "close") do
               headers
             else
               [{"connection", "close"} | Enum.reject(headers, &(elem(&1, 0) == "connection"))]
@@ -525,13 +526,22 @@ defmodule Bandit.HTTP1.Socket do
         socket.version == :"HTTP/1.1" ->
           {headers, %{socket | keepalive: true}}
 
-        socket.version == :"HTTP/1.0" && socket.request_connection_header == "keep-alive" ->
+        socket.version == :"HTTP/1.0" &&
+            connection_option?(socket.request_connection_header, "keep-alive") ->
           {[{"connection", "keep-alive"} | headers], %{socket | keepalive: true}}
 
         true ->
           {[{"connection", "close"} | headers], %{socket | keepalive: false}}
       end
     end
+
+    # The connection header carries a comma-separated list of options (RFC9110§7.6.1), so we
+    # look for a token within the (already downcased) value rather than comparing the whole
+    # string. This ensures list forms like "keep-alive, close" are handled correctly.
+    defp connection_option?(nil, _option), do: false
+
+    defp connection_option?(header_value, option),
+      do: header_value |> String.split(",") |> Enum.any?(&(String.trim(&1) == option))
 
     defp safe_downcase(str) when is_binary(str), do: String.downcase(str, :ascii)
     defp safe_downcase(str), do: str

--- a/test/bandit/http1/protocol_test.exs
+++ b/test/bandit/http1/protocol_test.exs
@@ -2357,6 +2357,20 @@ defmodule HTTP1ProtocolTest do
       assert SimpleHTTP1Client.connection_closed_for_reading?(client)
     end
 
+    test "closes the connection when an HTTP/1.1 client requests it via a comma-separated list",
+         context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "GET", "/echo_components", [
+        "host: localhost",
+        "connection: keep-alive, close"
+      ])
+
+      assert {:ok, "200 OK", headers, _body} = SimpleHTTP1Client.recv_reply(client)
+      assert Keyword.get_values(headers, :connection) == ["close"]
+      assert SimpleHTTP1Client.connection_closed_for_reading?(client)
+    end
+
     test "handles pipeline requests", context do
       client = SimpleHTTP1Client.tcp_client(context)
 
@@ -2520,6 +2534,32 @@ defmodule HTTP1ProtocolTest do
         "GET",
         "/echo_components",
         ["host: localhost", "connection: Keep-Alive"],
+        "1.0"
+      )
+
+      assert {:ok, "200 OK", _headers, _body} = SimpleHTTP1Client.recv_reply(client)
+    end
+
+    test "keepalive is respected in HTTP/1.0 when listed alongside other connection options",
+         context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(
+        client,
+        "GET",
+        "/echo_components",
+        ["host: localhost", "connection: keep-alive, x-custom"],
+        "1.0"
+      )
+
+      assert {:ok, "200 OK", headers, _body} = SimpleHTTP1Client.recv_reply(client)
+      assert Keyword.get_values(headers, :connection) == ["keep-alive"]
+
+      SimpleHTTP1Client.send(
+        client,
+        "GET",
+        "/echo_components",
+        ["host: localhost", "connection: keep-alive, x-custom"],
         "1.0"
       )
 


### PR DESCRIPTION
## Summary

`handle_keepalive/3` compared the whole `Connection` header value with `== "close"` and `== "keep-alive"`. Fixes #639.

Per RFC 9110 §7.6.1, `Connection` is a comma-separated list of connection options, and a recipient must look for the relevant option as a token within that list (RFC 9112 §9.6 for the close semantics). A value such as `Connection: keep-alive, close` does not equal `"close"`, so the close request was missed: Bandit kept the connection alive and did not echo `Connection: close`. The HTTP/1.0 keep-alive detection (`== "keep-alive"`) had the same flaw.

## Fix

Added a `connection_option?/2` helper that splits the (already-downcased) header value on `,` and checks token membership, and used it everywhere the header was previously compared with `==`. A bare `close` or `keep-alive` is a single-element list, so existing behavior for well-formed single-token headers is unchanged.

## Testing

Added two tests to `test/bandit/http1/protocol_test.exs`:
- `Connection: keep-alive, close` on HTTP/1.1 closes the connection and echoes `Connection: close`.
- `Connection: keep-alive, x-custom` on HTTP/1.0 is still recognized as a keep-alive request.

Confirmed red/green: reverting the lib change reproduces both failures exactly as described (list form treated as neither close nor keep-alive). With the fix, the full suite (758 tests) passes.