### PR TITLE
Add tests for untested configuration options

### DIFF
--- a/lib/bandit.ex
+++ b/lib/bandit.ex
@@ -230,7 +230,7 @@ defmodule Bandit do
   @type deflate_options :: [
           {:level, :zlib.zlevel()}
           | {:window_bits, :zlib.zwindowbits()}
-          | {:memory_level, :zlib.zmemlevel()}
+          | {:mem_level, :zlib.zmemlevel()}
           | {:strategy, :zlib.zstrategy()}
         ]
 

--- a/test/bandit/http2/plug_test.exs
+++ b/test/bandit/http2/plug_test.exs
@@ -541,6 +541,34 @@ defmodule HTTP2PlugTest do
       send_file(conn, 200, Path.join([__DIR__, "../../support/sendfile_large"]), 0, :all)
     end
 
+    test "respects sendfile_chunk_size when sending files", context do
+      context =
+        context
+        |> https_server(http_2_options: [sendfile_chunk_size: 1_024])
+        |> Enum.into(context)
+
+      socket = SimpleH2Client.setup_connection(context)
+      SimpleH2Client.send_simple_headers(socket, 1, :get, "/send_large_file", context.port)
+
+      assert {:ok, 1, false, [{":status", "200"} | _rest], _ctx} =
+               SimpleH2Client.recv_headers(socket)
+
+      chunks = recv_body_chunks(socket)
+
+      # The 3008 byte file should be read & sent as 1024 + 1024 + 960 byte DATA frames
+      assert length(chunks) == 3
+      assert Enum.all?(chunks, fn chunk -> byte_size(chunk) <= 1_024 end)
+
+      expected_body = File.read!(Path.join([__DIR__, "../../support/sendfile_large"]))
+      assert IO.iodata_to_binary(chunks) == expected_body
+    end
+
+    defp recv_body_chunks(socket, chunks \\ []) do
+      {:ok, 1, end_stream, chunk} = SimpleH2Client.recv_body(socket)
+      chunks = chunks ++ [chunk]
+      if end_stream, do: chunks, else: recv_body_chunks(socket, chunks)
+    end
+
     @tag :capture_log
     test "sending a file from another process works as expected", context do
       response = Req.get!(context.req, url: "/other_process_send_file")

--- a/test/bandit/websocket/protocol_test.exs
+++ b/test/bandit/websocket/protocol_test.exs
@@ -375,6 +375,75 @@ defmodule WebSocketProtocolTest do
 
       assert output =~ "Received compressed frame inflating too much"
     end
+
+    test "respects max_inflate_ratio for received frames", context do
+      # Build a payload which inflates at a ratio of about 10:1; large enough that inflation
+      # spans several :zlib.safeInflate/2 calls, but comfortably within the default ratio of 25
+      block = for i <- 1..6_000, into: <<>>, do: <<i::32>>
+      inflated_payload = :binary.copy(block, 6)
+
+      zstream = :zlib.open()
+      :ok = :zlib.deflateInit(zstream, :default, :deflated, -15, 8, :default)
+      deflated = zstream |> :zlib.deflate(inflated_payload, :sync) |> IO.iodata_to_binary()
+      :zlib.close(zstream)
+      payload_size = byte_size(deflated) - 4
+      <<payload::binary-size(^payload_size), 0x00, 0x00, 0xFF, 0xFF>> = deflated
+
+      # Ensure that a server with default options is happy to inflate it
+      client = SimpleWebSocketClient.tcp_client(context)
+      SimpleWebSocketClient.http1_handshake(client, EchoWebSock, [], true)
+      SimpleWebSocketClient.send_binary_frame(client, payload, 0xC)
+      assert {:ok, _echoed_payload} = SimpleWebSocketClient.recv_deflated_binary_frame(client)
+
+      output =
+        capture_log(fn ->
+          # The same payload must be refused by a server configured with a stricter ratio
+          context = http_server(context, websocket_options: [max_inflate_ratio: 5])
+          client = SimpleWebSocketClient.tcp_client(context)
+          SimpleWebSocketClient.http1_handshake(client, TerminateWebSock, [], true)
+          SimpleWebSocketClient.send_binary_frame(client, payload, 0xC)
+
+          # Get the error that terminate saw, to ensure we're closing for the expected reason
+          assert_receive {:error, "Received compressed frame inflating too much"}, 500
+
+          # Validate that the server has started the shutdown handshake from RFC6455§7.1.2
+          assert SimpleWebSocketClient.recv_connection_close_frame(client) == {:ok, <<1009::16>>}
+
+          # Verify that the server didn't send any extraneous frames
+          assert SimpleWebSocketClient.connection_closed_for_reading?(client)
+          Process.sleep(500)
+        end)
+
+      assert output =~ "Received compressed frame inflating too much"
+    end
+
+    test "respects deflate_options when deflating frames", context do
+      context = http_server(context, websocket_options: [deflate_options: [level: 0]])
+      client = SimpleWebSocketClient.tcp_client(context)
+      SimpleWebSocketClient.http1_handshake(client, EchoWebSock, [], true)
+
+      payload = String.duplicate("a", 1_000)
+      SimpleWebSocketClient.send_text_frame(client, payload)
+
+      {:ok, deflated_payload} = SimpleWebSocketClient.recv_deflated_text_frame(client)
+
+      # level: 0 emits stored (uncompressed) blocks, so the deflated payload must be larger
+      # than the original; the default level would compress it down to a handful of bytes
+      assert byte_size(deflated_payload) > byte_size(payload)
+
+      # Ensure that the payload still inflates back to the original
+      zstream = :zlib.open()
+      :ok = :zlib.inflateInit(zstream, -15)
+
+      inflated_payload =
+        zstream
+        |> :zlib.inflate(<<deflated_payload::binary, 0x00, 0x00, 0xFF, 0xFF>>)
+        |> IO.iodata_to_binary()
+
+      :zlib.close(zstream)
+
+      assert inflated_payload == payload
+    end
   end
 
   describe "ping frames" do


### PR DESCRIPTION
## Summary

Adds coverage for three documented options that previously had no tests, plus a one-line doc correction. Fixes #644.

* websocket `max_inflate_ratio`: a compressed frame within the default 25:1 ratio is accepted, and the same frame is refused with a 1009 close when a stricter ratio is configured
* websocket `deflate_options`: `level` settings are applied when deflating outbound frames
* http_2 `sendfile_chunk_size`: file responses are split into DATA frames no larger than the configured chunk size
* corrects the `deflate_options` typedoc in `lib/bandit.ex` to name the `mem_level` key actually read by both `Bandit.Compression` and `Bandit.WebSocket.PerMessageDeflate` (it was documented as `memory_level`, which is silently ignored — verified by grepping both modules)

## Testing methodology

Since this PR only adds tests (no lib behavior change), "red/green" here means confirming each new test actually exercises its option rather than passing vacuously. For each of the three option tests, I temporarily hardcoded the option's default value in the relevant lib code (bypassing `Keyword.get(opts, :option, default)`) and reran the test:

- `sendfile_chunk_size` neutralized → test fails (`length(chunks) == 1`, expected `3`)
- `max_inflate_ratio` neutralized → test fails (times out waiting for the 1009 close)
- `deflate_options: [level: 0]` neutralized → test fails (`byte_size(deflated_payload) == 11`, expected `> 1000`)

All three lib changes were reverted before committing — this PR touches only `lib/bandit.ex` (the doc fix) and test files.

Full suite (759 tests) passes.