### PR TITLE
Honor Accept-Encoding q-values, the wildcard, and case-insensitive codings

### DIFF
--- a/accept-encoding-qvalues.diff
+++ b/accept-encoding-qvalues.diff
@@ -1,0 +1,193 @@
+diff --git a/lib/bandit/compression.ex b/lib/bandit/compression.ex
+index 9d721d9..f45a24c 100644
+--- a/lib/bandit/compression.ex
++++ b/lib/bandit/compression.ex
+@@ -21,15 +21,57 @@ defmodule Bandit.Compression do
+ 
+   def negotiate_content_encoding(accept_encoding, http_opts) do
+     if Keyword.get(http_opts, :compress, true) do
+-      client_accept_encoding = Plug.Conn.Utils.list(accept_encoding)
++      # Parse Accept-Encoding per RFC9110§12.5.3, honoring q-values (a value of q=0 means 'not
++      # acceptable') and the '*' wildcard, and comparing codings case-insensitively. Among the
++      # codings the client is willing to accept, we pick the first in our own preference order
++      accepted = parse_accept_encoding(accept_encoding)
++      wildcard_q = Enum.find_value(accepted, fn {coding, q} -> if coding == "*", do: q end)
+ 
+       Keyword.get(http_opts, :response_encodings, @accepted_encodings)
+-      |> Enum.find(&(&1 in client_accept_encoding))
++      |> Enum.find(fn encoding ->
++        case List.keyfind(accepted, encoding, 0) do
++          {_coding, q} -> q > 0
++          nil -> wildcard_q != nil and wildcard_q > 0
++        end
++      end)
+     else
+       nil
+     end
+   end
+ 
++  @spec parse_accept_encoding(binary()) :: [{binary(), float()}]
++  defp parse_accept_encoding(accept_encoding) do
++    accept_encoding
++    |> Plug.Conn.Utils.list()
++    |> Enum.map(fn element ->
++      case String.split(element, ";") do
++        [coding] -> {normalize_coding(coding), 1.0}
++        [coding | params] -> {normalize_coding(coding), quality_value(params)}
++      end
++    end)
++  end
++
++  @spec normalize_coding(binary()) :: binary()
++  defp normalize_coding(coding), do: coding |> String.trim() |> String.downcase(:ascii)
++
++  # Per RFC9110§12.4.2. Malformed q values are leniently read as 1.0 rather than refusing the
++  # coding, since a client that bothered to list a coding presumably accepts it
++  @spec quality_value([binary()]) :: float()
++  defp quality_value(params) do
++    Enum.find_value(params, 1.0, fn param ->
++      case param |> String.trim() |> String.downcase(:ascii) |> String.split("=") do
++        ["q", value] ->
++          case Float.parse(value) do
++            {q, _rest} -> q
++            :error -> 1.0
++          end
++
++        _ ->
++          nil
++      end
++    end)
++  end
++
+   def new(adapter, status, headers, empty_body?, streamable \\ false) do
+     response_content_encoding_header = Bandit.Headers.get_header(headers, "content-encoding")
+ 
+diff --git a/test/bandit/compression_test.exs b/test/bandit/compression_test.exs
+new file mode 100644
+index 0000000..a6e22c6
+--- /dev/null
++++ b/test/bandit/compression_test.exs
+@@ -0,0 +1,72 @@
++defmodule CompressionTest do
++  use ExUnit.Case, async: true
++
++  alias Bandit.Compression
++
++  describe "negotiate_content_encoding/2" do
++    # The default response_encodings list is platform dependent (zstd is included when the
++    # :zstd module is available), so tests which exercise the wildcard pin an explicit
++    # preference order to stay deterministic across OTP versions
++    @encodings ~w(gzip x-gzip deflate)
++
++    defp negotiate(accept_encoding, opts \\ []),
++      do: Compression.negotiate_content_encoding(accept_encoding, opts)
++
++    test "returns nil when no accept-encoding header is present" do
++      assert negotiate(nil) == nil
++    end
++
++    test "selects a plainly listed encoding in server preference order" do
++      assert negotiate("gzip, deflate") == "gzip"
++      assert negotiate("deflate, gzip") == "gzip"
++      assert negotiate("deflate") == "deflate"
++    end
++
++    test "compares codings case-insensitively (RFC9110§8.4.1)" do
++      assert negotiate("GZIP") == "gzip"
++      assert negotiate("Deflate") == "deflate"
++    end
++
++    test "honors q-values on listed encodings (any q>0 is acceptable)" do
++      assert negotiate("gzip;q=1.0") == "gzip"
++      assert negotiate("gzip;q=0.5") == "gzip"
++      assert negotiate("br;q=1.0, gzip;q=0.5") == "gzip"
++    end
++
++    test "treats q=0 as a refusal" do
++      assert negotiate("gzip;q=0, deflate") == "deflate"
++      assert negotiate("gzip;q=0") == nil
++      assert negotiate("gzip;q=0.0, deflate;q=0.000") |> is_nil()
++    end
++
++    test "honors the '*' wildcard" do
++      assert negotiate("*", response_encodings: @encodings) == "gzip"
++      assert negotiate("*;q=0, deflate", response_encodings: @encodings) == "deflate"
++      assert negotiate("*;q=0", response_encodings: @encodings) == nil
++    end
++
++    test "tolerates optional whitespace and mixed case around the q parameter" do
++      assert negotiate("gzip ; q=0.8") == "gzip"
++      assert negotiate("gzip; Q=0") |> is_nil()
++    end
++
++    test "reads malformed q values leniently as acceptance" do
++      assert negotiate("gzip;q=abc") == "gzip"
++      assert negotiate("gzip;q=") == "gzip"
++    end
++
++    test "does not compress when only identity is acceptable" do
++      assert negotiate("identity") == nil
++      assert negotiate("identity;q=1.0, *;q=0", response_encodings: @encodings) == nil
++      assert negotiate("identity;q=0, gzip") == "gzip"
++    end
++
++    test "returns nil when compression is disabled" do
++      assert negotiate("gzip", compress: false) == nil
++    end
++
++    test "respects a configured response_encodings preference order" do
++      assert negotiate("gzip, deflate", response_encodings: ["deflate", "gzip"]) == "deflate"
++    end
++  end
++end
+diff --git a/test/bandit/http1/compression_negotiation_test.exs b/test/bandit/http1/compression_negotiation_test.exs
+new file mode 100644
+index 0000000..482dc32
+--- /dev/null
++++ b/test/bandit/http1/compression_negotiation_test.exs
+@@ -0,0 +1,45 @@
++defmodule HTTP1CompressionNegotiationTest do
++  use ExUnit.Case, async: true
++  use ServerHelpers
++
++  setup :http_server
++
++  def hello(conn), do: send_resp(conn, 200, String.duplicate("a", 10_000))
++
++  defp get_with_accept_encoding(context, accept_encoding) do
++    client = SimpleHTTP1Client.tcp_client(context)
++
++    SimpleHTTP1Client.send(client, "GET", "/hello", [
++      "host: localhost",
++      "accept-encoding: #{accept_encoding}"
++    ])
++
++    {:ok, "200 OK", headers, body} = SimpleHTTP1Client.recv_reply(client)
++    {Keyword.get(headers, :"content-encoding"), body}
++  end
++
++  test "compresses for a q-valued accept-encoding (Ruby net/http style)", context do
++    {encoding, body} =
++      get_with_accept_encoding(context, "gzip;q=1.0,deflate;q=0.6,identity;q=0.3")
++
++    assert encoding == "gzip"
++    assert :zlib.gunzip(body) == String.duplicate("a", 10_000)
++  end
++
++  test "compresses for an uppercase coding", context do
++    {encoding, _body} = get_with_accept_encoding(context, "GZIP")
++    assert encoding == "gzip"
++  end
++
++  test "honors a q=0 refusal end to end", context do
++    {encoding, body} = get_with_accept_encoding(context, "gzip;q=0, x-gzip;q=0, deflate;q=0")
++    assert encoding == nil
++    assert body == String.duplicate("a", 10_000)
++  end
++
++  test "plain accept-encoding lists behave exactly as before", context do
++    {encoding, body} = get_with_accept_encoding(context, "gzip, deflate")
++    assert encoding == "gzip"
++    assert :zlib.gunzip(body) == String.duplicate("a", 10_000)
++  end
++end

