### PR TITLE
Unify case-insensitive comma-separated header token checks

### DIFF
--- a/lib/bandit/compression.ex
+++ b/lib/bandit/compression.ex
@@ -50,22 +50,9 @@ defmodule Bandit.Compression do
 
   defp maybe_add_vary_header(adapter, status, headers) do
     if status != 204 && Keyword.get(adapter.opts.http, :compress, true) &&
-         !vary_includes_accept_encoding?(headers),
+         !Bandit.Headers.header_contains_token?(headers, "vary", "accept-encoding"),
        do: [{"vary", "accept-encoding"} | headers],
        else: headers
-  end
-
-  defp vary_includes_accept_encoding?(headers) do
-    # vary field-names are case-insensitive, and a plug may emit more than one vary header, so
-    # scan every vary header and compare tokens case-insensitively rather than trusting the
-    # first header's exact casing.
-    headers
-    |> Enum.filter(fn {name, _value} -> String.downcase(name, :ascii) == "vary" end)
-    |> Enum.any?(fn {_name, value} ->
-      value
-      |> Plug.Conn.Utils.list()
-      |> Enum.any?(&(String.downcase(&1, :ascii) == "accept-encoding"))
-    end)
   end
 
   defp response_has_strong_etag(headers) do
@@ -77,10 +64,7 @@ defmodule Bandit.Compression do
   end
 
   defp response_indicates_no_transform(headers) do
-    case Bandit.Headers.get_header(headers, "cache-control") do
-      nil -> false
-      header -> "no-transform" in Plug.Conn.Utils.list(header)
-    end
+    Bandit.Headers.header_contains_token?(headers, "cache-control", "no-transform")
   end
 
   defp start_stream("deflate", http_opts, _streamable) do

--- a/lib/bandit/compression.ex
+++ b/lib/bandit/compression.ex
@@ -49,9 +49,23 @@ defmodule Bandit.Compression do
   end
 
   defp maybe_add_vary_header(adapter, status, headers) do
-    if status != 204 && Keyword.get(adapter.opts.http, :compress, true),
-      do: [{"vary", "accept-encoding"} | headers],
-      else: headers
+    if status != 204 && Keyword.get(adapter.opts.http, :compress, true) &&
+         !vary_includes_accept_encoding?(headers),
+       do: [{"vary", "accept-encoding"} | headers],
+       else: headers
+  end
+
+  defp vary_includes_accept_encoding?(headers) do
+    # vary field-names are case-insensitive, and a plug may emit more than one vary header, so
+    # scan every vary header and compare tokens case-insensitively rather than trusting the
+    # first header's exact casing.
+    headers
+    |> Enum.filter(fn {name, _value} -> String.downcase(name, :ascii) == "vary" end)
+    |> Enum.any?(fn {_name, value} ->
+      value
+      |> Plug.Conn.Utils.list()
+      |> Enum.any?(&(String.downcase(&1, :ascii) == "accept-encoding"))
+    end)
   end
 
   defp response_has_strong_etag(headers) do

--- a/lib/bandit/headers.ex
+++ b/lib/bandit/headers.ex
@@ -13,6 +13,38 @@ defmodule Bandit.Headers do
     end
   end
 
+  # A number of headers (Connection, Vary, Cache-Control, ...) are defined as a comma-separated
+  # list of case-insensitive tokens (RFC9110§5.6.1), and field names are themselves
+  # case-insensitive (RFC9110§5.1). These two helpers centralize that "is this token present"
+  # check so each caller doesn't reimplement its own (subtly different) parsing.
+
+  @doc """
+  Returns whether `token` (expected to already be lowercase) appears as a comma-separated member
+  of `header_value`, compared case-insensitively. `header_value` may be `nil`, in which case this
+  always returns `false`.
+  """
+  @spec token_list_member?(header_value :: binary() | nil, token :: binary()) :: boolean()
+  def token_list_member?(nil, _token), do: false
+
+  def token_list_member?(header_value, token) do
+    header_value
+    |> Plug.Conn.Utils.list()
+    |> Enum.any?(&(String.downcase(&1, :ascii) == token))
+  end
+
+  @doc """
+  Returns whether any header named `header` (matched case-insensitively, and scanning every
+  instance if the header appears more than once) contains `token` (expected to already be
+  lowercase) as a comma-separated member of its value.
+  """
+  @spec header_contains_token?(Plug.Conn.headers(), header :: binary(), token :: binary()) ::
+          boolean()
+  def header_contains_token?(headers, header, token) do
+    headers
+    |> Enum.filter(fn {name, _value} -> String.downcase(name, :ascii) == header end)
+    |> Enum.any?(fn {_name, value} -> token_list_member?(value, token) end)
+  end
+
   # Host is special-cased (rather than using get_header/2) because, per RFC9112§3.2 /
   # RFC9110§7.2, a request MUST be rejected if it contains more than one host header,
   # even if the values are identical (unlike content-length, which tolerates duplicates

