### PR TITLE
Opt-in client disconnect notification for HTTP/1 plugs

### DIFF
--- a/lib/bandit.ex
+++ b/lib/bandit.ex
@@ -139,6 +139,17 @@ defmodule Bandit do
     Defaults to 50 headers
   * `max_requests`: The maximum number of requests to serve in a single
     HTTP/1.1 connection before closing the connection. Defaults to 0 (no limit)
+  * `notify_disconnect`: Whether to notify the process executing your Plug when the client
+    disconnects while the Plug is still running. Once the request body has been completely read
+    (or if there is none), Bandit will watch the socket and standard `{:tcp_closed, _}` /
+    `{:ssl_closed, _}` messages will arrive in the process running your Plug if the client goes
+    away; `Bandit.client_disconnect_message?/1` can be used to match them. This is useful for
+    long-running requests such as server-sent events or proxied upstream calls, where the work
+    should be abandoned as soon as the client is gone. Notification is best-effort (it is
+    delivered while Bandit is between reads on the socket, which is the case for the entire time
+    your Plug is running after the body has been read). Plugs which use `receive` while this
+    option is enabled must be careful to not consume & discard these messages (or messages
+    starting with the tag of the next pipelined request). Defaults to `false`
   * `clear_process_dict`: Whether to clear the process dictionary of all non-internal entries
     between subsequent keepalive requests. If set, all keys not starting with `$` are removed from
     the process dictionary between requests. Defaults to `true`
@@ -154,6 +165,7 @@ defmodule Bandit do
           | {:max_header_length, pos_integer()}
           | {:max_header_count, pos_integer()}
           | {:max_requests, pos_integer()}
+          | {:notify_disconnect, boolean()}
           | {:clear_process_dict, boolean()}
           | {:gc_every_n_keepalive_requests, pos_integer()}
           | {:log_unknown_messages, boolean()}
@@ -243,6 +255,38 @@ defmodule Bandit do
 
   require Logger
 
+  @doc """
+  Returns whether the given message indicates that the client has disconnected.
+
+  When the `notify_disconnect` HTTP/1 option is enabled, the process executing your Plug will
+  receive standard socket close messages if the client disconnects while your Plug is running.
+  Since the exact shape of these messages depends on the transport in use (TCP or TLS for HTTP/1,
+  stream resets for HTTP/2), this function provides a transport-agnostic way to recognize them
+  within a `receive` block:
+
+  ```elixir
+  def call(conn, _opts) do
+    conn = send_chunked(conn, 200)
+
+    receive do
+      msg ->
+        if Bandit.client_disconnect_message?(msg), do: raise("client went away")
+    after
+      30_000 -> :ok
+    end
+
+    ...
+  end
+  ```
+  """
+  @spec client_disconnect_message?(term()) :: boolean()
+  def client_disconnect_message?({:tcp_closed, _port}), do: true
+  def client_disconnect_message?({:ssl_closed, _sslsocket}), do: true
+  def client_disconnect_message?({:tcp_error, _port, _error}), do: true
+  def client_disconnect_message?({:ssl_error, _sslsocket, _error}), do: true
+  def client_disconnect_message?({:bandit, {:rst_stream, _error_code}}), do: true
+  def client_disconnect_message?(_msg), do: false
+
   @doc false
   @spec child_spec(options()) :: Supervisor.child_spec()
   def child_spec(arg) do
@@ -256,7 +300,7 @@ defmodule Bandit do
 
   @top_level_keys ~w(plug scheme port ip keyfile certfile otp_app cipher_suite display_plug startup_log thousand_island_options http_options http_1_options http_2_options websocket_options)a
   @http_keys ~w(compress response_encodings deflate_options zstd_options log_exceptions_with_status_codes log_protocol_errors log_client_closures)a
-  @http_1_keys ~w(enabled max_request_line_length max_header_length max_header_count max_requests clear_process_dict gc_every_n_keepalive_requests log_unknown_messages)a
+  @http_1_keys ~w(enabled max_request_line_length max_header_length max_header_count max_requests notify_disconnect clear_process_dict gc_every_n_keepalive_requests log_unknown_messages)a
   @http_2_keys ~w(enabled max_header_block_size max_requests max_reset_stream_rate sendfile_chunk_size default_local_settings)a
   @websocket_keys ~w(enabled max_frame_size max_fragmented_message_size validate_text_frames compress deflate_options max_inflate_ratio primitive_ops_module log_protocol_errors)a
   @thousand_island_keys ThousandIsland.ServerConfig.__struct__()

--- a/lib/bandit/http1/socket.ex
+++ b/lib/bandit/http1/socket.ex
@@ -19,6 +19,7 @@ defmodule Bandit.HTTP1.Socket do
             request_connection_header: nil,
             close_after_response: false,
             keepalive: nil,
+            notify_disconnect: false,
             opts: %{}
 
   @typedoc "An HTTP/1 read state"
@@ -40,6 +41,7 @@ defmodule Bandit.HTTP1.Socket do
           request_connection_header: binary(),
           close_after_response: boolean(),
           keepalive: boolean(),
+          notify_disconnect: boolean(),
           opts: %{
             required(:http_1) => Bandit.http_1_options()
           }
@@ -240,7 +242,7 @@ defmodule Bandit.HTTP1.Socket do
       socket = %{socket | buffer: buffer, unread_content_length: remaining_unread_content_length}
 
       if remaining_unread_content_length == 0 do
-        {:ok, body, %{socket | read_state: :read}}
+        {:ok, body, maybe_arm_disconnect_notifications(%{socket | read_state: :read})}
       else
         {:more, body, socket}
       end
@@ -249,7 +251,10 @@ defmodule Bandit.HTTP1.Socket do
     def read_data(%@for{read_state: :headers_read, body_encoding: "chunked"} = socket, opts) do
       case do_read_chunked_data!(socket.socket, socket.buffer, <<>>, 0, opts) do
         {:ok, body, buffer} ->