--- a/lib/bandit/compression.ex
+++ b/lib/bandit/compression.ex
@@ -21,13 +21,55 @@ defmodule Bandit.Compression do
 
   def negotiate_content_encoding(accept_encoding, http_opts) do
     if Keyword.get(http_opts, :compress, true) do
-      client_accept_encoding = Plug.Conn.Utils.list(accept_encoding)
+      # Parse Accept-Encoding per RFC9110§12.5.3, honoring q-values (a value of q=0 means 'not
+      # acceptable') and the '*' wildcard, and comparing codings case-insensitively. Among the
+      # codings the client is willing to accept, we pick the first in our own preference order
+      accepted = parse_accept_encoding(accept_encoding)
+      wildcard_q = Enum.find_value(accepted, fn {coding, q} -> if coding == "*", do: q end)
 
       Keyword.get(http_opts, :response_encodings, @accepted_encodings)
-      |> Enum.find(&(&1 in client_accept_encoding))
+      |> Enum.find(fn encoding ->
+        case List.keyfind(accepted, encoding, 0) do
+          {_coding, q} -> q > 0
+          nil -> wildcard_q != nil and wildcard_q > 0
+        end
+      end)
     else
       nil
     end
+  end
+
+  @spec parse_accept_encoding(binary()) :: [{binary(), float()}]
+  defp parse_accept_encoding(accept_encoding) do
+    accept_encoding
+    |> Plug.Conn.Utils.list()
+    |> Enum.map(fn element ->
+      case String.split(element, ";") do
+        [coding] -> {normalize_coding(coding), 1.0}
+        [coding | params] -> {normalize_coding(coding), quality_value(params)}
+      end
+    end)
+  end
+
+  @spec normalize_coding(binary()) :: binary()
+  defp normalize_coding(coding), do: coding |> String.trim() |> String.downcase(:ascii)
+
+  # Per RFC9110§12.4.2. Malformed q values are leniently read as 1.0 rather than refusing the
+  # coding, since a client that bothered to list a coding presumably accepts it
+  @spec quality_value([binary()]) :: float()
+  defp quality_value(params) do
+    Enum.find_value(params, 1.0, fn param ->
+      case param |> String.trim() |> String.downcase(:ascii) |> String.split("=") do
+        ["q", value] ->
+          case Float.parse(value) do
+            {q, _rest} -> q
+            :error -> 1.0
+          end
+
+        _ ->
+          nil
+      end
+    end)
   end
 
   def new(adapter, status, headers, empty_body?, streamable \\ false) do

