### PR TITLE
Use PROTOCOL_ERROR for a zero WINDOW_UPDATE increment

### DIFF
--- a/lib/bandit/http2/frame/window_update.ex
+++ b/lib/bandit/http2/frame/window_update.ex
@@ -13,7 +13,7 @@ defmodule Bandit.HTTP2.Frame.WindowUpdate do
   @spec deserialize(Bandit.HTTP2.Frame.flags(), Bandit.HTTP2.Stream.stream_id(), iodata()) ::
           {:ok, t()} | {:error, Bandit.HTTP2.Errors.error_code(), binary()}
   def deserialize(_flags, _stream_id, <<_reserved::1, 0::31>>) do
-    {:error, Bandit.HTTP2.Errors.flow_control_error(),
+    {:error, Bandit.HTTP2.Errors.protocol_error(),
      "Invalid WINDOW_UPDATE size increment (RFC9113§6.9)"}
   end
 

--- a/test/bandit/http2/frame_deserialization_test.exs
+++ b/test/bandit/http2/frame_deserialization_test.exs
@@ -403,7 +403,7 @@ defmodule HTTP2FrameDeserializationTest do
       frame = <<0, 0, 4, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0>>
 
       assert Frame.deserialize(frame, 16_384) ==
-               {{:error, Errors.flow_control_error(),
+               {{:error, Errors.protocol_error(),
                  "Invalid WINDOW_UPDATE size increment (RFC9113§6.9)"}, <<>>}
     end
 
@@ -411,7 +411,7 @@ defmodule HTTP2FrameDeserializationTest do
       frame = <<0, 0, 4, 8, 0, 0, 0, 0, 123, 0, 0, 0, 0>>
 
       assert Frame.deserialize(frame, 16_384) ==
-               {{:error, Errors.flow_control_error(),
+               {{:error, Errors.protocol_error(),
                  "Invalid WINDOW_UPDATE size increment (RFC9113§6.9)"}, <<>>}
     end
 


### PR DESCRIPTION
## Summary

A WINDOW_UPDATE frame with a flow-control increment of 0 was reported with `FLOW_CONTROL_ERROR`. Fixes #641.

RFC 9113 §6.9: "A receiver MUST treat the receipt of a WINDOW_UPDATE frame with a flow-control window increment of 0 as a stream error of type PROTOCOL_ERROR; errors on the connection flow-control window MUST be treated as a connection error." The error *type* is PROTOCOL_ERROR in both the stream and connection cases — `FLOW_CONTROL_ERROR` is the correct code for the other §6.9 case (a window that would exceed 2^31-1), which this change does not touch.

Bandit routes all frame-deserialization errors to connection-level handling by design (unrelated to this fix; noted in the issue as a separate, larger consideration around stream- vs connection-scoped errors for non-zero stream ids).

## Fix

One-line: `Bandit.HTTP2.Errors.flow_control_error()` → `protocol_error()` in the zero-increment clause.

## Testing

Updated the two existing tests in `test/bandit/http2/frame_deserialization_test.exs` that asserted the old (incorrect) error code. Confirmed red/green: reverting the lib change reproduces error code `3` (FLOW_CONTROL_ERROR) instead of `1` (PROTOCOL_ERROR) in both. With the fix, the full suite (756 tests) passes.