### PR TITLE
Match the weak-etag prefix W/ explicitly

### DIFF
--- a/lib/bandit/compression.ex
+++ b/lib/bandit/compression.ex
@@ -57,7 +57,7 @@ defmodule Bandit.Compression do
   defp response_has_strong_etag(headers) do
     case Bandit.Headers.get_header(headers, "etag") do
       nil -> false
-      "\W" <> _rest -> false
+      "W/" <> _rest -> false
       _strong_etag -> true
     end
   end

--- a/test/bandit/http1/protocol_test.exs
+++ b/test/bandit/http1/protocol_test.exs
@@ -1804,6 +1804,23 @@ defmodule HTTP1ProtocolTest do
       assert response.body == String.duplicate("a", 10_000)
     end
 
+    test "does no encoding if a malformed etag starting with W but not W/ is present", context do
+      response =
+        Req.get!(context.req,
+          url: "/send_malformed_w_etag",
+          headers: [{"accept-encoding", "deflate"}]
+        )
+
+      # An etag of "Wonky" starts with "W" but is not a well-formed weak etag (RFC9110§8.8.1
+      # requires the weak indicator to be "W/"), so it must be treated as a strong etag and
+      # compression must be skipped, just as with a well-formed strong etag.
+      assert response.status == 200
+      assert response.headers["content-length"] == ["10000"]
+      assert response.headers["content-encoding"] == nil
+      assert response.headers["vary"] == ["accept-encoding"]
+      assert response.body == String.duplicate("a", 10_000)
+    end
+
     test "does content encoding if a weak etag is present in the response", context do
       response =
         Req.get!(context.req, url: "/send_weak_etag", headers: [{"accept-encoding", "gzip"}])
@@ -1998,6 +2015,12 @@ defmodule HTTP1ProtocolTest do
     def send_weak_etag(conn) do
       conn
       |> put_resp_header("etag", "W/\"1234\"")
+      |> send_resp(200, String.duplicate("a", 10_000))
+    end
+
+    def send_malformed_w_etag(conn) do
+      conn
+      |> put_resp_header("etag", "Wonky")
       |> send_resp(200, String.duplicate("a", 10_000))
     end
 

--- a/test/bandit/http2/protocol_test.exs
+++ b/test/bandit/http2/protocol_test.exs
@@ -743,6 +743,36 @@ defmodule HTTP2ProtocolTest do
       assert SimpleH2Client.recv_body(socket) == {:ok, 1, true, expected}
     end
 
+    test "does no encoding if a malformed etag starting with W but not W/ is present", context do
+      socket = SimpleH2Client.setup_connection(context)
+
+      headers = [
+        {":method", "GET"},
+        {":path", "/send_malformed_w_etag"},
+        {":scheme", "https"},
+        {":authority", "localhost:#{context.port}"},
+        {"accept-encoding", "deflate"}
+      ]
+
+      SimpleH2Client.send_headers(socket, 1, true, headers)
+
+      # An etag of "Wonky" starts with "W" but is not a well-formed weak etag (RFC9110§8.8.1
+      # requires the weak indicator to be "W/"), so it must be treated as a strong etag and
+      # compression must be skipped, just as with a well-formed strong etag.
+      assert {:ok, 1, false,
+              [
+                {":status", "200"},
+                {"date", _date},
+                {"content-length", "10000"},
+                {"vary", "accept-encoding"},
+                {"cache-control", "max-age=0, private, must-revalidate"},
+                {"etag", "Wonky"}
+              ], _ctx} = SimpleH2Client.recv_headers(socket)
+
+      # Assert that we did not try to compress the body
+      assert SimpleH2Client.recv_body(socket) == {:ok, 1, true, String.duplicate("a", 10_000)}
+    end
+
     test "does no encoding if cache-control: no-transform is present in the response", context do
       socket = SimpleH2Client.setup_connection(context)
 
@@ -871,6 +901,12 @@ defmodule HTTP2ProtocolTest do
     def send_weak_etag(conn) do
       conn
       |> put_resp_header("etag", "W/\"1234\"")
+      |> send_resp(200, String.duplicate("a", 10_000))
+    end
+
+    def send_malformed_w_etag(conn) do
+      conn
+      |> put_resp_header("etag", "Wonky")
       |> send_resp(200, String.duplicate("a", 10_000))
     end
 


### PR DESCRIPTION
## Summary

The response compression path decided whether an etag is "strong" by matching the prefix `"\W"`. Fixes #642.

In Elixir, `"\W"` is not a recognized escape sequence and collapses to the single byte `"W"` (confirmed: `"\W" == "W"` is `true`), so the code actually matched any etag beginning with `W` rather than the RFC 9110 §8.8.1 weak-validator prefix `W/`. For well-formed etags this was accidentally correct (weak etags start with `W/`, strong etags start with a quote), but it misclassified a malformed, unquoted etag starting with `W` (e.g. `Wonky`) as weak, and relied on an escape-sequence quirk that newer Elixir versions flag.

## Fix

```diff
-      "\W" <> _rest -> false
+      "W/" <> _rest -> false
```

## Testing

Added a test to `test/bandit/http1/protocol_test.exs` sending a response with `etag: Wonky` (starts with `W`, not `W/`) and asserting compression is skipped, the same as for a well-formed strong etag — this is the case where behavior actually changes.

Confirmed red/green: reverting the lib change reproduces compression being (incorrectly) applied to the malformed-etag response. With the fix, the full suite (757 tests) passes; the existing well-formed strong/weak etag tests are unaffected.