### PR TITLE
Guard against stale conn reuse in Bandit.Adapter

### DIFF
--- a/lib/bandit/adapter.ex
+++ b/lib/bandit/adapter.ex
@@ -11,6 +11,7 @@ defmodule Bandit.Adapter do
 
   defstruct transport: nil,
             owner_pid: nil,
+            usage_counter: nil,
             method: nil,
             status: nil,
             content_encoding: nil,
@@ -24,6 +25,7 @@ defmodule Bandit.Adapter do
   @type t :: %__MODULE__{
           transport: Bandit.HTTPTransport.t(),
           owner_pid: pid() | nil,
+          usage_counter: {:counters.counters_ref(), non_neg_integer()},
           method: Plug.Conn.method() | nil,
           status: Plug.Conn.status() | nil,
           content_encoding: String.t(),
@@ -51,7 +53,8 @@ defmodule Bandit.Adapter do
       content_encoding: content_encoding,
       expect_continue: expect_continue?(headers, Bandit.HTTPTransport.version(transport)),
       metrics: %{req_header_end_time: Bandit.Telemetry.monotonic_time()},
-      opts: opts
+      opts: opts,
+      usage_counter: {:counters.new(1, []), 0}
     }
   end
 
@@ -67,6 +70,7 @@ defmodule Bandit.Adapter do
   @impl Plug.Conn.Adapter
   def read_req_body(%__MODULE__{} = adapter, opts) do
     validate_calling_process!(adapter)
+    validate_usage_counter!(adapter)
     adapter = maybe_send_continue(adapter)
 
     metrics =
@@ -82,7 +86,8 @@ defmodule Bandit.Adapter do
           |> Map.update(:req_body_bytes, byte_size(body), &(&1 + byte_size(body)))
           |> Map.put(:req_body_end_time, Bandit.Telemetry.monotonic_time())
 
-        {:ok, body, %{adapter | transport: transport, metrics: metrics}}
+        {:ok, body,
+         %{adapter | transport: transport, metrics: metrics} |> advance_usage_counter()}
 
       {:more, body, transport} ->
         body = IO.iodata_to_binary(body)
@@ -91,7 +96,8 @@ defmodule Bandit.Adapter do
           metrics
           |> Map.update(:req_body_bytes, byte_size(body), &(&1 + byte_size(body)))
 
-        {:more, body, %{adapter | transport: transport, metrics: metrics}}
+        {:more, body,
+         %{adapter | transport: transport, metrics: metrics} |> advance_usage_counter()}
     end
   end
 
@@ -112,6 +118,7 @@ defmodule Bandit.Adapter do
   @impl Plug.Conn.Adapter
   def send_resp(%__MODULE__{} = adapter, status, headers, body) do
     validate_calling_process!(adapter)
+    validate_usage_counter!(adapter)
     start_time = Bandit.Telemetry.monotonic_time()
 
     # Save an extra iodata_length by checking common cases
@@ -136,6 +143,7 @@ defmodule Bandit.Adapter do
       %{adapter | metrics: metrics}
       |> send_headers(status, headers, :raw)
       |> send_data(encoded_body, true)
+      |> advance_usage_counter()
 
     send(adapter.owner_pid, @already_sent)
     {:ok, nil, adapter}
@@ -154,6 +162,7 @@ defmodule Bandit.Adapter do
     if is_number(length) && length <= 0, do: raise("Length cannot be zero or negative")
 
     validate_calling_process!(adapter)
+    validate_usage_counter!(adapter)
     start_time = Bandit.Telemetry.monotonic_time()
     {:ok, fileinfo} = :file.read_file_info(path, [:raw, time: :universal])
     %File.Stat{type: :regular, size: size} = File.Stat.from_record(fileinfo)
@@ -175,7 +184,7 @@ defmodule Bandit.Adapter do
         |> Map.put(:resp_end_time, Bandit.Telemetry.monotonic_time())
 
       send(adapter.owner_pid, @already_sent)
-      {:ok, nil, %{adapter | transport: socket, metrics: metrics}}
+      {:ok, nil, %{adapter | transport: socket, metrics: metrics} |> advance_usage_counter()}
     else
       raise "Cannot read #{length} bytes starting at #{offset} as #{path} is only #{size} octets in length"
     end