--- a/test/bandit/compression_test.exs
+++ b/test/bandit/compression_test.exs
@@ -1,0 +1,72 @@
+defmodule CompressionTest do
+  use ExUnit.Case, async: true
+
+  alias Bandit.Compression
+
+  describe "negotiate_content_encoding/2" do
+    # The default response_encodings list is platform dependent (zstd is included when the
+    # :zstd module is available), so tests which exercise the wildcard pin an explicit
+    # preference order to stay deterministic across OTP versions
+    @encodings ~w(gzip x-gzip deflate)
+
+    defp negotiate(accept_encoding, opts \\ []),
+      do: Compression.negotiate_content_encoding(accept_encoding, opts)
+
+    test "returns nil when no accept-encoding header is present" do
+      assert negotiate(nil) == nil
+    end
+
+    test "selects a plainly listed encoding in server preference order" do
+      assert negotiate("gzip, deflate") == "gzip"
+      assert negotiate("deflate, gzip") == "gzip"
+      assert negotiate("deflate") == "deflate"
+    end
+
+    test "compares codings case-insensitively (RFC9110§8.4.1)" do
+      assert negotiate("GZIP") == "gzip"
+      assert negotiate("Deflate") == "deflate"
+    end
+
+    test "honors q-values on listed encodings (any q>0 is acceptable)" do
+      assert negotiate("gzip;q=1.0") == "gzip"
+      assert negotiate("gzip;q=0.5") == "gzip"
+      assert negotiate("br;q=1.0, gzip;q=0.5") == "gzip"
+    end
+
+    test "treats q=0 as a refusal" do
+      assert negotiate("gzip;q=0, deflate") == "deflate"
+      assert negotiate("gzip;q=0") == nil
+      assert negotiate("gzip;q=0.0, deflate;q=0.000") |> is_nil()
+    end
+
+    test "honors the '*' wildcard" do
+      assert negotiate("*", response_encodings: @encodings) == "gzip"
+      assert negotiate("*;q=0, deflate", response_encodings: @encodings) == "deflate"
+      assert negotiate("*;q=0", response_encodings: @encodings) == nil
+    end
+
+    test "tolerates optional whitespace and mixed case around the q parameter" do
+      assert negotiate("gzip ; q=0.8") == "gzip"
+      assert negotiate("gzip; Q=0") |> is_nil()
+    end
+
+    test "reads malformed q values leniently as acceptance" do
+      assert negotiate("gzip;q=abc") == "gzip"
+      assert negotiate("gzip;q=") == "gzip"
+    end
+
+    test "does not compress when only identity is acceptable" do
+      assert negotiate("identity") == nil
+      assert negotiate("identity;q=1.0, *;q=0", response_encodings: @encodings) == nil
+      assert negotiate("identity;q=0, gzip") == "gzip"
+    end
+
+    test "returns nil when compression is disabled" do
+      assert negotiate("gzip", compress: false) == nil
+    end
+
+    test "respects a configured response_encodings preference order" do
+      assert negotiate("gzip, deflate", response_encodings: ["deflate", "gzip"]) == "deflate"
+    end
+  end
+end

