### PR TITLE
Validate HTTP/2 header field values for CR/LF/NUL (GHSA-x3gh-xhj4-3vq8)

### DIFF
--- a/lib/bandit/headers.ex
+++ b/lib/bandit/headers.ex
@@ -2,8 +2,33 @@ defmodule Bandit.Headers do
   @moduledoc false
   # Conveniences for dealing with headers.
 
+  @invalid_field_value_pattern_key {__MODULE__, :invalid_field_value_pattern}
+
   @spec is_port_number(integer()) :: Macro.t()
   defguardp is_port_number(port) when Bitwise.band(port, 0xFFFF) === port
+
+  # RFC9110§5.5 / RFC9113§8.2.1: field values containing CR, LF, or NUL characters
+  # are invalid and dangerous (a common request-smuggling / response-splitting /
+  # log-injection vector). Shared by both HTTP/1 and HTTP/2 so that neither
+  # transport can drift from the other's validation. The match pattern is
+  # compiled once (lazily, on first use) and cached in :persistent_term, since
+  # compiling it on every call is a measurable fraction of header parsing time.
+  @spec field_value_valid?(binary()) :: boolean()
+  def field_value_valid?(value) do
+    :binary.match(value, invalid_field_value_pattern()) == :nomatch
+  end
+
+  defp invalid_field_value_pattern do
+    case :persistent_term.get(@invalid_field_value_pattern_key, :undefined) do
+      :undefined ->
+        pattern = :binary.compile_pattern(["\r", "\n", "\0"])
+        :persistent_term.put(@invalid_field_value_pattern_key, pattern)
+        pattern
+
+      pattern ->
+        pattern
+    end
+  end
 
   @spec get_header(Plug.Conn.headers(), header :: binary()) :: binary() | nil
   def get_header(headers, header) do

--- a/lib/bandit/http1/socket.ex
+++ b/lib/bandit/http1/socket.ex
@@ -50,8 +50,6 @@ defmodule Bandit.HTTP1.Socket do
 
     @max_chunk_size_byte_count 16
 
-    @invalid_field_value_pattern_key {__MODULE__, :invalid_field_value_pattern}
-
     def peer_data(%@for{} = socket), do: Bandit.SocketHelpers.peer_data(socket.socket)
 
     def sock_data(%@for{} = socket), do: Bandit.SocketHelpers.sock_data(socket.socket)
@@ -188,28 +186,12 @@ defmodule Bandit.HTTP1.Socket do
       end
     end
 
-    # RFC9110§5.5: field values containing CR, LF, or NUL characters are invalid and
-    # dangerous (a common request-smuggling / response-splitting vector). The match
-    # pattern is compiled once (lazily, on first use) and cached in :persistent_term,
-    # since compiling it on every call is a measurable fraction of header parsing time.
     @spec validate_field_value!(binary()) :: :ok
     defp validate_field_value!(value) do
-      if :binary.match(value, invalid_field_value_pattern()) != :nomatch do
-        request_error!("Field value contains invalid characters (RFC9110§5.5)")
-      else
+      if Bandit.Headers.field_value_valid?(value) do
         :ok
-      end
-    end
-
-    defp invalid_field_value_pattern do
-      case :persistent_term.get(@invalid_field_value_pattern_key, :undefined) do
-        :undefined ->
-          pattern = :binary.compile_pattern(["\r", "\n", "\0"])
-          :persistent_term.put(@invalid_field_value_pattern_key, pattern)
-          pattern
-
-        pattern ->
-          pattern
+      else
+        request_error!("Field value contains invalid characters (RFC9110§5.5)")
       end
     end
 

--- a/lib/bandit/http2/stream.ex
+++ b/lib/bandit/http2/stream.ex
@@ -132,9 +132,11 @@ defmodule Bandit.HTTP2.Stream do
           exactly_one_instance_of!(pseudo_headers, ":scheme", stream)
           exactly_one_instance_of!(pseudo_headers, ":method", stream)
           exactly_one_instance_of!(pseudo_headers, ":path", stream)
+          at_most_one_instance_of!(pseudo_headers, ":authority", stream)
           headers_all_lowercase!(headers, stream)
           no_connection_headers!(headers, stream)
           valid_te_header!(headers, stream)
+          valid_field_values!(headers, stream)
           content_length = get_content_length!(headers, stream)
           headers = combine_cookie_crumbs(headers)
           stream = %{stream | bytes_remaining: content_length}
@@ -195,6 +197,13 @@ defmodule Bandit.HTTP2.Stream do
         do: stream_error!("Expected 1 #{header} headers", stream)
     end
 
+    # RFC9113§8.3 - a pseudo header field name (such as :authority, which is optional
+    # and so cannot use exactly_one_instance_of!/3) must not appear more than once
+    defp at_most_one_instance_of!(headers, header, stream) do
+      if Enum.count(headers, fn {key, _value} -> key == header end) > 1,
+        do: stream_error!("Expected at most 1 #{header} headers", stream)
+    end
+
     # RFC9113§8.2 - all headers name fields must be lowercsae
     defp headers_all_lowercase!(headers, stream) do
       if !Enum.all?(headers, fn {key, _value} -> lowercase?(key) end),