@@ -184,6 +193,7 @@ defmodule Bandit.Adapter do
   @impl Plug.Conn.Adapter
   def send_chunked(%__MODULE__{} = adapter, status, headers) do
     validate_calling_process!(adapter)
+    validate_usage_counter!(adapter)
     start_time = Bandit.Telemetry.monotonic_time()
     metrics = Map.put(adapter.metrics, :resp_start_time, start_time)
 
@@ -204,7 +214,9 @@ defmodule Bandit.Adapter do
 
     adapter = %{adapter | metrics: metrics, compression_context: compression_context}
     send(adapter.owner_pid, @already_sent)
-    {:ok, nil, send_headers(adapter, status, headers, :chunk_encoded)}
+
+    {:ok, nil,
+     adapter |> send_headers(status, headers, :chunk_encoded) |> advance_usage_counter()}
   end
 
   @impl Plug.Conn.Adapter
@@ -216,9 +228,13 @@ defmodule Bandit.Adapter do
     # this entire section of the API is a bit slanty regardless.
 
     validate_calling_process!(adapter)
+    validate_usage_counter!(adapter)
 
     # chunk/2 is unique among Plug.Conn.Adapter's sending callbacks in that it can return an error
-    # tuple instead of just raising or dying on error. Rescue here to implement this
+    # tuple instead of just raising or dying on error. Rescue here to implement this. On that
+    # error path no new adapter is returned, so advance_usage_counter/1 is deliberately not
+    # called - Plug's documented behaviour there is for the caller to keep using its
+    # already-current conn
     try do
       if Bandit.SocketHelpers.iodata_empty?(chunk) do
         {encoded_chunk, compression_metrics} =
@@ -233,13 +249,13 @@ defmodule Bandit.Adapter do
             adapter
           end
 
-        {:ok, nil, send_data(adapter, "", true)}
+        {:ok, nil, adapter |> send_data("", true) |> advance_usage_counter()}
       else
         {encoded_chunk, compression_context} =
           Bandit.Compression.compress_chunk(chunk, adapter.compression_context)
 
         adapter = %{adapter | compression_context: compression_context}
-        {:ok, nil, send_data(adapter, encoded_chunk, false)}
+        {:ok, nil, adapter |> send_data(encoded_chunk, false) |> advance_usage_counter()}
       end
     rescue
       error in Bandit.TransportError -> {:error, error.error}
@@ -250,6 +266,7 @@ defmodule Bandit.Adapter do
   @impl Plug.Conn.Adapter
   def inform(%__MODULE__{} = adapter, status, headers) do
     validate_calling_process!(adapter)
+    validate_usage_counter!(adapter)
     # It's a bit weird to be casing on the underlying version here, but whether or not to send
     # an informational response is actually defined in RFC9110§15.2 so we consider it as an aspect
     # of semantics that belongs here and not in the underlying transport
@@ -258,7 +275,7 @@ defmodule Bandit.Adapter do
     else
       # inform/3 is unique in that headers comes in as a keyword list
       headers = Enum.map(headers, fn {header, value} -> {to_string(header), value} end)
-      {:ok, send_headers(adapter, status, headers, :inform)}
+      {:ok, adapter |> send_headers(status, headers, :inform) |> advance_usage_counter()}
     end
   end
 
@@ -304,9 +321,14 @@ defmodule Bandit.Adapter do
 
   @impl Plug.Conn.Adapter
   def upgrade(%__MODULE__{} = adapter, protocol, opts) do
+    validate_usage_counter!(adapter)
+
     if Keyword.get(adapter.opts.websocket, :enabled, true) &&
          Bandit.HTTPTransport.supported_upgrade?(adapter.transport, protocol),
-       do: {:ok, %{adapter | upgrade: {protocol, opts, adapter.opts.websocket}}},
+       do:
+         {:ok,
+          %{adapter | upgrade: {protocol, opts, adapter.opts.websocket}}
+          |> advance_usage_counter()},
        else: {:error, :not_supported}
   end
 