-          {:ok, IO.iodata_to_binary(body), %{socket | read_state: :read, buffer: buffer}}
+          socket =
+            maybe_arm_disconnect_notifications(%{socket | read_state: :read, buffer: buffer})
+
+          {:ok, IO.iodata_to_binary(body), socket}
 
         {:more, body, buffer} ->
           {:more, IO.iodata_to_binary(body), %{socket | buffer: buffer}}
@@ -610,6 +615,52 @@ defmodule Bandit.HTTP1.Socket do
         else
           reraise e, __STACKTRACE__
         end
+    end
+
+    def set_disconnect_notifications(%@for{} = socket, true) do
+      if Keyword.get(socket.opts.http_1, :notify_disconnect, false),
+        do: maybe_arm_disconnect_notifications(%{socket | notify_disconnect: true}),
+        else: socket
+    end
+
+    def set_disconnect_notifications(%@for{notify_disconnect: true} = socket, false) do
+      _ = ThousandIsland.Socket.setopts(socket.socket, active: false)
+      drain_disconnect_notifications(%{socket | notify_disconnect: false})
+    end
+
+    def set_disconnect_notifications(%@for{} = socket, false), do: socket
+
+    # Active mode and the passive reads done elsewhere in this module do not mix, so we only ever
+    # arm the socket once the request body has been completely consumed (or was never there to
+    # begin with). From that point until the response is complete, the only things the client can
+    # legitimately send us are the start of a pipelined next request or a connection close, both
+    # of which we recover in drain_disconnect_notifications/1 once the plug has finished
+    defp maybe_arm_disconnect_notifications(
+           %@for{notify_disconnect: true, read_state: :read} = socket
+         ) do
+      _ = ThousandIsland.Socket.setopts(socket.socket, active: :once)
+      socket
+    end
+
+    defp maybe_arm_disconnect_notifications(%@for{} = socket), do: socket
+
+    # Return the socket to a fully passive state: any data the client sent while we were in
+    # active mode is re-injected into our read buffer (it is the start of the next pipelined
+    # request), and any close/error notification the plug did not consume is turned into a
+    # close_after_response so that we don't try to reuse a dead connection for keepalive
+    defp drain_disconnect_notifications(%@for{} = socket) do
+      receive do
+        {tag, _sock, data} when tag in [:tcp, :ssl] ->
+          drain_disconnect_notifications(%{socket | buffer: socket.buffer <> data})
+
+        {tag, _sock} when tag in [:tcp_closed, :ssl_closed] ->
+          drain_disconnect_notifications(%{socket | close_after_response: true})
+
+        {tag, _sock, _error} when tag in [:tcp_error, :ssl_error] ->
+          drain_disconnect_notifications(%{socket | close_after_response: true})
+      after
+        0 -> socket
+      end
     end
 
     def supported_upgrade?(%@for{} = _socket, protocol), do: protocol == :websocket

--- a/lib/bandit/http2/stream.ex
+++ b/lib/bandit/http2/stream.ex
@@ -551,6 +551,11 @@ defmodule Bandit.HTTP2.Stream do
       )
     end
 
+    # HTTP/2 stream processes already receive `{:bandit, {:rst_stream, error_code}}` messages when
+    # the client cancels a stream, and are linked to the connection process (and so die) when the
+    # client goes away entirely. There is nothing extra to arm here
+    def set_disconnect_notifications(%@for{} = stream, _enabled), do: stream
+
     def supported_upgrade?(%@for{} = _stream, _protocol), do: false
 
     def send_on_error(%@for{} = stream, %Bandit.HTTP2.Errors.StreamError{} = error) do

--- a/lib/bandit/http_transport.ex
+++ b/lib/bandit/http_transport.ex
@@ -39,6 +39,9 @@ defprotocol Bandit.HTTPTransport do
   @spec ensure_completed(t()) :: t()
   def ensure_completed(transport)
 
+  @spec set_disconnect_notifications(t(), boolean()) :: t()
+  def set_disconnect_notifications(transport, enabled)
+
   @spec supported_upgrade?(t(), atom()) :: boolean()
   def supported_upgrade?(transport, protocol)
 

--- a/lib/bandit/pipeline.ex
+++ b/lib/bandit/pipeline.ex
@@ -34,6 +34,7 @@ defmodule Bandit.Pipeline do
       {:ok, method, request_target, headers, transport} =
         Bandit.HTTPTransport.read_headers(transport)
 
+      transport = Bandit.HTTPTransport.set_disconnect_notifications(transport, true)
       conn = build_conn!(transport, method, request_target, headers, conn_data, opts)
       span = Bandit.Telemetry.start_span(:request, measurements, Map.put(metadata, :conn, conn))
 
@@ -43,6 +44,7 @@ defmodule Bandit.Pipeline do
         |> maybe_upgrade!()
         |> case do
           {:no_upgrade, conn} ->
+            conn = reset_disconnect_notifications(conn)
             %Plug.Conn{adapter: {_mod, adapter}} = conn = commit_response!(conn)
             Bandit.Telemetry.stop_span(span, adapter.metrics, %{conn: conn})
             {:ok, adapter.transport}
@@ -164,6 +166,17 @@ defmodule Bandit.Pipeline do
   end
 
   defp maybe_upgrade!(conn), do: {:no_upgrade, conn}
+
+  # Return the transport to a fully passive state before we consider the response committed. Any
+  # socket-level messages that the plug did not consume are recovered here (see
+  # `Bandit.HTTPTransport.set_disconnect_notifications/2`). Upgrade and error paths don't come
+  # through here; neither of them goes on to reuse the connection for reading, so there is
+  # nothing for them to recover
+  @spec reset_disconnect_notifications(Plug.Conn.t()) :: Plug.Conn.t()
+  defp reset_disconnect_notifications(%Plug.Conn{adapter: {mod, adapter}} = conn) do
+    transport = Bandit.HTTPTransport.set_disconnect_notifications(adapter.transport, false)
+    %{conn | adapter: {mod, %{adapter | transport: transport}}}
+  end
 
   @spec commit_response!(Plug.Conn.t()) :: Plug.Conn.t() | no_return()
   defp commit_response!(conn) do