--- a/test/bandit/http1/compression_negotiation_test.exs
+++ b/test/bandit/http1/compression_negotiation_test.exs
@@ -1,0 +1,45 @@
+defmodule HTTP1CompressionNegotiationTest do
+  use ExUnit.Case, async: true
+  use ServerHelpers
+
+  setup :http_server
+
+  def hello(conn), do: send_resp(conn, 200, String.duplicate("a", 10_000))
+
+  defp get_with_accept_encoding(context, accept_encoding) do
+    client = SimpleHTTP1Client.tcp_client(context)
+
+    SimpleHTTP1Client.send(client, "GET", "/hello", [
+      "host: localhost",
+      "accept-encoding: #{accept_encoding}"
+    ])
+
+    {:ok, "200 OK", headers, body} = SimpleHTTP1Client.recv_reply(client)
+    {Keyword.get(headers, :"content-encoding"), body}
+  end
+
+  test "compresses for a q-valued accept-encoding (Ruby net/http style)", context do
+    {encoding, body} =
+      get_with_accept_encoding(context, "gzip;q=1.0,deflate;q=0.6,identity;q=0.3")
+
+    assert encoding == "gzip"
+    assert :zlib.gunzip(body) == String.duplicate("a", 10_000)
+  end
+
+  test "compresses for an uppercase coding", context do
+    {encoding, _body} = get_with_accept_encoding(context, "GZIP")
+    assert encoding == "gzip"
+  end
+
+  test "honors a q=0 refusal end to end", context do
+    {encoding, body} = get_with_accept_encoding(context, "gzip;q=0, x-gzip;q=0, deflate;q=0")
+    assert encoding == nil
+    assert body == String.duplicate("a", 10_000)
+  end
+
+  test "plain accept-encoding lists behave exactly as before", context do
+    {encoding, body} = get_with_accept_encoding(context, "gzip, deflate")
+    assert encoding == "gzip"
+    assert :zlib.gunzip(body) == String.duplicate("a", 10_000)
+  end
+end


### PR DESCRIPTION
Hi @mtrudel 

Thanks again for creating great software. Here's a new PR.

Note: I had Claude assist with ~50 lines of code, ~100 lines of incremental tests, and the write-up below.

## What this fixes

Response compression negotiation currently matches the client's `Accept-Encoding` tokens with a plain string membership test over the comma-split header. Tokens are compared whole and case-sensitively, so any parameterized or non-lowercase token fails to match anything. The four broken cases below (and the two already-correct anchor rows) were all verified against unmodified main:

| Accept-Encoding sent by client | today | with this PR |
|---|---|---|
| `gzip, deflate` | gzip | gzip |
| `gzip;q=1.0` | no compression | gzip |
| `br;q=1.0, gzip;q=0.5` | no compression | gzip |
| `*` | no compression | first server preference |
| `GZIP` | no compression | gzip |
| `gzip;q=0, deflate` | deflate | deflate |

The fix parses `Accept-Encoding` per RFC 9110 section 12.5.3: q-values are honored (a coding with `q=0` is a refusal), the `*` wildcard admits codings the client did not list, and codings compare case-insensitively per section 8.4.1. Selection stays in the server's own preference order, which is the same policy as today and a valid one (the server chooses among the codings the client finds acceptable).

## Why this is a value add

Real clients send q-values. The most prominent example is Ruby's standard library: `Net::HTTP` sends `Accept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3` on every request by default, which means every stock Ruby client talking to a Bandit service silently receives uncompressed responses today. Any client using q-values to express preferences among brotli, zstd, and gzip hits the same behavior, and it is invisible when it happens: nothing errors, responses are simply larger than they need to be. Given how much care Bandit's compression stack already puts into doing the right thing (zstd support, preference ordering, vary handling, etag and no-transform awareness), the negotiation step deserves to speak full RFC 9110 as well; this PR is the missing 40 lines of that story.

## Standards and protocol basis

RFC 9110 section 12.5.3 (Accept-Encoding: q-values, the `*` wildcard, and the identity coding), section 12.4.2 (quality values), and section 8.4.1 (content codings compare case-insensitively). Malformed q-values are read leniently as acceptance, on the reasoning that a client which bothered to list a coding presumably accepts it; `identity` yields no compression exactly as before, since it never appears in the server's encoding list.

## Why this approach is pragmatic

The change is confined to `negotiate_content_encoding/2` in `Bandit.Compression` plus two small private helpers; no other module is touched and the negotiation call sites are unchanged. The parse builds on `Plug.Conn.Utils.list/1` exactly as the current code does, then splits each element on `;` and reads a q parameter if one exists. For the common browser header (`gzip, deflate, br, zstd`, no parameters) the added work over today's code is a single-element split and a downcase per token, a handful of small allocations on a path that already allocates the token list. Server preference order is preserved as the selection policy rather than sorting by client q-value, deliberately: it keeps behavior identical for every header that works today and keeps the diff small; a q-value-ordered policy would be a separate conversation.

One test-design point worth flagging for review: the default `response_encodings` list is platform-dependent (zstd joins it when OTP 28's `:zstd` module is present), so the wildcard tests pin an explicit preference order rather than asserting against the default. Without that, `negotiate("*") == "gzip"` passes on OTP 27 and fails on OTP 28, where the wildcard correctly admits zstd first; Bandit's CI matrix covers both.

## Performance

One parse of a short header per request carrying `Accept-Encoding`, in place of the existing membership scan over the same comma-split list. No change when the header is absent or when `compress: false`. Response paths are untouched.

## Size

Library code: 46 added lines including comments in `lib/bandit/compression.ex` (the parser is about 30 lines of code). Tests: 117 lines across two files.

## Regression testing

Fifteen tests. Unit coverage in `test/bandit/compression_test.exs` (11 tests): plain lists select in server preference order exactly as before; case-insensitive matching; q-values on listed codings; `q=0` refusals including `0.0` and `0.000` forms; the wildcard, wildcard refusal, and wildcard with explicit refusals; whitespace and case tolerance around the q parameter; lenient handling of malformed q-values; identity handling including `identity;q=0, gzip`; `compress: false`; and a configured `response_encodings` order.

End-to-end coverage in `test/bandit/http1/compression_negotiation_test.exs` (4 tests): a Ruby `Net::HTTP` style header produces a gzip response that gunzips back to the original body; an uppercase coding compresses; a full `q=0` refusal produces an uncompressed response end to end; and a plain browser-style list behaves byte-for-byte as before (the no-regression anchor).