@@ -331,4 +353,42 @@ defmodule Bandit.Adapter do
 
   defp validate_calling_process!(%{owner_pid: owner}) when owner == self(), do: :ok
   defp validate_calling_process!(_), do: raise("Adapter functions must be called by stream owner")
+
+  # Every Plug.Conn.Adapter callback that returns an updated conn bumps the shared side of
+  # usage_counter and stamps the returned adapter's local side to match. If a later call comes
+  # in with an adapter whose local count is behind the shared count's current value, some other
+  # (newer) copy of the conn already advanced the connection - which can only happen if this
+  # adapter is a stale conn that should have been discarded. Using the conn at that point would
+  # otherwise let Bandit silently misinterpret leftover socket state (e.g. treating unread
+  # request body as already consumed, or vice versa), corrupting this request or the next one on
+  # the connection.
+  #
+  # validate_usage_counter! is called unconditionally at the top of every callback, since a
+  # stale conn is a bug no matter what the call ends up doing. advance_usage_counter is called
+  # separately, only at the point a callback actually commits to returning a new adapter - some
+  # callbacks (inform/3, upgrade/3, chunk/2) have paths that report failure without producing a
+  # new conn, and Plug's documented behaviour in that case is for the caller to keep using the
+  # same (still current) conn.
+  defp validate_usage_counter!(%__MODULE__{usage_counter: {shared, local}}) do
+    case :counters.get(shared, 1) do
+      ^local ->
+        :ok
+
+      _stale ->
+        raise """
+        Stale conn passed to a Plug.Conn function.
+
+        This conn is not the one most recently returned by read_body/2, send_resp/3, or another \
+        Plug.Conn function that returns an updated conn. Every such function returns an updated \
+        conn that must be threaded through to the rest of your pipeline - discarding it and \
+        reusing an older conn will corrupt this connection, and potentially the next request on \
+        it if the connection is kept alive.
+        """
+    end
+  end
+
+  defp advance_usage_counter(%__MODULE__{usage_counter: {shared, local}} = adapter) do
+    :counters.add(shared, 1, 1)
+    %{adapter | usage_counter: {shared, local + 1}}
+  end
 end