--- a/notify-disconnect.diff
+++ b/notify-disconnect.diff
@@ -1,0 +1,479 @@
+diff --git a/lib/bandit.ex b/lib/bandit.ex
+index aed2de5..675683b 100644
+--- a/lib/bandit.ex
++++ b/lib/bandit.ex
+@@ -139,6 +139,17 @@ defmodule Bandit do
+     Defaults to 50 headers
+   * `max_requests`: The maximum number of requests to serve in a single
+     HTTP/1.1 connection before closing the connection. Defaults to 0 (no limit)
++  * `notify_disconnect`: Whether to notify the process executing your Plug when the client
++    disconnects while the Plug is still running. Once the request body has been completely read
++    (or if there is none), Bandit will watch the socket and standard `{:tcp_closed, _}` /
++    `{:ssl_closed, _}` messages will arrive in the process running your Plug if the client goes
++    away; `Bandit.client_disconnect_message?/1` can be used to match them. This is useful for
++    long-running requests such as server-sent events or proxied upstream calls, where the work
++    should be abandoned as soon as the client is gone. Notification is best-effort (it is
++    delivered while Bandit is between reads on the socket, which is the case for the entire time
++    your Plug is running after the body has been read). Plugs which use `receive` while this
++    option is enabled must be careful to not consume & discard these messages (or messages
++    starting with the tag of the next pipelined request). Defaults to `false`
+   * `clear_process_dict`: Whether to clear the process dictionary of all non-internal entries
+     between subsequent keepalive requests. If set, all keys not starting with `$` are removed from
+     the process dictionary between requests. Defaults to `true`
+@@ -154,6 +165,7 @@ defmodule Bandit do
+           | {:max_header_length, pos_integer()}
+           | {:max_header_count, pos_integer()}
+           | {:max_requests, pos_integer()}
++          | {:notify_disconnect, boolean()}
+           | {:clear_process_dict, boolean()}
+           | {:gc_every_n_keepalive_requests, pos_integer()}
+           | {:log_unknown_messages, boolean()}
+@@ -243,6 +255,38 @@ defmodule Bandit do
+ 
+   require Logger
+ 
++  @doc """
++  Returns whether the given message indicates that the client has disconnected.
++
++  When the `notify_disconnect` HTTP/1 option is enabled, the process executing your Plug will
++  receive standard socket close messages if the client disconnects while your Plug is running.
++  Since the exact shape of these messages depends on the transport in use (TCP or TLS for HTTP/1,
++  stream resets for HTTP/2), this function provides a transport-agnostic way to recognize them
++  within a `receive` block:
++
++  ```elixir
++  def call(conn, _opts) do
++    conn = send_chunked(conn, 200)
++
++    receive do
++      msg ->
++        if Bandit.client_disconnect_message?(msg), do: raise("client went away")
++    after
++      30_000 -> :ok
++    end
++
++    ...
++  end
++  ```
++  """
++  @spec client_disconnect_message?(term()) :: boolean()
++  def client_disconnect_message?({:tcp_closed, _port}), do: true
++  def client_disconnect_message?({:ssl_closed, _sslsocket}), do: true
++  def client_disconnect_message?({:tcp_error, _port, _error}), do: true
++  def client_disconnect_message?({:ssl_error, _sslsocket, _error}), do: true
++  def client_disconnect_message?({:bandit, {:rst_stream, _error_code}}), do: true
++  def client_disconnect_message?(_msg), do: false
++
+   @doc false
+   @spec child_spec(options()) :: Supervisor.child_spec()
+   def child_spec(arg) do
+@@ -256,7 +300,7 @@ defmodule Bandit do
+ 
+   @top_level_keys ~w(plug scheme port ip keyfile certfile otp_app cipher_suite display_plug startup_log thousand_island_options http_options http_1_options http_2_options websocket_options)a
+   @http_keys ~w(compress response_encodings deflate_options zstd_options log_exceptions_with_status_codes log_protocol_errors log_client_closures)a
+-  @http_1_keys ~w(enabled max_request_line_length max_header_length max_header_count max_requests clear_process_dict gc_every_n_keepalive_requests log_unknown_messages)a
++  @http_1_keys ~w(enabled max_request_line_length max_header_length max_header_count max_requests notify_disconnect clear_process_dict gc_every_n_keepalive_requests log_unknown_messages)a
+   @http_2_keys ~w(enabled max_header_block_size max_requests max_reset_stream_rate sendfile_chunk_size default_local_settings)a
+   @websocket_keys ~w(enabled max_frame_size max_fragmented_message_size validate_text_frames compress deflate_options max_inflate_ratio primitive_ops_module log_protocol_errors)a
+   @thousand_island_keys ThousandIsland.ServerConfig.__struct__()
+diff --git a/lib/bandit/http1/socket.ex b/lib/bandit/http1/socket.ex
+index 8183054..e1567eb 100644
+--- a/lib/bandit/http1/socket.ex
++++ b/lib/bandit/http1/socket.ex
+@@ -19,6 +19,7 @@ defmodule Bandit.HTTP1.Socket do
+             request_connection_header: nil,
+             close_after_response: false,
+             keepalive: nil,
++            notify_disconnect: false,
+             opts: %{}
+ 
+   @typedoc "An HTTP/1 read state"
+@@ -40,6 +41,7 @@ defmodule Bandit.HTTP1.Socket do
+           request_connection_header: binary(),
+           close_after_response: boolean(),
+           keepalive: boolean(),
++          notify_disconnect: boolean(),
+           opts: %{
+             required(:http_1) => Bandit.http_1_options()
+           }
+@@ -224,7 +226,7 @@ defmodule Bandit.HTTP1.Socket do
+       socket = %{socket | buffer: buffer, unread_content_length: remaining_unread_content_length}
+ 
+       if remaining_unread_content_length == 0 do
+-        {:ok, body, %{socket | read_state: :read}}
++        {:ok, body, maybe_arm_disconnect_notifications(%{socket | read_state: :read})}
+       else
+         {:more, body, socket}
+       end
+@@ -233,7 +235,10 @@ defmodule Bandit.HTTP1.Socket do
+     def read_data(%@for{read_state: :headers_read, body_encoding: "chunked"} = socket, opts) do
+       case do_read_chunked_data!(socket.socket, socket.buffer, <<>>, 0, opts) do
+         {:ok, body, buffer} ->
+-          {:ok, IO.iodata_to_binary(body), %{socket | read_state: :read, buffer: buffer}}
++          socket =
++            maybe_arm_disconnect_notifications(%{socket | read_state: :read, buffer: buffer})
++
++          {:ok, IO.iodata_to_binary(body), socket}
+ 
+         {:more, body, buffer} ->
+           {:more, IO.iodata_to_binary(body), %{socket | buffer: buffer}}
+@@ -612,6 +617,52 @@ defmodule Bandit.HTTP1.Socket do
+         end
+     end
+ 
++    def set_disconnect_notifications(%@for{} = socket, true) do
++      if Keyword.get(socket.opts.http_1, :notify_disconnect, false),
++        do: maybe_arm_disconnect_notifications(%{socket | notify_disconnect: true}),
++        else: socket
++    end
++
++    def set_disconnect_notifications(%@for{notify_disconnect: true} = socket, false) do
++      _ = ThousandIsland.Socket.setopts(socket.socket, active: false)
++      drain_disconnect_notifications(%{socket | notify_disconnect: false})
++    end
++
++    def set_disconnect_notifications(%@for{} = socket, false), do: socket
++
++    # Active mode and the passive reads done elsewhere in this module do not mix, so we only ever
++    # arm the socket once the request body has been completely consumed (or was never there to
++    # begin with). From that point until the response is complete, the only things the client can
++    # legitimately send us are the start of a pipelined next request or a connection close, both
++    # of which we recover in drain_disconnect_notifications/1 once the plug has finished
++    defp maybe_arm_disconnect_notifications(
++           %@for{notify_disconnect: true, read_state: :read} = socket
++         ) do
++      _ = ThousandIsland.Socket.setopts(socket.socket, active: :once)
++      socket
++    end
++
++    defp maybe_arm_disconnect_notifications(%@for{} = socket), do: socket
++
++    # Return the socket to a fully passive state: any data the client sent while we were in
++    # active mode is re-injected into our read buffer (it is the start of the next pipelined
++    # request), and any close/error notification the plug did not consume is turned into a
++    # close_after_response so that we don't try to reuse a dead connection for keepalive
++    defp drain_disconnect_notifications(%@for{} = socket) do
++      receive do
++        {tag, _sock, data} when tag in [:tcp, :ssl] ->
++          drain_disconnect_notifications(%{socket | buffer: socket.buffer <> data})
++
++        {tag, _sock} when tag in [:tcp_closed, :ssl_closed] ->
++          drain_disconnect_notifications(%{socket | close_after_response: true})
++
++        {tag, _sock, _error} when tag in [:tcp_error, :ssl_error] ->
++          drain_disconnect_notifications(%{socket | close_after_response: true})
++      after
++        0 -> socket
++      end
++    end
++
+     def supported_upgrade?(%@for{} = _socket, protocol), do: protocol == :websocket
+ 
+     def send_on_error(%@for{}, %Bandit.TransportError{}), do: :ok
+diff --git a/lib/bandit/http2/stream.ex b/lib/bandit/http2/stream.ex
+index f3a6c91..50f3150 100644
+--- a/lib/bandit/http2/stream.ex
++++ b/lib/bandit/http2/stream.ex
+@@ -551,6 +551,11 @@ defmodule Bandit.HTTP2.Stream do
+       )
+     end
+ 
++    # HTTP/2 stream processes already receive `{:bandit, {:rst_stream, error_code}}` messages when
++    # the client cancels a stream, and are linked to the connection process (and so die) when the
++    # client goes away entirely. There is nothing extra to arm here
++    def set_disconnect_notifications(%@for{} = stream, _enabled), do: stream
++
+     def supported_upgrade?(%@for{} = _stream, _protocol), do: false
+ 
+     def send_on_error(%@for{} = stream, %Bandit.HTTP2.Errors.StreamError{} = error) do
+diff --git a/lib/bandit/http_transport.ex b/lib/bandit/http_transport.ex
+index b1a05bd..13e0482 100644
+--- a/lib/bandit/http_transport.ex
++++ b/lib/bandit/http_transport.ex
+@@ -39,6 +39,9 @@ defprotocol Bandit.HTTPTransport do
+   @spec ensure_completed(t()) :: t()
+   def ensure_completed(transport)
+ 
++  @spec set_disconnect_notifications(t(), boolean()) :: t()
++  def set_disconnect_notifications(transport, enabled)
++
+   @spec supported_upgrade?(t(), atom()) :: boolean()
+   def supported_upgrade?(transport, protocol)
+ 
+diff --git a/lib/bandit/pipeline.ex b/lib/bandit/pipeline.ex
+index e245047..ebd389e 100644
+--- a/lib/bandit/pipeline.ex
++++ b/lib/bandit/pipeline.ex
+@@ -34,6 +34,7 @@ defmodule Bandit.Pipeline do
+       {:ok, method, request_target, headers, transport} =
+         Bandit.HTTPTransport.read_headers(transport)
+ 
++      transport = Bandit.HTTPTransport.set_disconnect_notifications(transport, true)
+       conn = build_conn!(transport, method, request_target, headers, conn_data, opts)
+       span = Bandit.Telemetry.start_span(:request, measurements, Map.put(metadata, :conn, conn))
+ 
+@@ -43,6 +44,7 @@ defmodule Bandit.Pipeline do
+         |> maybe_upgrade!()
+         |> case do
+           {:no_upgrade, conn} ->
++            conn = reset_disconnect_notifications(conn)
+             %Plug.Conn{adapter: {_mod, adapter}} = conn = commit_response!(conn)
+             Bandit.Telemetry.stop_span(span, adapter.metrics, %{conn: conn})
+             {:ok, adapter.transport}
+@@ -165,6 +167,17 @@ defmodule Bandit.Pipeline do
+ 
+   defp maybe_upgrade!(conn), do: {:no_upgrade, conn}
+ 
++  # Return the transport to a fully passive state before we consider the response committed. Any
++  # socket-level messages that the plug did not consume are recovered here (see
++  # `Bandit.HTTPTransport.set_disconnect_notifications/2`). Upgrade and error paths don't come
++  # through here; neither of them goes on to reuse the connection for reading, so there is
++  # nothing for them to recover
++  @spec reset_disconnect_notifications(Plug.Conn.t()) :: Plug.Conn.t()
++  defp reset_disconnect_notifications(%Plug.Conn{adapter: {mod, adapter}} = conn) do
++    transport = Bandit.HTTPTransport.set_disconnect_notifications(adapter.transport, false)
++    %{conn | adapter: {mod, %{adapter | transport: transport}}}
++  end
++
+   @spec commit_response!(Plug.Conn.t()) :: Plug.Conn.t() | no_return()
+   defp commit_response!(conn) do
+     case conn do
+diff --git a/test/bandit/http1/notify_disconnect_test.exs b/test/bandit/http1/notify_disconnect_test.exs
+new file mode 100644
+index 0000000..0de9796
+--- /dev/null
++++ b/test/bandit/http1/notify_disconnect_test.exs
+@@ -0,0 +1,233 @@
++defmodule HTTP1NotifyDisconnectTest do
++  use ExUnit.Case, async: true
++  use ServerHelpers
++
++  def call(conn, opts) do
++    conn = Plug.Conn.fetch_query_params(conn)
++
++    case conn.query_params["websock"] do
++      nil -> super(conn, opts)
++      websock -> Plug.Conn.upgrade_adapter(conn, :websocket, {String.to_atom(websock), [], []})
++    end
++  end
++
++  defp encoded_self, do: self() |> :erlang.term_to_binary() |> Base.encode64()
++
++  def test_pid(conn) do
++    conn
++    |> get_req_header("x-test-pid")
++    |> hd()
++    |> Base.decode64!()
++    |> :erlang.binary_to_term()
++  end
++
++  # Wait for a disconnect message, skipping over any other messages (such as Bandit's internal
++  # `{:plug_conn, :sent}` message) and putting them back in our mailbox when we're done, just as
++  # a well behaved receive loop in a real plug would
++  defp watch_for_disconnect(conn, timeout \\ 5_000) do
++    pid = test_pid(conn)
++    deadline = System.monotonic_time(:millisecond) + timeout
++    do_watch_for_disconnect(pid, deadline, [])
++    conn
++  end
++
++  defp do_watch_for_disconnect(pid, deadline, skipped) do
++    remaining = max(deadline - System.monotonic_time(:millisecond), 0)
++
++    receive do
++      msg ->
++        if Bandit.client_disconnect_message?(msg) do
++          requeue(skipped)
++          send(pid, :got_disconnect)
++        else
++          do_watch_for_disconnect(pid, deadline, [msg | skipped])
++        end
++    after
++      remaining ->
++        requeue(skipped)
++        send(pid, :no_disconnect)
++    end
++  end
++
++  defp requeue(skipped), do: skipped |> Enum.reverse() |> Enum.each(&send(self(), &1))
++
++  describe "notify_disconnect" do
++    test "delivers a disconnect message to the plug process when the client goes away", context do
++      context =
++        context |> http_server(http_1_options: [notify_disconnect: true]) |> Enum.into(context)
++
++      client = SimpleHTTP1Client.tcp_client(context)
++
++      SimpleHTTP1Client.send(client, "GET", "/wait_for_disconnect", [
++        "host: localhost",
++        "x-test-pid: #{encoded_self()}"
++      ])
++
++      assert_receive :plug_started, 1000
++      Transport.close(client)
++      assert_receive :got_disconnect, 1000
++    end
++
++    def wait_for_disconnect(conn) do
++      send(test_pid(conn), :plug_started)
++      conn = watch_for_disconnect(conn)
++      send_resp(conn, 204, "")
++    end
++
++    test "arms notification once the request body has been completely read", context do
++      context =
++        context |> http_server(http_1_options: [notify_disconnect: true]) |> Enum.into(context)
++
++      client = SimpleHTTP1Client.tcp_client(context)
++
++      SimpleHTTP1Client.send(client, "POST", "/read_body_then_wait", [
++        "host: localhost",
++        "x-test-pid: #{encoded_self()}",
++        "content-length: 5"
++      ])
++
++      Transport.send(client, "hello")
++      assert_receive :body_read, 1000
++      Transport.close(client)
++      assert_receive :got_disconnect, 1000
++    end
++
++    def read_body_then_wait(conn) do
++      {:ok, "hello", conn} = read_body(conn)
++      send(test_pid(conn), :body_read)
++      conn = watch_for_disconnect(conn)
++      send_resp(conn, 204, "")
++    end
++
++    test "delivers a disconnect message while streaming a chunked response", context do
++      context =
++        context |> http_server(http_1_options: [notify_disconnect: true]) |> Enum.into(context)
++
++      client = SimpleHTTP1Client.tcp_client(context)
++
++      SimpleHTTP1Client.send(client, "GET", "/sse_wait", [
++        "host: localhost",
++        "x-test-pid: #{encoded_self()}"
++      ])
++
++      assert_receive :plug_started, 1000
++      Transport.close(client)
++      assert_receive :got_disconnect, 1000
++    end
++
++    def sse_wait(conn) do
++      conn = send_chunked(conn, 200)
++      {:ok, conn} = chunk(conn, "data: hi\n\n")
++      send(test_pid(conn), :plug_started)
++      watch_for_disconnect(conn)
++    end
++
++    test "delivers a disconnect message over TLS", context do
++      context =
++        context |> https_server(http_1_options: [notify_disconnect: true]) |> Enum.into(context)
++
++      client = Transport.tls_client(context, ["http/1.1"])
++
++      SimpleHTTP1Client.send(client, "GET", "/wait_for_disconnect", [
++        "host: localhost",
++        "x-test-pid: #{encoded_self()}"
++      ])
++
++      assert_receive :plug_started, 1000
++      Transport.close(client)
++      assert_receive :got_disconnect, 1000
++    end
++
++    test "does not deliver any messages when the option is not set", context do
++      context = context |> http_server() |> Enum.into(context)
++      client = SimpleHTTP1Client.tcp_client(context)
++
++      SimpleHTTP1Client.send(client, "GET", "/short_watch", [
++        "host: localhost",
++        "x-test-pid: #{encoded_self()}"
++      ])
++
++      assert_receive :plug_started, 1000
++      Transport.close(client)
++      assert_receive :no_disconnect, 1000
++      refute_received :got_disconnect
++      refute_received {:unexpected, _}
++    end
++
++    def short_watch(conn) do
++      send(test_pid(conn), :plug_started)
++      conn = watch_for_disconnect(conn, 500)
++      send_resp(conn, 204, "")
++    end
++
++    test "pipelined requests sent while the socket is being watched are not lost", context do
++      context =
++        context |> http_server(http_1_options: [notify_disconnect: true]) |> Enum.into(context)
++
++      client = SimpleHTTP1Client.tcp_client(context)
++
++      SimpleHTTP1Client.send(client, "GET", "/short_wait", [
++        "host: localhost",
++        "x-test-pid: #{encoded_self()}"
++      ])
++
++      assert_receive :plug_started, 1000
++
++      SimpleHTTP1Client.send(client, "GET", "/short_wait", [
++        "host: localhost",
++        "x-test-pid: #{encoded_self()}"
++      ])
++
++      assert {:ok, "200 OK", _headers, "first"} = SimpleHTTP1Client.recv_reply(client)
++      assert_receive :plug_started, 1000
++      assert {:ok, "200 OK", _headers, "first"} = SimpleHTTP1Client.recv_reply(client)
++    end
++
++    def short_wait(conn) do
++      send(test_pid(conn), :plug_started)
++      Process.sleep(200)
++      send_resp(conn, 200, "first")
++    end
++
++    test "keepalive requests are served normally when the client stays connected", context do
++      context =
++        context |> http_server(http_1_options: [notify_disconnect: true]) |> Enum.into(context)
++
++      client = SimpleHTTP1Client.tcp_client(context)
++
++      for _ <- 1..3 do
++        SimpleHTTP1Client.send(client, "GET", "/hello_world", ["host: localhost"])
++        assert {:ok, "200 OK", _headers, "OK"} = SimpleHTTP1Client.recv_reply(client)
++      end
++    end
++
++    def hello_world(conn), do: send_resp(conn, 200, "OK")
++
++    defmodule EchoWebSock do
++      use NoopWebSock
++      def handle_in({data, opcode: :text}, state), do: {:push, {:text, data}, state}
++    end
++
++    test "does not interfere with websocket upgrades", context do
++      context =
++        context |> http_server(http_1_options: [notify_disconnect: true]) |> Enum.into(context)
++
++      client = SimpleWebSocketClient.tcp_client(context)
++      SimpleWebSocketClient.http1_handshake(client, EchoWebSock)
++      SimpleWebSocketClient.send_text_frame(client, "hello")
++      assert {:ok, "hello"} = SimpleWebSocketClient.recv_text_frame(client)
++    end
++  end
++
++  describe "client_disconnect_message?/1" do
++    test "recognizes socket close and error messages" do
++      assert Bandit.client_disconnect_message?({:tcp_closed, :fake_port})
++      assert Bandit.client_disconnect_message?({:ssl_closed, :fake_socket})
++      assert Bandit.client_disconnect_message?({:tcp_error, :fake_port, :econnreset})
++      assert Bandit.client_disconnect_message?({:ssl_error, :fake_socket, :econnreset})
++      assert Bandit.client_disconnect_message?({:bandit, {:rst_stream, 8}})
++      refute Bandit.client_disconnect_message?({:tcp, :fake_port, "data"})
++      refute Bandit.client_disconnect_message?(:other)
++    end
++  end
++end

