### PR TITLE
Consolidate Plug.Conn.Adapter calling-process tests into adapter_test.exs

### DIFF
--- a/test/bandit/adapter_test.exs
+++ b/test/bandit/adapter_test.exs
@@ -1,0 +1,156 @@
+defmodule Bandit.AdapterTest do
+  use ExUnit.Case, async: true
+  use ServerHelpers
+  use ReqHelpers
+
+  # Bandit.Adapter implements Plug.Conn.Adapter once, shared verbatim by both the HTTP/1 and
+  # HTTP/2 stacks - its behaviour doesn't vary by protocol, so it's tested here against a single
+  # (HTTP/1) server rather than duplicated per protocol.
+
+  setup :http_server
+  setup :req_http1_client
+
+  describe "calling process validation" do
+    test "raises if read_body is called from a process other than the stream owner", context do
+      response = Req.post!(context.req, url: "/other_process_body_read", body: "OK")
+
+      assert response.status == 200
+    end
+
+    def other_process_body_read(conn) do
+      {:ok, "OK", conn} = read_body(conn)
+
+      error =
+        Task.async(fn ->
+          try do
+            read_body(conn)
+          rescue
+            error -> error
+          end
+        end)
+        |> Task.await()
+
+      assert error == %RuntimeError{message: "Adapter functions must be called by stream owner"}
+
+      send_resp(conn, 200, "OK")
+    end
+
+    @tag :capture_log
+    test "raises if send_resp is called from a process other than the stream owner", context do
+      response = Req.get!(context.req, url: "/other_process_send_resp")
+
+      assert response.status == 200
+    end
+
+    def other_process_send_resp(conn) do
+      error =
+        Task.async(fn ->
+          try do
+            send_resp(conn, 200, "NOT OK")
+          rescue
+            error -> error
+          end
+        end)
+        |> Task.await()
+
+      assert error == %RuntimeError{message: "Adapter functions must be called by stream owner"}
+
+      send_resp(conn, 200, "OK")
+    end
+
+    @tag :capture_log
+    test "raises if send_chunked is called from a process other than the stream owner", context do
+      response = Req.get!(context.req, url: "/other_process_send_chunked")
+
+      assert response.status == 200
+    end
+
+    def other_process_send_chunked(conn) do
+      error =
+        Task.async(fn ->
+          try do
+            send_chunked(conn, 200)
+          rescue
+            error -> error
+          end
+        end)
+        |> Task.await()
+
+      assert error == %RuntimeError{message: "Adapter functions must be called by stream owner"}
+
+      send_resp(conn, 200, "OK")
+    end
+
+    @tag :capture_log
+    test "raises if chunk is called from a process other than the stream owner", context do
+      response = Req.get!(context.req, url: "/other_process_chunk")
+
+      assert response.status == 200
+    end
+
+    def other_process_chunk(conn) do
+      conn = send_chunked(conn, 200)
+
+      error =
+        Task.async(fn ->
+          try do
+            chunk(conn, "NOT OK")
+          rescue
+            error -> error
+          end
+        end)
+        |> Task.await()
+
+      assert error == %RuntimeError{message: "Adapter functions must be called by stream owner"}
+
+      {:ok, conn} = chunk(conn, "OK")
+      conn
+    end
+
+    @tag :capture_log
+    test "raises if send_file is called from a process other than the stream owner", context do
+      response = Req.get!(context.req, url: "/other_process_send_file")
+
+      assert response.status == 200
+    end
+
+    def other_process_send_file(conn) do
+      error =
+        Task.async(fn ->
+          try do
+            send_file(conn, 200, Path.join([__DIR__, "../support/sendfile"]), 0, :all)
+          rescue
+            error -> error
+          end
+        end)
+        |> Task.await()
+
+      assert error == %RuntimeError{message: "Adapter functions must be called by stream owner"}
+
+      send_resp(conn, 200, "OK")
+    end
+
+    @tag :capture_log
+    test "raises if inform is called from a process other than the stream owner", context do
+      response = Req.get!(context.req, url: "/other_process_inform")
+
+      assert response.status == 200
+    end
+
+    def other_process_inform(conn) do
+      error =
+        Task.async(fn ->
+          try do
+            inform(conn, 100, [])
+          rescue
+            error -> error
+          end
+        end)
+        |> Task.await()
+
+      assert error == %RuntimeError{message: "Adapter functions must be called by stream owner"}
+
+      send_resp(conn, 200, "OK")
+    end
+  end
+end