--- a/lib/bandit/http1/socket.ex
+++ b/lib/bandit/http1/socket.ex
@@ -508,14 +508,14 @@ defmodule Bandit.HTTP1.Socket do
 
           {headers, %{socket | keepalive: false}}
 
-        connection_option?(socket.request_connection_header, "close") ||
-            connection_option?(response_connection_header, "close") ->
+        Bandit.Headers.token_list_member?(socket.request_connection_header, "close") ||
+            Bandit.Headers.token_list_member?(response_connection_header, "close") ->
           # Per RFC9112§9.6, a party that intends to close the connection SHOULD send a
           # 'close' connection option in its final message. If the response hasn't already
           # declared this itself, do so now (this happens when the client, not the plug,
           # is the one that asked for the connection to close).
           headers =
-            if connection_option?(response_connection_header, "close") do
+            if Bandit.Headers.token_list_member?(response_connection_header, "close") do
               headers
             else
               [{"connection", "close"} | Enum.reject(headers, &(elem(&1, 0) == "connection"))]
@@ -527,21 +527,13 @@ defmodule Bandit.HTTP1.Socket do
           {headers, %{socket | keepalive: true}}
 
         socket.version == :"HTTP/1.0" &&
-            connection_option?(socket.request_connection_header, "keep-alive") ->
+            Bandit.Headers.token_list_member?(socket.request_connection_header, "keep-alive") ->
           {[{"connection", "keep-alive"} | headers], %{socket | keepalive: true}}
 
         true ->
           {[{"connection", "close"} | headers], %{socket | keepalive: false}}
       end
     end
-
-    # The connection header carries a comma-separated list of options (RFC9110§7.6.1), so we
-    # look for a token within the (already downcased) value rather than comparing the whole
-    # string. This ensures list forms like "keep-alive, close" are handled correctly.
-    defp connection_option?(nil, _option), do: false
-
-    defp connection_option?(header_value, option),
-      do: header_value |> String.split(",") |> Enum.any?(&(String.trim(&1) == option))
 
     defp safe_downcase(str) when is_binary(str), do: String.downcase(str, :ascii)
     defp safe_downcase(str), do: str

--- a/lib/bandit/http1/socket.ex
+++ b/lib/bandit/http1/socket.ex
@@ -508,13 +508,14 @@ defmodule Bandit.HTTP1.Socket do
 
           {headers, %{socket | keepalive: false}}
 
-        socket.request_connection_header == "close" || response_connection_header == "close" ->
+        connection_option?(socket.request_connection_header, "close") ||
+            connection_option?(response_connection_header, "close") ->
           # Per RFC9112§9.6, a party that intends to close the connection SHOULD send a
           # 'close' connection option in its final message. If the response hasn't already
           # declared this itself, do so now (this happens when the client, not the plug,
           # is the one that asked for the connection to close).
           headers =
-            if response_connection_header == "close" do
+            if connection_option?(response_connection_header, "close") do
               headers
             else
               [{"connection", "close"} | Enum.reject(headers, &(elem(&1, 0) == "connection"))]
@@ -525,13 +526,22 @@ defmodule Bandit.HTTP1.Socket do
         socket.version == :"HTTP/1.1" ->
           {headers, %{socket | keepalive: true}}
 
-        socket.version == :"HTTP/1.0" && socket.request_connection_header == "keep-alive" ->
+        socket.version == :"HTTP/1.0" &&
+            connection_option?(socket.request_connection_header, "keep-alive") ->
           {[{"connection", "keep-alive"} | headers], %{socket | keepalive: true}}
 
         true ->
           {[{"connection", "close"} | headers], %{socket | keepalive: false}}
       end
     end
+
+    # The connection header carries a comma-separated list of options (RFC9110§7.6.1), so we
+    # look for a token within the (already downcased) value rather than comparing the whole
+    # string. This ensures list forms like "keep-alive, close" are handled correctly.
+    defp connection_option?(nil, _option), do: false
+
+    defp connection_option?(header_value, option),
+      do: header_value |> String.split(",") |> Enum.any?(&(String.trim(&1) == option))
 
     defp safe_downcase(str) when is_binary(str), do: String.downcase(str, :ascii)
     defp safe_downcase(str), do: str

--- a/test/bandit/headers_test.exs
+++ b/test/bandit/headers_test.exs
@@ -106,4 +106,63 @@ defmodule Bandit.HeadersTest do
       end
     end
   end