--- a/test/bandit/http1/notify_disconnect_test.exs
+++ b/test/bandit/http1/notify_disconnect_test.exs
@@ -1,0 +1,233 @@
+defmodule HTTP1NotifyDisconnectTest do
+  use ExUnit.Case, async: true
+  use ServerHelpers
+
+  def call(conn, opts) do
+    conn = Plug.Conn.fetch_query_params(conn)
+
+    case conn.query_params["websock"] do
+      nil -> super(conn, opts)
+      websock -> Plug.Conn.upgrade_adapter(conn, :websocket, {String.to_atom(websock), [], []})
+    end
+  end
+
+  defp encoded_self, do: self() |> :erlang.term_to_binary() |> Base.encode64()
+
+  def test_pid(conn) do
+    conn
+    |> get_req_header("x-test-pid")
+    |> hd()
+    |> Base.decode64!()
+    |> :erlang.binary_to_term()
+  end
+
+  # Wait for a disconnect message, skipping over any other messages (such as Bandit's internal
+  # `{:plug_conn, :sent}` message) and putting them back in our mailbox when we're done, just as
+  # a well behaved receive loop in a real plug would
+  defp watch_for_disconnect(conn, timeout \\ 5_000) do
+    pid = test_pid(conn)
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_watch_for_disconnect(pid, deadline, [])
+    conn
+  end
+
+  defp do_watch_for_disconnect(pid, deadline, skipped) do
+    remaining = max(deadline - System.monotonic_time(:millisecond), 0)
+
+    receive do
+      msg ->
+        if Bandit.client_disconnect_message?(msg) do
+          requeue(skipped)
+          send(pid, :got_disconnect)
+        else
+          do_watch_for_disconnect(pid, deadline, [msg | skipped])
+        end
+    after
+      remaining ->
+        requeue(skipped)
+        send(pid, :no_disconnect)
+    end
+  end
+
+  defp requeue(skipped), do: skipped |> Enum.reverse() |> Enum.each(&send(self(), &1))
+
+  describe "notify_disconnect" do
+    test "delivers a disconnect message to the plug process when the client goes away", context do
+      context =
+        context |> http_server(http_1_options: [notify_disconnect: true]) |> Enum.into(context)
+
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "GET", "/wait_for_disconnect", [
+        "host: localhost",
+        "x-test-pid: #{encoded_self()}"
+      ])
+
+      assert_receive :plug_started, 1000
+      Transport.close(client)
+      assert_receive :got_disconnect, 1000
+    end
+
+    def wait_for_disconnect(conn) do
+      send(test_pid(conn), :plug_started)
+      conn = watch_for_disconnect(conn)
+      send_resp(conn, 204, "")
+    end
+
+    test "arms notification once the request body has been completely read", context do
+      context =
+        context |> http_server(http_1_options: [notify_disconnect: true]) |> Enum.into(context)
+
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "POST", "/read_body_then_wait", [
+        "host: localhost",
+        "x-test-pid: #{encoded_self()}",
+        "content-length: 5"
+      ])
+
+      Transport.send(client, "hello")
+      assert_receive :body_read, 1000
+      Transport.close(client)
+      assert_receive :got_disconnect, 1000
+    end
+
+    def read_body_then_wait(conn) do
+      {:ok, "hello", conn} = read_body(conn)
+      send(test_pid(conn), :body_read)
+      conn = watch_for_disconnect(conn)
+      send_resp(conn, 204, "")
+    end
+
+    test "delivers a disconnect message while streaming a chunked response", context do
+      context =
+        context |> http_server(http_1_options: [notify_disconnect: true]) |> Enum.into(context)
+
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "GET", "/sse_wait", [
+        "host: localhost",
+        "x-test-pid: #{encoded_self()}"
+      ])
+
+      assert_receive :plug_started, 1000
+      Transport.close(client)
+      assert_receive :got_disconnect, 1000
+    end
+
+    def sse_wait(conn) do
+      conn = send_chunked(conn, 200)
+      {:ok, conn} = chunk(conn, "data: hi\n\n")
+      send(test_pid(conn), :plug_started)
+      watch_for_disconnect(conn)
+    end
+
+    test "delivers a disconnect message over TLS", context do
+      context =
+        context |> https_server(http_1_options: [notify_disconnect: true]) |> Enum.into(context)
+
+      client = Transport.tls_client(context, ["http/1.1"])
+
+      SimpleHTTP1Client.send(client, "GET", "/wait_for_disconnect", [
+        "host: localhost",
+        "x-test-pid: #{encoded_self()}"
+      ])
+
+      assert_receive :plug_started, 1000
+      Transport.close(client)
+      assert_receive :got_disconnect, 1000
+    end
+
+    test "does not deliver any messages when the option is not set", context do
+      context = context |> http_server() |> Enum.into(context)
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "GET", "/short_watch", [
+        "host: localhost",
+        "x-test-pid: #{encoded_self()}"
+      ])
+
+      assert_receive :plug_started, 1000
+      Transport.close(client)
+      assert_receive :no_disconnect, 1000
+      refute_received :got_disconnect
+      refute_received {:unexpected, _}
+    end
+
+    def short_watch(conn) do
+      send(test_pid(conn), :plug_started)
+      conn = watch_for_disconnect(conn, 500)
+      send_resp(conn, 204, "")
+    end
+
+    test "pipelined requests sent while the socket is being watched are not lost", context do
+      context =
+        context |> http_server(http_1_options: [notify_disconnect: true]) |> Enum.into(context)
+
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "GET", "/short_wait", [
+        "host: localhost",
+        "x-test-pid: #{encoded_self()}"
+      ])
+
+      assert_receive :plug_started, 1000
+
+      SimpleHTTP1Client.send(client, "GET", "/short_wait", [
+        "host: localhost",
+        "x-test-pid: #{encoded_self()}"
+      ])
+
+      assert {:ok, "200 OK", _headers, "first"} = SimpleHTTP1Client.recv_reply(client)
+      assert_receive :plug_started, 1000
+      assert {:ok, "200 OK", _headers, "first"} = SimpleHTTP1Client.recv_reply(client)
+    end
+
+    def short_wait(conn) do
+      send(test_pid(conn), :plug_started)
+      Process.sleep(200)
+      send_resp(conn, 200, "first")
+    end
+
+    test "keepalive requests are served normally when the client stays connected", context do
+      context =
+        context |> http_server(http_1_options: [notify_disconnect: true]) |> Enum.into(context)
+
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      for _ <- 1..3 do
+        SimpleHTTP1Client.send(client, "GET", "/hello_world", ["host: localhost"])
+        assert {:ok, "200 OK", _headers, "OK"} = SimpleHTTP1Client.recv_reply(client)
+      end
+    end
+
+    def hello_world(conn), do: send_resp(conn, 200, "OK")
+
+    defmodule EchoWebSock do
+      use NoopWebSock
+      def handle_in({data, opcode: :text}, state), do: {:push, {:text, data}, state}
+    end
+
+    test "does not interfere with websocket upgrades", context do
+      context =
+        context |> http_server(http_1_options: [notify_disconnect: true]) |> Enum.into(context)
+
+      client = SimpleWebSocketClient.tcp_client(context)
+      SimpleWebSocketClient.http1_handshake(client, EchoWebSock)
+      SimpleWebSocketClient.send_text_frame(client, "hello")
+      assert {:ok, "hello"} = SimpleWebSocketClient.recv_text_frame(client)
+    end
+  end
+
+  describe "client_disconnect_message?/1" do
+    test "recognizes socket close and error messages" do
+      assert Bandit.client_disconnect_message?({:tcp_closed, :fake_port})
+      assert Bandit.client_disconnect_message?({:ssl_closed, :fake_socket})
+      assert Bandit.client_disconnect_message?({:tcp_error, :fake_port, :econnreset})
+      assert Bandit.client_disconnect_message?({:ssl_error, :fake_socket, :econnreset})
+      assert Bandit.client_disconnect_message?({:bandit, {:rst_stream, 8}})
+      refute Bandit.client_disconnect_message?({:tcp, :fake_port, "data"})
+      refute Bandit.client_disconnect_message?(:other)
+    end
+  end
+end