--- a/test/bandit/http1/plug_test.exs
+++ b/test/bandit/http1/plug_test.exs
@@ -556,30 +556,6 @@ defmodule HTTP1PlugTest do
   end
 
   describe "adapter callback edge cases" do
-    test "raises if an adapter function is called from a process other than the stream owner",
-         context do
-      response = Req.get!(context.req, url: "/call_from_other_process")
-
-      assert response.status == 200
-      assert response.body =~ "Adapter functions must be called by stream owner"
-    end
-
-    def call_from_other_process(conn) do
-      result =
-        fn ->
-          try do
-            send_resp(conn, 200, "should not happen")
-            :sent
-          rescue
-            e -> {:error, Exception.message(e)}
-          end
-        end
-        |> Task.async()
-        |> Task.await()
-
-      send_resp(conn, 200, inspect(result))
-    end
-
     test "push is not supported", context do
       response = Req.get!(context.req, url: "/push_response")
 

--- a/test/bandit/http2/plug_test.exs
+++ b/test/bandit/http2/plug_test.exs
@@ -132,31 +132,6 @@ defmodule HTTP2PlugTest do
     conn |> send_resp(200, body)
   end
 
-  @tag :capture_log
-  test "reading request body from another process works as expected", context do
-    response = Req.post!(context.req, url: "/other_process_body_read", body: "OK")
-
-    assert response.status == 200
-  end
-
-  def other_process_body_read(conn) do
-    {:ok, "OK", conn} = read_body(conn)
-
-    error =
-      Task.async(fn ->
-        try do
-          read_body(conn)
-        rescue
-          error -> error
-        end
-      end)
-      |> Task.await()
-
-    assert error == %RuntimeError{message: "Adapter functions must be called by stream owner"}
-
-    send_resp(conn, 200, "OK")
-  end
-
   test "reading request body respects length option", context do
     socket = SimpleH2Client.setup_connection(context)
 
@@ -360,29 +335,6 @@ defmodule HTTP2PlugTest do
     conn |> resp(200, "OK")
   end
 
-  @tag :capture_log
-  test "sending a body from another process works as expected", context do
-    response = Req.get!(context.req, url: "/other_process_send_body")
-
-    assert response.status == 200
-  end
-
-  def other_process_send_body(conn) do
-    error =
-      Task.async(fn ->
-        try do
-          send_resp(conn, 200, "NOT OK")
-        rescue
-          error -> error
-        end
-      end)
-      |> Task.await()
-
-    assert error == %RuntimeError{message: "Adapter functions must be called by stream owner"}
-
-    send_resp(conn, 200, "OK")
-  end
-
   test "sending a chunk", context do
     response = Req.get!(context.req, url: "/chunk_test")
 
@@ -397,55 +349,6 @@ defmodule HTTP2PlugTest do
     |> elem(1)
     |> chunk("OK")
     |> elem(1)