+
+  describe "token_list_member?/2" do
+    test "returns false for a nil header value" do
+      refute Headers.token_list_member?(nil, "close")
+    end
+
+    test "matches a bare single-token value" do
+      assert Headers.token_list_member?("close", "close")
+      refute Headers.token_list_member?("keep-alive", "close")
+    end
+
+    test "matches a token within a comma-separated list, regardless of position" do
+      assert Headers.token_list_member?("keep-alive, close", "close")
+      assert Headers.token_list_member?("close, keep-alive", "close")
+      assert Headers.token_list_member?("keep-alive,close", "close")
+    end
+
+    test "compares tokens case-insensitively" do
+      assert Headers.token_list_member?("Close", "close")
+      assert Headers.token_list_member?("keep-alive, CLOSE", "close")
+    end
+
+    test "does not match a token that is only a substring of a list member" do
+      refute Headers.token_list_member?("closely", "close")
+    end
+  end
+
+  describe "header_contains_token?/3" do
+    test "returns false when the header is absent" do
+      refute Headers.header_contains_token?([], "vary", "accept-encoding")
+    end
+
+    test "matches a token within the header's value" do
+      assert Headers.header_contains_token?(
+               [{"vary", "accept-encoding"}],
+               "vary",
+               "accept-encoding"
+             )
+
+      refute Headers.header_contains_token?(
+               [{"vary", "accept-language"}],
+               "vary",
+               "accept-encoding"
+             )
+    end
+
+    test "matches the header name case-insensitively" do
+      assert Headers.header_contains_token?(
+               [{"Vary", "Accept-Encoding"}],
+               "vary",
+               "accept-encoding"
+             )
+    end
+
+    test "scans every instance of a repeated header" do
+      headers = [{"vary", "accept-language"}, {"vary", "accept-encoding"}]
+      assert Headers.header_contains_token?(headers, "vary", "accept-encoding")
+    end
+  end
 end

--- a/test/bandit/http1/protocol_test.exs
+++ b/test/bandit/http1/protocol_test.exs
@@ -2357,6 +2357,20 @@ defmodule HTTP1ProtocolTest do
       assert SimpleHTTP1Client.connection_closed_for_reading?(client)
     end
 
+    test "closes the connection when an HTTP/1.1 client requests it via a comma-separated list",
+         context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "GET", "/echo_components", [
+        "host: localhost",
+        "connection: keep-alive, close"
+      ])
+
+      assert {:ok, "200 OK", headers, _body} = SimpleHTTP1Client.recv_reply(client)
+      assert Keyword.get_values(headers, :connection) == ["close"]
+      assert SimpleHTTP1Client.connection_closed_for_reading?(client)
+    end
+
     test "handles pipeline requests", context do
       client = SimpleHTTP1Client.tcp_client(context)
 
@@ -2520,6 +2534,32 @@ defmodule HTTP1ProtocolTest do
         "GET",
         "/echo_components",
         ["host: localhost", "connection: Keep-Alive"],
+        "1.0"
+      )
+
+      assert {:ok, "200 OK", _headers, _body} = SimpleHTTP1Client.recv_reply(client)
+    end
+
+    test "keepalive is respected in HTTP/1.0 when listed alongside other connection options",
+         context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(
+        client,
+        "GET",
+        "/echo_components",
+        ["host: localhost", "connection: keep-alive, x-custom"],
+        "1.0"
+      )
+
+      assert {:ok, "200 OK", headers, _body} = SimpleHTTP1Client.recv_reply(client)
+      assert Keyword.get_values(headers, :connection) == ["keep-alive"]
+
+      SimpleHTTP1Client.send(
+        client,
+        "GET",
+        "/echo_components",
+        ["host: localhost", "connection: keep-alive, x-custom"],
         "1.0"
       )
 

--- a/test/bandit/http1/protocol_test.exs
+++ b/test/bandit/http1/protocol_test.exs
@@ -1678,6 +1678,61 @@ defmodule HTTP1ProtocolTest do
       assert response.body == :zlib.gzip(String.duplicate("a", 10_000))
     end
 