--- a/test/bandit/adapter_test.exs
+++ b/test/bandit/adapter_test.exs
@@ -1,0 +1,215 @@
+defmodule Bandit.AdapterTest do
+  use ExUnit.Case, async: true
+  use ServerHelpers
+  use ReqHelpers
+
+  require Logger
+
+  # Bandit.Adapter implements Plug.Conn.Adapter once, shared verbatim by both the HTTP/1 and
+  # HTTP/2 stacks - its behaviour doesn't vary by protocol, so it's tested here against a single
+  # (HTTP/1) server rather than duplicated per protocol.
+
+  setup :http_server
+  setup :req_http1_client
+
+  # https://github.com/mtrudel/bandit/issues/649 - using a conn from before a mutating
+  # Plug.Conn.Adapter call (read_body, send_resp, send_chunked, chunk, send_file, inform,
+  # upgrade_adapter) instead of the one it returned used to silently corrupt state - most
+  # dangerously, the next request on the connection (ensure_completed would drain the wrong
+  # number of bytes off the wire, having been handed stale bookkeeping about how much of the
+  # body was actually already read). Every callback that returns a new conn should instead raise
+  # immediately, on this request, the moment it's handed a conn that isn't the most recently
+  # returned one.
+  describe "stale conn validation" do
+    @tag :capture_log
+    test "raises if a stale conn from before read_body is reused for read_body", context do
+      assert_stale_conn_raises(context, "/stale_before_read_body")
+    end
+
+    def stale_before_read_body(conn) do
+      {:ok, _body, _fresh_conn} = read_body(conn)
+      {:ok, _body, _conn} = read_body(conn)
+      send_resp(conn, 200, "unreachable")
+    end
+
+    @tag :capture_log
+    test "raises if a stale conn from before read_body is reused for send_resp", context do
+      assert_stale_conn_raises(context, "/stale_before_send_resp")
+    end
+
+    def stale_before_send_resp(conn) do
+      {:ok, _body, _fresh_conn} = read_body(conn)
+      send_resp(conn, 200, "unreachable")
+    end
+
+    @tag :capture_log
+    test "raises if a stale conn from before read_body is reused for send_chunked", context do
+      assert_stale_conn_raises(context, "/stale_before_send_chunked")
+    end
+
+    def stale_before_send_chunked(conn) do
+      {:ok, _body, _fresh_conn} = read_body(conn)
+      send_chunked(conn, 200)
+    end
+
+    @tag :capture_log
+    test "raises if a stale conn from before a chunk is reused for a later chunk", context do
+      # Plug.Conn.chunk/2 requires the conn to already be in :chunked state, so unlike the other
+      # stale-conn cases here, staleness has to be established between two live chunk/2 calls
+      # rather than via an unrelated read_body/2 call. By the time the second (stale) call
+      # raises, headers have already gone out, so Bandit can't retroactively send a fresh error
+      # status - it just tears the connection down instead, which the client observes as a
+      # malformed/incomplete response at a point that's a timing race, and so not worth pinning
+      # down exactly. Only the one deterministic, server-side signal is asserted on here.
+      _ = Req.get(context.req, url: "/stale_before_chunk")
+
+      assert_receive {:log, %{level: :error, msg: {:string, msg}}}, 500
+      assert msg =~ "Stale conn passed to a Plug.Conn function"
+    end
+
+    def stale_before_chunk(conn) do
+      conn = send_chunked(conn, 200)
+      {:ok, _fresher_conn} = chunk(conn, "first")
+      {:ok, _conn} = chunk(conn, "second")
+      conn
+    end
+
+    @tag :capture_log
+    test "raises if a stale conn from before read_body is reused for send_file", context do
+      assert_stale_conn_raises(context, "/stale_before_send_file")
+    end
+
+    def stale_before_send_file(conn) do
+      {:ok, _body, _fresh_conn} = read_body(conn)
+      send_file(conn, 200, Path.join([__DIR__, "../support/sendfile"]), 0, :all)
+    end
+
+    @tag :capture_log
+    test "raises if a stale conn from before read_body is reused for inform", context do
+      assert_stale_conn_raises(context, "/stale_before_inform")
+    end
+
+    def stale_before_inform(conn) do
+      {:ok, _body, _fresh_conn} = read_body(conn)
+      conn |> inform(100, []) |> send_resp(200, "unreachable")
+    end
+
+    @tag :capture_log
+    test "raises if a stale conn from before read_body is reused for upgrade", context do
+      assert_stale_conn_raises(context, "/stale_before_upgrade")
+    end
+
+    defmodule MyNoopWebSock do
+      use NoopWebSock
+    end
+
+    def stale_before_upgrade(conn) do
+      {:ok, _body, _fresh_conn} = read_body(conn)
+      upgrade_adapter(conn, :websocket, {MyNoopWebSock, [], []})
+    end
+
+    defp assert_stale_conn_raises(context, path) do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "POST", path, ["host: banana", "content-length: 2"])
+      Transport.send(client, "OK")
+
+      assert {:ok, "500 Internal Server Error", _headers, _} =
+               SimpleHTTP1Client.recv_reply(client)
+
+      assert_receive {:log, %{level: :error, msg: {:string, msg}}}, 500
+      assert msg =~ "Stale conn passed to a Plug.Conn function"
+
+      # The connection is closed rather than kept alive, so there's no "next request" for the
+      # stale conn's bad bookkeeping to corrupt
+      SimpleHTTP1Client.send(client, "GET", "/hello_world", ["host: banana"])
+      assert SimpleHTTP1Client.connection_closed_for_reading?(client)
+    end
+
+    def hello_world(conn) do
+      send_resp(conn, 200, "OK")
+    end
+  end
+
+  # A conn is only stale - and should only trip the check above - once some other, newer copy
+  # of it has actually advanced the connection. Some Plug.Conn.Adapter callbacks have paths that
+  # report failure without returning a new conn at all (Plug's documented behaviour in that case
+  # is for the caller to keep using its already-current conn), so those paths must not advance
+  # the connection either, or they'd make the caller's still-current conn look stale.
+  describe "usage counter is not advanced when no new conn is produced" do
+    test "inform does not advance the counter when declined for an HTTP/1.0 client", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+      SimpleHTTP1Client.send(client, "GET", "/decline_then_send_resp", ["host: banana"], "1.0")
+
+      assert {:ok, "200 OK", _headers, "OK"} = SimpleHTTP1Client.recv_reply(client)
+    end
+
+    def decline_then_send_resp(conn) do
+      # inform/3 reports {:error, :not_supported} for HTTP/1.0 clients without returning a new
+      # conn - Plug.Conn.inform/3 returns `conn` unchanged in that case, so this is exactly the
+      # same (still-current) conn send_resp is then called with
+      conn = inform(conn, 100, [{"x-from", "inform"}])
+      send_resp(conn, 200, "OK")
+    end
+
+    @tag :capture_log
+    test "upgrade does not advance the counter when unsupported", context do
+      context =
+        context
+        |> http_server(websocket_options: [enabled: false])
+        |> Enum.into(context)
+
+      response = Req.get!(context.req, url: "/upgrade_then_rescue", base_url: context.base)
+
+      assert response.status == 200
+      assert response.body == "OK"
+    end
+
+    defmodule MyOtherNoopWebSock do
+      use NoopWebSock
+    end
+
+    def upgrade_then_rescue(conn) do
+      # In actual use, it's the caller's responsibility to ensure the upgrade is valid before
+      # calling upgrade_adapter. On failure, Plug.Conn.upgrade_adapter/3 raises ArgumentError
+      # without returning a new conn, so the documented recovery is to keep using this (still
+      # current) conn - exactly what the rescue clause below does.
+      upgrade_adapter(conn, :websocket, {MyOtherNoopWebSock, [], []})
+    rescue
+      ArgumentError -> send_resp(conn, 200, "OK")
+    end
+
+    test "chunk does not advance the counter when the transport raises", context do
+      # Force a genuine Bandit.TransportError deterministically (rather than racing a client
+      # disconnect) by having the plug close its own underlying socket mid-response, then
+      # attempting to write to it twice. `Req.get/2` (not `Req.get!/2`) is used since the
+      # connection closing mid-response is expected to surface as a client-side error too - the
+      # only thing this test cares about is what the server logs
+      _ = Req.get(context.req, url: "/close_socket_then_chunk_twice")
+
+      assert_receive {:log, %{level: :info, msg: {:string, msg}}}, 500
+      assert msg == "both post-close chunk/2 calls failed without raising a stale-conn error"
+    end
+
+    def close_socket_then_chunk_twice(conn) do
+      conn = send_chunked(conn, 200)
+      {Bandit.Adapter, adapter} = conn.adapter
+      ThousandIsland.Socket.close(adapter.transport.socket)
+
+      # chunk/2 is unique among Plug.Conn.Adapter's sending callbacks in that it reports
+      # transport errors as an {:error, reason} return value rather than raising - Plug's
+      # Plug.Conn.chunk/2 does not return a new conn in that case, so the caller keeps using its
+      # already-current (here, still broken) conn. If chunk/2 had incorrectly advanced the usage
+      # counter on the first (failed) call, the second call would raise "Stale conn passed to a
+      # Plug.Conn function" instead of returning the same {:error, _} shape
+      {:error, _} = chunk(conn, "first")
+      {:error, _} = chunk(conn, "second")
+
+      Logger.info("both post-close chunk/2 calls failed without raising a stale-conn error",
+        plug: {__MODULE__, []}
+      )
+
+      conn
+    end
+  end
+end