-  end
-
-  @tag :capture_log
-  test "setting a chunked response from another process works as expected", context do
-    response = Req.get!(context.req, url: "/other_process_set_chunk")
-
-    assert response.status == 200
-  end
-
-  def other_process_set_chunk(conn) do
-    error =
-      Task.async(fn ->
-        try do
-          send_chunked(conn, 200)
-        rescue
-          error -> error
-        end
-      end)
-      |> Task.await()
-
-    assert error == %RuntimeError{message: "Adapter functions must be called by stream owner"}
-
-    send_resp(conn, 200, "OK")
-  end
-
-  @tag :capture_log
-  test "sending a chunk from another process works as expected", context do
-    response = Req.get!(context.req, url: "/other_process_send_chunk")
-
-    assert response.status == 200
-  end
-
-  def other_process_send_chunk(conn) do
-    conn = conn |> send_chunked(200)
-
-    error =
-      Task.async(fn ->
-        try do
-          chunk(conn, "NOT OK")
-        rescue
-          error -> error
-        end
-      end)
-      |> Task.await()
-
-    assert error == %RuntimeError{message: "Adapter functions must be called by stream owner"}
-
-    {:ok, conn} = chunk(conn, "OK")
-    conn
   end
 
   describe "send_file" do
@@ -578,29 +481,6 @@ defmodule HTTP2PlugTest do
       {:ok, 1, end_stream, chunk} = SimpleH2Client.recv_body(socket)
       chunks = chunks ++ [chunk]
       if end_stream, do: chunks, else: recv_body_chunks(socket, chunks)
-    end
-
-    @tag :capture_log
-    test "sending a file from another process works as expected", context do
-      response = Req.get!(context.req, url: "/other_process_send_file")
-
-      assert response.status == 200
-    end
-
-    def other_process_send_file(conn) do
-      error =
-        Task.async(fn ->
-          try do
-            send_file(conn, 200, Path.join([__DIR__, "../../support/sendfile"]), 0, :all)
-          rescue
-            error -> error
-          end
-        end)
-        |> Task.await()
-
-      assert error == %RuntimeError{message: "Adapter functions must be called by stream owner"}
-
-      send_resp(conn, 200, "OK")
     end
   end
 
@@ -839,29 +719,6 @@ defmodule HTTP2PlugTest do
   def send_inform(conn) do
     conn = conn |> inform(100, [{:"x-from", "inform"}])
     conn |> send_resp(200, "Informer")
-  end
-
-  @tag :capture_log
-  test "sending an inform response from another process works as expected", context do
-    response = Req.get!(context.req, url: "/other_process_send_inform")
-
-    assert response.status == 200
-  end
-
-  def other_process_send_inform(conn) do
-    error =
-      Task.async(fn ->
-        try do
-          inform(conn, 100, [])
-        rescue
-          error -> error
-        end
-      end)
-      |> Task.await()
-
-    assert error == %RuntimeError{message: "Adapter functions must be called by stream owner"}
-
-    send_resp(conn, 200, "OK")
   end
 
   test "reading HTTP version", context do


### PR DESCRIPTION
## Summary

* `Bandit.Adapter` implements `Plug.Conn.Adapter` once, shared verbatim by both the HTTP/1 and
  HTTP/2 stacks - its "must be called by stream owner" check doesn't vary by protocol, but its
  test coverage was split unevenly across `test/bandit/http1/plug_test.exs` (`send_resp` only)
  and `test/bandit/http2/plug_test.exs` (`read_body`, `send_resp`, `send_chunked`, `chunk`,
  `send_file`, `inform`).
* Moves all of it into a single `test/bandit/adapter_test.exs`, run against one representative
  (HTTP/1) server, with matching coverage for every relevant `Plug.Conn.Adapter` callback.
* Pure test reorganization - no `lib/` changes.

This is split out from a separate PR that adds stale-conn detection to `Bandit.Adapter`
(https://github.com/mtrudel/bandit/pull/649-fix, opened separately) since that PR also needs to
touch `test/bandit/adapter_test.exs`; keeping this as its own PR avoids conflating the two.
Whichever of the two merges second will need a small rebase to combine the two `describe` blocks
in that file.

## Test plan

- [x] `mix test` (789 tests, 0 failures)
- [x] `mix format --check-formatted`
- [x] `mix credo --strict`