### PR DESCRIPTION
Hi @mtrudel 

Note: this is about ~100 lines of code and ~200 lines of test for this feature. Hope I'm not bombarding you with too many things today. Assisted by Claude. Please fill free to ask any questions.

## What this adds

A new HTTP/1 option, `http_1_options: [notify_disconnect: true]`. When enabled, Bandit watches the socket while your Plug is running, and the standard OTP socket close messages (`{:tcp_closed, _}` or `{:ssl_closed, _}`) arrive in the process executing the Plug if the client goes away. Since the exact message shape depends on the transport, the PR also adds one small public helper, `Bandit.client_disconnect_message?/1`, which recognizes disconnect messages across plain TCP, TLS, and HTTP/2 stream resets, so application code can write one `receive` clause that works everywhere.

A Plug serving server-sent events, relaying a slow upstream call, or doing a long computation can now notice mid-request that nobody is listening and wind down gracefully:

```elixir
def call(conn, _opts) do
  conn = send_chunked(conn, 200)

  receive do
    msg -> if Bandit.client_disconnect_message?(msg), do: raise("client went away")
  after
    30_000 -> :ok
  end

  # continue with the response...
end
```

## Why this is a value add

This PR aims to complete the disconnect handling by covering the one remaining window: a Plug that is computing or waiting, and not currently touching the socket. That window has grown in importance, because the workloads that live in it (server-sent events, LLM and upstream reverse proxies, long polls) have become everyday Elixir traffic. The tracker shows the same scenario coming up organically over time: [#344](https://github.com/mtrudel/bandit/issues/344), an [Elixir Forum thread](https://elixirforum.com/t/handling-client-disconnect-during-serversentevents-using-plug-with-bandit/57919) where your helpfully walked a user through the write-side signal, [#490](https://github.com/mtrudel/bandit/issues/490), and most recently [#630](https://github.com/mtrudel/bandit/issues/630) (Aug 2026), where a proxy author described relaying long upstream responses for clients that had already gone. There is clearly appetite for this, and your own incremental fixes suggest he cares about the scenario too; this PR just offers the next step.

On HTTP/2, the per-stream process model the you built in the 1.4.0 refactor gets this exactly right: a stream process is linked to its connection and sees `{:bandit, {:rst_stream, code}}` messages when a client cancels, so h2 plugs are never left working for a departed client. HTTP/1's single-process-per-connection design is a deliberate and successful choice (it is a big part of why Bandit's HTTP/1 engine benchmarks up to 4x Cowboy's, per the project's own CI), and the quiet tradeoff it makes is that nothing is reading the socket while a Plug runs. This PR keeps that design and its performance fully intact, and simply gives HTTP/1 plugs the same visibility their HTTP/2 siblings already enjoy, which also fits your stated principle from [PR #602](https://github.com/mtrudel/bandit/pull/602) that features should behave uniformly across HTTP versions. For what it's worth, Cowboy obtains the same property from its two-process-per-request model, at the cost of the extra process and message copying that Bandit's architecture intentionally avoids; this PR gets the property without paying that cost.

You mentioned once back in 2024 that "the single-function nature of the Plug API makes it impossible for a single-process-per-connection model such as Bandit to close connections eagerly." This PR agrees completely and does not attempt eager closing. Notification is a different and compatible thing: the disconnect becomes visible as a message, and what to do about it stays entirely in the application's hands, inside the Plug contract.

## Standards and protocol basis

This is server behavior rather than a wire-protocol feature, but it touches protocol correctness in two places, both handled. First, HTTP/1.1 connection reuse (RFC 9112 sections 9.3 and 9.6): any bytes the client sends while the socket is being watched are the start of the next pipelined request, and they are recovered into the read buffer so keepalive processing sees them exactly as if they had been read passively. Second, if a close or error was observed but the Plug did not consume the message, the connection is marked close-after-response so a finished connection is never reused. WebSocket upgrades (RFC 6455) are unaffected, covered by a regression test.

## Why this approach is pragmatic

The change is small because Bandit's architecture made it small. The `Bandit.HTTPTransport` protocol from the 1.4.0 refactor provides a clean seam for a cross-version concern, the option plumbing and buffer handling already exist, and the whole feature slots into them. The specific choices:

Opt-in, off by default. This changes the message-receiving environment of Plug processes (a `receive` loop written before this option existed could conceivably consume a socket message), and Bandit's performance discipline deserves protecting; nothing should be added to the default path. When off, the cost is one `Keyword.get` per request.

Arm only when there is nothing left to read. Erlang sockets in active mode and the passive `recv` calls used elsewhere in the module do not mix, so the socket is switched to `active: :once` only when the request body has been completely consumed, which is exactly when Bandit has no more reason to read. That happens at one of two points: at Plug invocation for bodyless requests (the SSE case), or the moment `read_data` consumes the final body byte, for both content-length and chunked bodies (the proxied POST case). This is why the option covers the #630 use case, where the Plug reads the body first and then waits on an upstream.

`active: :once`, never `active: true`. At most one data message can ever be delivered, so ordering between mailbox data and later passive reads stays trivially provable. The tradeoff is that notification is best-effort by nature: if a pipelined request arrives first and consumes the one shot, a subsequent close is discovered at the next socket touch, exactly as today. The docs say so plainly.

Disarm and recover before the response is committed. On the normal path, the pipeline returns the socket to passive mode and drains the mailbox: data messages are re-injected into the read buffer, close and error messages set `close_after_response`. The upgrade and error paths intentionally do not disarm; neither ever performs another passive read on the connection (the WebSocket handler consumes queued socket messages in arrival order through the standard active-mode path, and the error path closes), which is verified by tests.

Raw OTP messages plus a recognizer, rather than translated messages. The Plug runs in the handler process itself, so there is no intermediary that could rewrite `{:tcp_closed, _}` into something prettier while in flight. Instead of asking applications to know about `tcp_closed` vs `ssl_closed` vs h2's `{:bandit, {:rst_stream, _}}`, the `Bandit.client_disconnect_message?/1` helper owns that knowledge, and as a bonus gives HTTP/2 plugs the same contract with zero h2 changes.

The cross-version surface stays honest: `set_disconnect_notifications/2` is added to the internal `Bandit.HTTPTransport` protocol with a documented no-op for HTTP/2, since h2 stream processes already have both behaviors this option provides.