--- a/test/bandit/adapter_test.exs
+++ b/test/bandit/adapter_test.exs
@@ -3,6 +3,8 @@ defmodule Bandit.AdapterTest do
   use ServerHelpers
   use ReqHelpers
 
+  require Logger
+
   # Bandit.Adapter implements Plug.Conn.Adapter once, shared verbatim by both the HTTP/1 and
   # HTTP/2 stacks - its behaviour doesn't vary by protocol, so it's tested here against a single
   # (HTTP/1) server rather than duplicated per protocol.
@@ -151,6 +153,207 @@ defmodule Bandit.AdapterTest do
       assert error == %RuntimeError{message: "Adapter functions must be called by stream owner"}
 
       send_resp(conn, 200, "OK")
+    end
+  end
+
+  # https://github.com/mtrudel/bandit/issues/649 - using a conn from before a mutating
+  # Plug.Conn.Adapter call (read_body, send_resp, send_chunked, chunk, send_file, inform,
+  # upgrade_adapter) instead of the one it returned used to silently corrupt state - most
+  # dangerously, the next request on the connection (ensure_completed would drain the wrong
+  # number of bytes off the wire, having been handed stale bookkeeping about how much of the
+  # body was actually already read). Every callback that returns a new conn should instead raise
+  # immediately, on this request, the moment it's handed a conn that isn't the most recently
+  # returned one.
+  describe "stale conn validation" do
+    @tag :capture_log
+    test "raises if a stale conn from before read_body is reused for read_body", context do
+      assert_stale_conn_raises(context, "/stale_before_read_body")
+    end
+
+    def stale_before_read_body(conn) do
+      {:ok, _body, _fresh_conn} = read_body(conn)
+      {:ok, _body, _conn} = read_body(conn)
+      send_resp(conn, 200, "unreachable")
+    end
+
+    @tag :capture_log
+    test "raises if a stale conn from before read_body is reused for send_resp", context do
+      assert_stale_conn_raises(context, "/stale_before_send_resp")
+    end
+
+    def stale_before_send_resp(conn) do
+      {:ok, _body, _fresh_conn} = read_body(conn)
+      send_resp(conn, 200, "unreachable")
+    end
+
+    @tag :capture_log
+    test "raises if a stale conn from before read_body is reused for send_chunked", context do
+      assert_stale_conn_raises(context, "/stale_before_send_chunked")
+    end
+
+    def stale_before_send_chunked(conn) do
+      {:ok, _body, _fresh_conn} = read_body(conn)
+      send_chunked(conn, 200)
+    end
+
+    @tag :capture_log
+    test "raises if a stale conn from before a chunk is reused for a later chunk", context do
+      # Plug.Conn.chunk/2 requires the conn to already be in :chunked state, so unlike the other
+      # stale-conn cases here, staleness has to be established between two live chunk/2 calls
+      # rather than via an unrelated read_body/2 call. By the time the second (stale) call
+      # raises, headers have already gone out, so Bandit can't retroactively send a fresh error
+      # status - it just tears the connection down instead, which the client observes as a
+      # malformed/incomplete response at a point that's a timing race, and so not worth pinning
+      # down exactly. Only the one deterministic, server-side signal is asserted on here.
+      _ = Req.get(context.req, url: "/stale_before_chunk")
+
+      assert_receive {:log, %{level: :error, msg: {:string, msg}}}, 500
+      assert msg =~ "Stale conn passed to a Plug.Conn function"
+    end
+
+    def stale_before_chunk(conn) do
+      conn = send_chunked(conn, 200)
+      {:ok, _fresher_conn} = chunk(conn, "first")
+      {:ok, _conn} = chunk(conn, "second")
+      conn
+    end
+
+    @tag :capture_log
+    test "raises if a stale conn from before read_body is reused for send_file", context do
+      assert_stale_conn_raises(context, "/stale_before_send_file")
+    end
+
+    def stale_before_send_file(conn) do
+      {:ok, _body, _fresh_conn} = read_body(conn)
+      send_file(conn, 200, Path.join([__DIR__, "../support/sendfile"]), 0, :all)
+    end
+
+    @tag :capture_log
+    test "raises if a stale conn from before read_body is reused for inform", context do
+      assert_stale_conn_raises(context, "/stale_before_inform")
+    end
+
+    def stale_before_inform(conn) do
+      {:ok, _body, _fresh_conn} = read_body(conn)
+      conn |> inform(100, []) |> send_resp(200, "unreachable")
+    end
+
+    @tag :capture_log
+    test "raises if a stale conn from before read_body is reused for upgrade", context do
+      assert_stale_conn_raises(context, "/stale_before_upgrade")
+    end
+
+    defmodule MyNoopWebSock do
+      use NoopWebSock
+    end
+
+    def stale_before_upgrade(conn) do
+      {:ok, _body, _fresh_conn} = read_body(conn)
+      upgrade_adapter(conn, :websocket, {MyNoopWebSock, [], []})
+    end
+
+    defp assert_stale_conn_raises(context, path) do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "POST", path, ["host: banana", "content-length: 2"])
+      Transport.send(client, "OK")
+
+      assert {:ok, "500 Internal Server Error", _headers, _} =
+               SimpleHTTP1Client.recv_reply(client)
+
+      assert_receive {:log, %{level: :error, msg: {:string, msg}}}, 500
+      assert msg =~ "Stale conn passed to a Plug.Conn function"
+
+      # The connection is closed rather than kept alive, so there's no "next request" for the
+      # stale conn's bad bookkeeping to corrupt
+      SimpleHTTP1Client.send(client, "GET", "/hello_world", ["host: banana"])
+      assert SimpleHTTP1Client.connection_closed_for_reading?(client)
+    end
+
+    def hello_world(conn) do
+      send_resp(conn, 200, "OK")
+    end
+  end
+
+  # A conn is only stale - and should only trip the check above - once some other, newer copy
+  # of it has actually advanced the connection. Some Plug.Conn.Adapter callbacks have paths that
+  # report failure without returning a new conn at all (Plug's documented behaviour in that case
+  # is for the caller to keep using its already-current conn), so those paths must not advance
+  # the connection either, or they'd make the caller's still-current conn look stale.
+  describe "usage counter is not advanced when no new conn is produced" do
+    test "inform does not advance the counter when declined for an HTTP/1.0 client", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+      SimpleHTTP1Client.send(client, "GET", "/decline_then_send_resp", ["host: banana"], "1.0")
+
+      assert {:ok, "200 OK", _headers, "OK"} = SimpleHTTP1Client.recv_reply(client)
+    end
+
+    def decline_then_send_resp(conn) do
+      # inform/3 reports {:error, :not_supported} for HTTP/1.0 clients without returning a new
+      # conn - Plug.Conn.inform/3 returns `conn` unchanged in that case, so this is exactly the
+      # same (still-current) conn send_resp is then called with
+      conn = inform(conn, 100, [{"x-from", "inform"}])
+      send_resp(conn, 200, "OK")
+    end
+
+    @tag :capture_log
+    test "upgrade does not advance the counter when unsupported", context do
+      context =
+        context
+        |> http_server(websocket_options: [enabled: false])
+        |> Enum.into(context)
+
+      response = Req.get!(context.req, url: "/upgrade_then_rescue", base_url: context.base)
+
+      assert response.status == 200
+      assert response.body == "OK"
+    end
+
+    defmodule MyOtherNoopWebSock do
+      use NoopWebSock
+    end
+
+    def upgrade_then_rescue(conn) do
+      # In actual use, it's the caller's responsibility to ensure the upgrade is valid before
+      # calling upgrade_adapter. On failure, Plug.Conn.upgrade_adapter/3 raises ArgumentError
+      # without returning a new conn, so the documented recovery is to keep using this (still
+      # current) conn - exactly what the rescue clause below does.
+      upgrade_adapter(conn, :websocket, {MyOtherNoopWebSock, [], []})
+    rescue
+      ArgumentError -> send_resp(conn, 200, "OK")
+    end
+
+    test "chunk does not advance the counter when the transport raises", context do
+      # Force a genuine Bandit.TransportError deterministically (rather than racing a client
+      # disconnect) by having the plug close its own underlying socket mid-response, then
+      # attempting to write to it twice. `Req.get/2` (not `Req.get!/2`) is used since the
+      # connection closing mid-response is expected to surface as a client-side error too - the
+      # only thing this test cares about is what the server logs
+      _ = Req.get(context.req, url: "/close_socket_then_chunk_twice")
+
+      assert_receive {:log, %{level: :info, msg: {:string, msg}}}, 500
+      assert msg == "both post-close chunk/2 calls failed without raising a stale-conn error"
+    end
+
+    def close_socket_then_chunk_twice(conn) do
+      conn = send_chunked(conn, 200)
+      {Bandit.Adapter, adapter} = conn.adapter
+      ThousandIsland.Socket.close(adapter.transport.socket)
+
+      # chunk/2 is unique among Plug.Conn.Adapter's sending callbacks in that it reports
+      # transport errors as an {:error, reason} return value rather than raising - Plug's
+      # Plug.Conn.chunk/2 does not return a new conn in that case, so the caller keeps using its
+      # already-current (here, still broken) conn. If chunk/2 had incorrectly advanced the usage
+      # counter on the first (failed) call, the second call would raise "Stale conn passed to a
+      # Plug.Conn function" instead of returning the same {:error, _} shape
+      {:error, _} = chunk(conn, "first")
+      {:error, _} = chunk(conn, "second")
+
+      Logger.info("both post-close chunk/2 calls failed without raising a stale-conn error",
+        plug: {__MODULE__, []}
+      )
+
+      conn
     end
   end
 end