+    test "does not duplicate an existing vary: accept-encoding header", context do
+      response =
+        Req.get!(context.req,
+          url: "/send_big_body_with_vary_accept_encoding",
+          headers: [{"accept-encoding", "deflate"}]
+        )
+
+      assert response.status == 200
+      assert response.headers["content-encoding"] == ["deflate"]
+      assert response.headers["vary"] == ["accept-encoding"]
+    end
+
+    def send_big_body_with_vary_accept_encoding(conn) do
+      conn
+      |> put_resp_header("vary", "accept-encoding")
+      |> send_resp(200, String.duplicate("a", 10_000))
+    end
+
+    test "does not duplicate an existing vary header regardless of its casing", context do
+      response =
+        Req.get!(context.req,
+          url: "/send_big_body_with_vary_mixed_case",
+          headers: [{"accept-encoding", "deflate"}]
+        )
+
+      assert response.status == 200
+      assert response.headers["content-encoding"] == ["deflate"]
+      assert response.headers["vary"] == ["Accept-Encoding"]
+    end
+
+    def send_big_body_with_vary_mixed_case(conn) do
+      conn
+      |> put_resp_header("vary", "Accept-Encoding")
+      |> send_resp(200, String.duplicate("a", 10_000))
+    end
+
+    test "still adds vary: accept-encoding alongside an unrelated existing vary header",
+         context do
+      response =
+        Req.get!(context.req,
+          url: "/send_big_body_with_vary_accept_language",
+          headers: [{"accept-encoding", "deflate"}]
+        )
+
+      assert response.status == 200
+      assert response.headers["content-encoding"] == ["deflate"]
+      assert response.headers["vary"] == ["accept-encoding", "accept-language"]
+    end
+
+    def send_big_body_with_vary_accept_language(conn) do
+      conn
+      |> put_resp_header("vary", "accept-language")
+      |> send_resp(200, String.duplicate("a", 10_000))
+    end
+
     test "does not indicate content encoding or vary for 204 responses", context do
       response =
         Req.get!(context.req, url: "/send_204", headers: [{"accept-encoding", "deflate"}])

--- a/test/bandit/http1/protocol_test.exs
+++ b/test/bandit/http1/protocol_test.exs
@@ -1885,6 +1885,22 @@ defmodule HTTP1ProtocolTest do
       assert response.body == String.duplicate("a", 10_000)
     end
 
+    test "does no encoding if cache-control: no-transform is present with mixed casing",
+         context do
+      response =
+        Req.get!(context.req,
+          url: "/send_mixed_case_no_transform",
+          headers: [{"accept-encoding", "deflate"}]
+        )
+
+      # Cache-Control directives are case-insensitive (RFC9111§5.2), so "No-Transform" must be
+      # recognized the same as "no-transform"
+      assert response.status == 200
+      assert response.headers["content-length"] == ["10000"]
+      assert response.headers["content-encoding"] == nil
+      assert response.body == String.duplicate("a", 10_000)
+    end
+
     test "falls back to no encoding if no encodings match", context do
       response =
         Req.get!(context.req, url: "/send_big_body", headers: [{"accept-encoding", "a, b, c"}])
@@ -2059,6 +2075,12 @@ defmodule HTTP1ProtocolTest do
     def send_no_transform(conn) do
       conn
       |> put_resp_header("cache-control", "no-transform")
+      |> send_resp(200, String.duplicate("a", 10_000))
+    end
+
+    def send_mixed_case_no_transform(conn) do
+      conn
+      |> put_resp_header("cache-control", "No-Transform")
       |> send_resp(200, String.duplicate("a", 10_000))
     end
   end


### PR DESCRIPTION
## Stacked PR

This is stacked on #655 (Connection header token parsing) and #658 (Vary dedup), since it refactors the code those introduce. **Merge #655 and #658 first**, then I'll retarget this PR's base to `main` (or it can be rebased). The diff shown here is only the incremental refactor on top of both.

## Summary

While working through #655 and #658 I noticed three call sites independently reimplementing "does this header's value contain this token" with inconsistent case-insensitivity:

- `lib/bandit/http1/socket.ex` (`connection_option?/2`, from #655): manual `String.split(",")` + trim, no name-casing concern since request header names are always downcased by Bandit's own parser.
- `lib/bandit/compression.ex` (`vary_includes_accept_encoding?/1`, from #658): scans repeated headers, case-insensitive on both name and token — this one was already correct because #658 fixed exactly this class of bug for `Vary`.
- `lib/bandit/compression.ex` (`response_indicates_no_transform/1`, pre-existing, untouched by either PR): only checks the *first* `cache-control` header and compares the `no-transform` token with exact-case `in`, so `Cache-Control: No-Transform` was silently ignored. Per RFC 9111 §5.2, cache directive names are case-insensitive — this is the same bug class as #642/#643, just not filed as its own issue.

## Change

Added two shared helpers to `Bandit.Headers`:
- `token_list_member?(header_value, token)` — nil-safe, splits on comma, compares case-insensitively
- `header_contains_token?(headers, header, token)` — scans every instance of `header` (matched case-insensitively by name) and delegates to `token_list_member?/2`

All three call sites now use these. Behavior for Connection and Vary is unchanged (same tests from #655/#658 still pass); Cache-Control's `no-transform` check is now case-insensitive and scans repeated headers, matching the other two.

## Testing

- Added a regression test for the Cache-Control case-insensitivity fix (`cache-control: No-Transform` now suppresses compression). Confirmed red: reverting to the old `get_header` + exact-match implementation reproduces the failure. Green with the fix.
- Added direct unit tests for both new `Bandit.Headers` helpers in `test/bandit/headers_test.exs`.
- Full suite (771 tests) passes; `mix format --check-formatted` is clean.