### PR TITLE
fix: detect stale connections after request body reads

### DIFF
--- a/lib/bandit/adapter.ex
+++ b/lib/bandit/adapter.ex
@@ -8,9 +8,11 @@ defmodule Bandit.Adapter do
 
   @behaviour Plug.Conn.Adapter
   @already_sent {:plug_conn, :sent}
+  @owner_ref_key {__MODULE__, :owner_ref}
 
   defstruct transport: nil,
             owner_pid: nil,
+            owner_ref: nil,
             method: nil,
             status: nil,
             content_encoding: nil,
@@ -24,6 +26,7 @@ defmodule Bandit.Adapter do
   @type t :: %__MODULE__{
           transport: Bandit.HTTPTransport.t(),
           owner_pid: pid() | nil,
+          owner_ref: reference() | nil,
           method: Plug.Conn.method() | nil,
           status: Plug.Conn.status() | nil,
           content_encoding: String.t(),
@@ -38,6 +41,9 @@ defmodule Bandit.Adapter do
         }
 
   def init(owner_pid, transport, method, headers, opts) do
+    owner_ref = make_ref()
+    Process.put(@owner_ref_key, owner_ref)
+
     content_encoding =
       Bandit.Compression.negotiate_content_encoding(
         Bandit.Headers.get_header(headers, "accept-encoding"),
@@ -47,6 +53,7 @@ defmodule Bandit.Adapter do
     %__MODULE__{
       transport: transport,
       owner_pid: owner_pid,
+      owner_ref: owner_ref,
       method: method,
       content_encoding: content_encoding,
       expect_continue: expect_continue?(headers, Bandit.HTTPTransport.version(transport)),
@@ -82,7 +89,8 @@ defmodule Bandit.Adapter do
           |> Map.update(:req_body_bytes, byte_size(body), &(&1 + byte_size(body)))
           |> Map.put(:req_body_end_time, Bandit.Telemetry.monotonic_time())
 
-        {:ok, body, %{adapter | transport: transport, metrics: metrics}}
+        adapter = rebind(%{adapter | transport: transport, metrics: metrics})
+        {:ok, body, adapter}
 
       {:more, body, transport} ->
         body = IO.iodata_to_binary(body)
@@ -91,7 +99,8 @@ defmodule Bandit.Adapter do
           metrics
           |> Map.update(:req_body_bytes, byte_size(body), &(&1 + byte_size(body)))
 
-        {:more, body, %{adapter | transport: transport, metrics: metrics}}
+        adapter = rebind(%{adapter | transport: transport, metrics: metrics})
+        {:more, body, adapter}
     end
   end
 
@@ -329,6 +338,18 @@ defmodule Bandit.Adapter do
   def get_http_protocol(%__MODULE__{} = adapter),
     do: Bandit.HTTPTransport.version(adapter.transport)
 
-  defp validate_calling_process!(%{owner_pid: owner}) when owner == self(), do: :ok
+  defp rebind(adapter) do
+    owner_ref = make_ref()
+    Process.put(@owner_ref_key, owner_ref)
+    %{adapter | owner_ref: owner_ref}
+  end
+
+  defp validate_calling_process!(%{owner_pid: owner, owner_ref: owner_ref})
+       when owner == self() do
+    if Process.get(@owner_ref_key) == owner_ref,
+      do: :ok,
+      else: raise("Adapter is not bound to the current request")
+  end
+
   defp validate_calling_process!(_), do: raise("Adapter functions must be called by stream owner")
 end

--- a/test/bandit/http1/protocol_test.exs
+++ b/test/bandit/http1/protocol_test.exs
@@ -750,6 +750,9 @@ defmodule HTTP1ProtocolTest do
       Transport.send(client, "CDE")
 
       assert {:ok, "200 OK", _, "ABC,D,E"} = SimpleHTTP1Client.recv_reply(client)
+
+      SimpleHTTP1Client.send(client, "GET", "/echo_method", ["host: localhost"])
+      assert {:ok, "200 OK", _, "GET"} = SimpleHTTP1Client.recv_reply(client)
     end
 
     def beyond_buffer_read(conn) do
@@ -757,6 +760,58 @@ defmodule HTTP1ProtocolTest do
       {:more, second, conn} = Plug.Conn.read_body(conn, length: 1)
       {:ok, third, conn} = Plug.Conn.read_body(conn)
       send_resp(conn, 200, "#{first},#{second},#{third}")
+    end
+
+    @tag :capture_log
+    test "rejects a stale conn after an incremental body read", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      Transport.send(
+        client,
+        "POST /respond_with_stale_conn HTTP/1.1\r\nhost: localhost\r\ncontent-length: 5\r\n\r\nAB"
+      )
+
+      Process.sleep(10)
+
+      Transport.send(
+        client,
+        "CDEGET /echo_method HTTP/1.1\r\nhost: localhost\r\n\r\n"
+      )
+
+      assert {:ok, "500 Internal Server Error", headers, ""} =
+               SimpleHTTP1Client.recv_reply(client)
+
+      assert Bandit.Headers.get_header(headers, :connection) == "close"
+      assert SimpleHTTP1Client.connection_closed_for_reading?(client)
+
+      assert_receive {:log, %{level: :error, msg: {:string, msg}}}, 500
+      assert msg =~ "** (RuntimeError) Adapter is not bound to the current request"
+    end
+
+    def respond_with_stale_conn(conn) do
+      {:more, "ABC", _conn} = Plug.Conn.read_body(conn, length: 3)
+      send_resp(conn, 200, "should not be sent")
+    end
+
+    @tag :capture_log
+    test "rejects an earlier conn for another body read", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      Transport.send(
+        client,
+        "POST /read_body_with_stale_conn HTTP/1.1\r\nhost: localhost\r\ncontent-length: 2\r\n\r\nAB"
+      )
+
+      assert {:ok, "500 Internal Server Error", _, ""} = SimpleHTTP1Client.recv_reply(client)
+      assert SimpleHTTP1Client.connection_closed_for_reading?(client)
+
+      assert_receive {:log, %{level: :error, msg: {:string, msg}}}, 500
+      assert msg =~ "** (RuntimeError) Adapter is not bound to the current request"
+    end
+
+    def read_body_with_stale_conn(conn) do
+      {:more, "A", _conn} = Plug.Conn.read_body(conn, length: 1)
+      Plug.Conn.read_body(conn)
     end
 
     test "handles the case where we read from the network in smaller chunks than we return",


### PR DESCRIPTION
Plug requires callers to continue with the `Plug.Conn` returned by `read_body/2`, but an application can mistakenly discard it and later respond with the original connection. Bandit currently accepts that stale adapter state even though the body read has already consumed bytes from the socket, so `ensure_completed/1` drains the body again and can consume the beginning of the next keep-alive request. Issue #649 provides a deterministic content-length reproduction that forces incremental socket reads and demonstrates the next request being parsed from corrupted data. Bandit should turn this misuse into an immediate, visible failure without relying on OS-specific socket byte counters.

## Summary

Extend `Bandit.Adapter`'s existing owner-process validation with a per-request binding token kept both in the adapter and in the owning process dictionary. Initialize the token when the adapter is built, and after every successful `read_req_body/2` call rotate it while returning the new token only in the updated adapter, so any discarded pre-read connection becomes observably stale. Have the existing adapter-operation validation reject a token that is no longer current before a stale connection can send a response or trigger body draining; this keeps the invariant shared by HTTP/1 and HTTP/2 while adding no transport-specific or OS-dependent accounting.

## Testing

A plug retains the connection returned from `read_body/2`, sends its response normally, and the keep-alive connection remains usable for the next well-formed request.
A plug reads an incrementally delivered content-length body but calls `send_resp/3` with the pre-read connection; Bandit raises and logs an explicit stale/unbound-connection error rather than silently completing the request with stale transport state.
After stale-connection misuse, the server closes the HTTP/1 connection, so a pipelined or subsequently sent request is never parsed from bytes incorrectly drained by `ensure_completed/1`.
Reusing an earlier connection for another body read is rejected by the same binding validation, while consecutive reads that thread each returned connection continue to work.

Fixes #649