--- a/test/bandit/http1/protocol_test.exs
+++ b/test/bandit/http1/protocol_test.exs
@@ -815,6 +815,58 @@ defmodule HTTP1ProtocolTest do
       send_resp(conn, 200, "#{first},#{second},#{third}")
     end
 
+    @tag :capture_log
+    test "rejects a stale conn after an incremental body read", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      Transport.send(
+        client,
+        "POST /respond_with_stale_conn HTTP/1.1\r\nhost: localhost\r\ncontent-length: 5\r\n\r\nAB"
+      )
+
+      Process.sleep(10)
+
+      Transport.send(
+        client,
+        "CDEGET /echo_method HTTP/1.1\r\nhost: localhost\r\n\r\n"
+      )
+
+      assert {:ok, "500 Internal Server Error", headers, ""} =
+               SimpleHTTP1Client.recv_reply(client)
+
+      assert Bandit.Headers.get_header(headers, :connection) == "close"
+      assert SimpleHTTP1Client.connection_closed_for_reading?(client)
+
+      assert_receive {:log, %{level: :error, msg: {:string, msg}}}, 500
+      assert msg =~ "** (RuntimeError) Stale conn passed to a Plug.Conn function."
+    end
+
+    def respond_with_stale_conn(conn) do
+      {:more, "ABC", _conn} = Plug.Conn.read_body(conn, length: 3)
+      send_resp(conn, 200, "should not be sent")
+    end
+
+    @tag :capture_log
+    test "rejects an earlier conn for another body read", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      Transport.send(
+        client,
+        "POST /read_body_with_stale_conn HTTP/1.1\r\nhost: localhost\r\ncontent-length: 2\r\n\r\nAB"
+      )
+
+      assert {:ok, "500 Internal Server Error", _, ""} = SimpleHTTP1Client.recv_reply(client)
+      assert SimpleHTTP1Client.connection_closed_for_reading?(client)
+
+      assert_receive {:log, %{level: :error, msg: {:string, msg}}}, 500
+      assert msg =~ "** (RuntimeError) Stale conn passed to a Plug.Conn function."
+    end
+
+    def read_body_with_stale_conn(conn) do
+      {:more, "A", _conn} = Plug.Conn.read_body(conn, length: 1)
+      Plug.Conn.read_body(conn)
+    end
+
     test "handles the case where we read from the network in smaller chunks than we return",
          context do
       client = SimpleHTTP1Client.tcp_client(context)


### PR DESCRIPTION
`Bandit.Adapter` now holds a `usage_counter: {shared_counter_ref, local_count}` tuple.
`shared_counter_ref` is a `:counters` reference created once per request and shared (by
reference) across every functional copy of the adapter; `local_count` is stamped with its
value each time a callback returns a new adapter. Every callback that can return a new conn
compares its `local_count` against the shared counter's current value before doing any work,
and advances both together - but only once it has actually committed to returning a new conn since some callbacks (`inform/3`, `upgrade/3` , `chunk/2`) can safely return without a new conn

These two values should always match; a mismatch means some other, newer copy of the conn already advanced the connection, which can only happen if a stale conn was reused - Bandit now raises immediately instead of silently trusting it.

Closes #649