@@ -220,6 +229,13 @@ defmodule Bandit.HTTP2.Stream do
     defp valid_te_header!(headers, stream) do
       if Bandit.Headers.get_header(headers, "te") not in [nil, "trailers"],
         do: stream_error!("Received invalid TE header", stream)
+    end
+
+    # RFC9113§8.2.1 - field values containing CR, LF, or NUL characters are invalid and
+    # dangerous (a common request-smuggling / response-splitting / log-injection vector)
+    defp valid_field_values!(headers, stream) do
+      if Enum.any?(headers, fn {_key, value} -> not Bandit.Headers.field_value_valid?(value) end),
+        do: stream_error!("Field value contains invalid characters (RFC9113§8.2.1)", stream)
     end
 
     defp get_content_length!(headers, stream) do

--- a/test/bandit/http2/protocol_test.exs
+++ b/test/bandit/http2/protocol_test.exs
@@ -2321,6 +2321,93 @@ defmodule HTTP2ProtocolTest do
       assert msg == "** (Bandit.HTTP2.Errors.StreamError) Path does not start with /"
     end
 
+    @tag :capture_log
+    test "returns a stream error if multiple :authority pseudo headers are received", context do
+      socket = SimpleH2Client.setup_connection(context)
+
+      headers = [
+        {":method", "HEAD"},
+        {":path", "/"},
+        {":scheme", "https"},
+        {":authority", "localhost:#{context.port}"},
+        {":authority", "localhost:#{context.port}"}
+      ]
+
+      SimpleH2Client.send_headers(socket, 1, true, headers)
+
+      assert SimpleH2Client.recv_rst_stream(socket) == {:ok, 1, 1}
+
+      assert_receive {:log, %{level: :error, msg: {:string, msg}, meta: %{stream_id: 1}}}, 500
+      assert msg == "** (Bandit.HTTP2.Errors.StreamError) Expected at most 1 :authority headers"
+    end
+
+    @tag :capture_log
+    test "returns a stream error if a header value contains a bare CR (RFC9113§8.2.1)", context do
+      socket = SimpleH2Client.setup_connection(context)
+
+      headers = [
+        {":method", "GET"},
+        {":path", "/"},
+        {":scheme", "https"},
+        {":authority", "localhost:#{context.port}"},
+        {"x-foo", "a\rb"}
+      ]
+
+      SimpleH2Client.send_headers(socket, 1, true, headers)
+
+      assert SimpleH2Client.recv_rst_stream(socket) == {:ok, 1, 1}
+
+      assert_receive {:log, %{level: :error, msg: {:string, msg}, meta: %{stream_id: 1}}}, 500
+
+      assert msg ==
+               "** (Bandit.HTTP2.Errors.StreamError) Field value contains invalid characters (RFC9113§8.2.1)"
+    end
+
+    @tag :capture_log
+    test "returns a stream error if a header value contains a bare LF (RFC9113§8.2.1)", context do
+      socket = SimpleH2Client.setup_connection(context)
+
+      headers = [
+        {":method", "GET"},
+        {":path", "/"},
+        {":scheme", "https"},
+        {":authority", "localhost:#{context.port}"},
+        {"x-foo", "a\nx-injected: yes"}
+      ]
+
+      SimpleH2Client.send_headers(socket, 1, true, headers)
+
+      assert SimpleH2Client.recv_rst_stream(socket) == {:ok, 1, 1}
+
+      assert_receive {:log, %{level: :error, msg: {:string, msg}, meta: %{stream_id: 1}}}, 500
+
+      assert msg ==
+               "** (Bandit.HTTP2.Errors.StreamError) Field value contains invalid characters (RFC9113§8.2.1)"
+    end
+
+    @tag :capture_log
+    test "returns a stream error if a header value contains a NUL byte (RFC9113§8.2.1)",
+         context do
+      socket = SimpleH2Client.setup_connection(context)
+
+      headers = [
+        {":method", "GET"},
+        {":path", "/"},
+        {":scheme", "https"},
+        {":authority", "localhost:#{context.port}"},
+        {"x-foo", "a\0b"}
+      ]
+
+      SimpleH2Client.send_headers(socket, 1, true, headers)
+
+      assert SimpleH2Client.recv_rst_stream(socket) == {:ok, 1, 1}
+
+      assert_receive {:log, %{level: :error, msg: {:string, msg}, meta: %{stream_id: 1}}}, 500
+
+      assert msg ==
+               "** (Bandit.HTTP2.Errors.StreamError) Field value contains invalid characters (RFC9113§8.2.1)"
+    end
+
     test "combines Cookie headers per RFC9113§8.2.3", context do
       socket = SimpleH2Client.setup_connection(context)
 


### PR DESCRIPTION
Fixes https://github.com/mtrudel/bandit/security/advisories/GHSA-x3gh-xhj4-3vq8.

The fix in #620 was too narrow - being a constraint in RFC9110 it applies to both HTTP/1 and HTTP/2. This PR makes that so.