### PR TITLE
Bound and cancel HTTP/2 sends blocked on the connection window (GHSA-xj8g-532w-jv94)

### DIFF
--- a/lib/bandit/http2/connection.ex
+++ b/lib/bandit/http2/connection.ex
@@ -6,6 +6,11 @@ defmodule Bandit.HTTP2.Connection do
 
   require Logger
 
+  # A stream blocked on the connection send window is bounded by the same 15s that already
+  # bounds a block on the stream send window (`Bandit.HTTP2.Stream`'s `read_timeout`), so that
+  # neither path can pin a stream process (and any resources it holds) indefinitely.
+  @pending_send_timeout 15_000
+
   defstruct local_settings: %Bandit.HTTP2.Settings{},
             remote_settings: %Bandit.HTTP2.Settings{},
             fragment_frame: nil,
@@ -31,7 +36,9 @@ defmodule Bandit.HTTP2.Connection do
           send_window_size: non_neg_integer(),
           recv_window_size: non_neg_integer(),
           streams: Bandit.HTTP2.StreamCollection.t(),
-          pending_sends: [{Bandit.HTTP2.Stream.stream_id(), iodata(), boolean(), fun()}],
+          pending_sends: [
+            {Bandit.HTTP2.Stream.stream_id(), iodata(), boolean(), fun(), integer()}
+          ],
           conn_data: Bandit.Pipeline.conn_data(),
           telemetry_span: ThousandIsland.Telemetry.t(),
           plug: Bandit.Pipeline.plug_def(),
@@ -213,6 +220,14 @@ defmodule Bandit.HTTP2.Connection do
   def handle_frame(%Bandit.HTTP2.Frame.Priority{}, _socket, connection), do: connection
 
   def handle_frame(%Bandit.HTTP2.Frame.RstStream{} = frame, _socket, connection) do
+    # A stream blocked sending on the connection window is stuck inside a synchronous call to
+    # this connection process, so it cannot itself observe the message that deliver_rst_stream/2
+    # sends below; explicitly release any pending send for this stream so RST_STREAM actually
+    # frees the resources it pins instead of being silently queued until the block eventually
+    # clears (or never does).
+    connection =
+      purge_pending_send(connection, frame.stream_id, {:error, {:rst_stream, frame.error_code}})
+
     streams =
       with_stream(connection, frame.stream_id, fn stream ->
         Bandit.HTTP2.Stream.deliver_rst_stream(stream, frame.error_code)
@@ -343,9 +358,43 @@ defmodule Bandit.HTTP2.Connection do
     |> Enum.reverse()
     |> Enum.reduce(connection, fn pending_send, connection ->
       connection = connection |> Map.update!(:pending_sends, &List.delete(&1, pending_send))
-      {stream_id, rest, end_stream, on_unblock} = pending_send
+      {stream_id, rest, end_stream, on_unblock, _expires_at} = pending_send
       send_data(stream_id, [], rest, end_stream, on_unblock, socket, connection)
     end)
+  end
+
+  # Releases a queued pending send for `stream_id` (if any), replying to its blocked caller with
+  # `reply` instead of leaving it to be written later against a stream that may no longer exist.
+  @spec purge_pending_send(t(), Bandit.HTTP2.Stream.stream_id(), term()) :: t()
+  defp purge_pending_send(connection, stream_id, reply) do
+    case List.keytake(connection.pending_sends, stream_id, 0) do
+      nil ->
+        connection
+
+      {{_stream_id, _rest, _end_stream, on_unblock, _expires_at}, pending_sends} ->
+        on_unblock.(reply)
+        %{connection | pending_sends: pending_sends}
+    end
+  end
+
+  # Bounds how long a send can sit in pending_sends waiting on the connection send window. Called
+  # whenever data arrives on the connection (see `Bandit.HTTP2.Handler.handle_data/3`), so a
+  # client that only ever sends keepalive PINGs (defeating the transport-level read timeout)
+  # cannot pin a blocked stream's process, Plug state, and any resources it holds indefinitely.
+  @spec expire_pending_sends(t()) :: t()
+  def expire_pending_sends(connection) do
+    now = :erlang.monotonic_time(:millisecond)
+
+    {expired, live} =
+      Enum.split_with(connection.pending_sends, fn {_, _, _, _, expires_at} ->
+        expires_at <= now
+      end)
+
+    Enum.each(expired, fn {_stream_id, _rest, _end_stream, on_unblock, _expires_at} ->
+      on_unblock.({:error, :timeout})
+    end)
+
+    %{connection | pending_sends: live}
   end
 
   #
@@ -440,12 +489,17 @@ defmodule Bandit.HTTP2.Connection do
   end
 
   defp finish_data(_stream_id, <<>>, _end_stream, on_unblock, connection) do
-    on_unblock.()
+    on_unblock.(:ok)
     connection
   end
 
   defp finish_data(stream_id, rest, end_stream, on_unblock, connection) do
-    pending_sends = [{stream_id, rest, end_stream, on_unblock} | connection.pending_sends]
+    expires_at = :erlang.monotonic_time(:millisecond) + @pending_send_timeout
+
+    pending_sends = [
+      {stream_id, rest, end_stream, on_unblock, expires_at} | connection.pending_sends
+    ]
+
     %{connection | pending_sends: pending_sends}
   end
 
@@ -484,6 +538,16 @@ defmodule Bandit.HTTP2.Connection do
 
   @spec stream_terminated(pid(), t()) :: t()
   def stream_terminated(pid, connection) do
+    # If this stream had a pending send queued, its process is by definition the one that just
+    # exited (that's what an :EXIT for `pid` means), so there is no longer a live caller to hear
+    # the reply; the purge here is only to drop the queued bytes so they can't be written later
+    # against a stream nothing is running anymore. The reply value itself is never observed.
+    connection =
+      case Bandit.HTTP2.StreamCollection.get_stream_id(connection.streams, pid) do
+        nil -> connection
+        stream_id -> purge_pending_send(connection, stream_id, {:error, :closed})
+      end
+
     %{connection | streams: Bandit.HTTP2.StreamCollection.delete(connection.streams, pid)}
   end
 

--- a/lib/bandit/http2/handler.ex
+++ b/lib/bandit/http2/handler.ex
@@ -19,6 +19,12 @@ defmodule Bandit.HTTP2.Handler do
 
   @impl ThousandIsland.Handler
   def handle_data(data, socket, state) do
+    # Any inbound data (including PING keepalives that would otherwise defeat the transport-level
+    # read timeout) is an opportunity to release sends that have been queued too long waiting on
+    # the connection send window.
+    connection = Bandit.HTTP2.Connection.expire_pending_sends(state.connection)
+    state = %{state | connection: connection}
+
     (state.buffer <> data)
     |> Stream.unfold(
       &Bandit.HTTP2.Frame.deserialize(&1, state.connection.local_settings.max_frame_size)
@@ -78,7 +84,8 @@ defmodule Bandit.HTTP2.Handler do
     # In 'normal' cases where there is sufficient space in the send windows for this message to be
     # sent, Connection will call `unblock` synchronously in the `Connection.send_data` call below.
     # In cases where there is not enough space in the connection window, Connection will call
-    # `unblock` at some point in the future once space opens up in the window. This
+    # `unblock` at some point in the future once space opens up in the window, the queued send
+    # expires (Connection.expire_pending_sends/1), or the client resets the stream. This
     # keeps this code simple in that we can blindly send noreply here and let Connection handle
     # the separate cases. This ensures that we have backpressure all the way back to the
     # stream's handler process in the event of window overruns.
@@ -87,7 +94,7 @@ defmodule Bandit.HTTP2.Handler do
     # are managed internally by the stream and are not considered here at all. If the stream has
     # managed to send this message, it is because there was enough room in the stream's send
     # window to do so.
-    unblock = fn -> GenServer.reply(from, :ok) end
+    unblock = fn reply -> GenServer.reply(from, reply) end
 
     connection =
       Bandit.HTTP2.Connection.send_data(

--- a/lib/bandit/http2/stream.ex
+++ b/lib/bandit/http2/stream.ex
@@ -444,13 +444,25 @@ defmodule Bandit.HTTP2.Stream do
       stream =
         if stream.pending_headers != nil or end_stream or bytes_to_send > 0 do
           headers = stream.pending_headers || []
-          call(stream, {:send_data, headers, data_to_send, end_stream_to_send}, :infinity)
 
-          %{
-            stream
-            | pending_headers: nil,
-              send_window_size: stream.send_window_size - bytes_to_send
-          }
+          case call(stream, {:send_data, headers, data_to_send, end_stream_to_send}, :infinity) do
+            :ok ->
+              %{
+                stream
+                | pending_headers: nil,
+                  send_window_size: stream.send_window_size - bytes_to_send
+              }
+
+            {:error, :timeout} ->
+              stream_error!(
+                "Timeout waiting for space in the connection send_window",
+                stream,
+                Bandit.HTTP2.Errors.flow_control_error()
+              )
+
+            {:error, {:rst_stream, error_code}} ->
+              do_recv_rst_stream!(stream, error_code)
+          end
         else
           stream
         end

--- a/lib/bandit/http2/stream_collection.ex
+++ b/lib/bandit/http2/stream_collection.ex
@@ -41,6 +41,9 @@ defmodule Bandit.HTTP2.StreamCollection do
     end
   end
 
+  @spec get_stream_id(t(), pid()) :: Bandit.HTTP2.Stream.stream_id() | nil
+  def get_stream_id(collection, pid), do: Map.get(collection.pid_to_id, pid)
+
   @spec insert(t(), Bandit.HTTP2.Stream.stream_id(), pid()) :: t()
   def insert(collection, stream_id, pid) do
     %__MODULE__{

--- a/test/bandit/http2/protocol_test.exs
+++ b/test/bandit/http2/protocol_test.exs
@@ -1762,6 +1762,116 @@ defmodule HTTP2ProtocolTest do
     end
   end
 
+  # GHSA-xj8g-532w-jv94: a stream blocked writing against the *connection* send window used to
+  # sit in a `GenServer.call(connection_pid, ..., :infinity)` that neither RST_STREAM nor any
+  # timeout could release, pinning the stream process (and any resources its Plug held) forever.
+  describe "connection send window blocking (GHSA-xj8g-532w-jv94)" do
+    setup do
+      Process.register(self(), __MODULE__)
+      :ok
+    end
+
+    def blocking_test(conn) do
+      data = String.duplicate("a", 10_000)
+
+      send(__MODULE__, {:plug_ready, self()})
+      receive do: (:go -> :ok)
+
+      conn = send_chunked(conn, 200)
+
+      conn =
+        Enum.reduce(1..6, conn, fn _i, conn ->
+          {:ok, conn} = chunk(conn, data)
+          conn
+        end)
+
+      send(__MODULE__, {:blocking_chunk_started, self()})
+
+      case chunk(conn, data) do
+        {:ok, conn} ->
+          send(__MODULE__, {:blocking_chunk_returned, self()})
+          conn
+
+        {:error, reason} ->
+          send(__MODULE__, {:blocking_chunk_error, self(), reason})
+          conn
+      end
+    end
+
+    # Grants a generous stream-level window (so the default 65_535 byte connection window is the
+    # one that ends up blocking) and drives the plug until it is stuck mid-write, with 4_465 bytes
+    # of its 7th 10_000 byte chunk still unsent
+    defp start_blocked_stream(socket, context) do
+      SimpleH2Client.send_simple_headers(socket, 1, :get, "/blocking_test", context[:port])
+
+      assert_receive {:plug_ready, plug_pid}, 1_000
+
+      SimpleH2Client.send_window_update(socket, 1, 1_000_000)
+
+      # The window update is only observable once the plug produces frames, so let the connection
+      # process apply it before any body is written
+      Process.sleep(100)
+      send(plug_pid, :go)
+
+      assert SimpleH2Client.successful_response?(socket, 1, false)
+      Enum.each(1..6, fn _i -> SimpleH2Client.recv_body(socket) end)
+      assert {:ok, 1, false, chunk} = SimpleH2Client.recv_body(socket)
+      assert byte_size(chunk) == 5_535
+
+      assert_receive {:blocking_chunk_started, ^plug_pid}, 1_000
+      refute_receive {:blocking_chunk_returned, ^plug_pid}, 500
+
+      plug_pid
+    end
+
+    @tag :capture_log
+    test "RST_STREAM releases a stream blocked on the connection send window", context do
+      context = https_server(context, thousand_island_options: [read_timeout: 2_000])
+      socket = SimpleH2Client.setup_connection(context)
+
+      plug_pid = start_blocked_stream(socket, context)
+      ref = Process.monitor(plug_pid)
+
+      SimpleH2Client.send_rst_stream(socket, 1, Bandit.HTTP2.Errors.cancel())
+
+      assert_receive {:blocking_chunk_error, ^plug_pid, :closed}, 1_000
+      assert_receive {:DOWN, ^ref, :process, ^plug_pid, _reason}, 1_000
+    end
+
+    @tag :slow
+    @tag :capture_log
+    @tag timeout: 120_000
+    test "a stream blocked on the connection send window is eventually released even when kept alive by PINGs",
+         context do
+      context = https_server(context, thousand_island_options: [read_timeout: 2_000])
+      socket = SimpleH2Client.setup_connection(context)
+
+      plug_pid = start_blocked_stream(socket, context)
+      ref = Process.monitor(plug_pid)
+
+      # Well past the timeout that now bounds a connection-window block; a send-only keepalive so
+      # we don't consume the frame the final assertion below relies on
+      ping_until(socket, 16_000)
+
+      assert_receive {:blocking_chunk_error, ^plug_pid,
+                      "Timeout waiting for space in the connection send_window"},
+                     1_000
+
+      assert_receive {:DOWN, ^ref, :process, ^plug_pid, _reason}, 1_000
+    end
+
+    defp ping_until(socket, duration) do
+      deadline = System.monotonic_time(:millisecond) + duration
+
+      Stream.repeatedly(fn ->
+        SimpleH2Client.send_frame(socket, 6, 0, 0, <<1, 2, 3, 4, 5, 6, 7, 8>>)
+        Process.sleep(250)
+        System.monotonic_time(:millisecond)
+      end)
+      |> Enum.find(&(&1 >= deadline))
+    end
+  end
+
   describe "HEADERS frames" do
     test "sends non-end of stream headers when there is a body", context do
       socket = SimpleH2Client.setup_connection(context)


### PR DESCRIPTION
## Summary

Fixes https://github.com/mtrudel/bandit/security/advisories/GHSA-xj8g-532w-jv94.

I validated the report's claims against `main` before writing a fix: `Stream.send_data/3` really does call `GenServer.call(connection_pid, {:send_data, ...}, :infinity)`, the reply for a connection-window-blocked send really is only fired later via `Connection.pending_sends`/`do_pending_sends/2`, `stream_terminated/2` really doesn't touch `pending_sends`, and `handle_frame(%RstStream{}, ...)` really only `send/2`s to the blocked stream's mailbox — which it can't read while stuck inside the synchronous call. So a client can hold a stream (and any resources its Plug holds, e.g. a pooled upstream connection) open indefinitely by exhausting the connection send window, never sending a connection-level WINDOW_UPDATE, and keeping the connection alive with periodic PINGs, which don't touch `pending_sends` and so don't unblock anything.

I did diverge from the report's suggested fix in one place: the report's own "contrast" test expects `chunk/2` to *return* `{:error, reason}` for the pre-existing stream-window-timeout path, but that path actually *raises* (`stream_error!`), and it's `Bandit.Adapter.chunk/2`'s own `rescue` that turns any raise into an `{:error, reason}` tuple for the Plug. So both new failure modes here (timeout, RST_STREAM) raise through the same existing mechanism rather than needing new plumbing.

## Fix

- `handle_frame(%RstStream{}, ...)` now purges and replies to any pending send for that stream directly, from the same connection process that already owns both the incoming RST_STREAM and `pending_sends` — this closes the "cancel frees nothing" gap deterministically rather than waiting on a timeout.
- Every `pending_sends` entry now carries a deadline, matching the 15s that already bounds a block on the *stream* window (`Bandit.HTTP2.Stream`'s `read_timeout`). `Bandit.HTTP2.Handler.handle_data/3` sweeps expired entries on every inbound read (frame parsing included), so a client that only ever sends PING keepalives can no longer defeat it.
- `stream_terminated/2` now also purges any pending send left behind by a stream process that exited some other way, so stale bytes can't later be flushed onto the wire for a stream nothing is running anymore.

Both new failure modes reuse the stream's existing error paths (`stream_error!` with `FLOW_CONTROL_ERROR` for the timeout, `do_recv_rst_stream!` for the reset) rather than inventing new ones, so behavior downstream of the block (RST_STREAM sent to the client, process teardown, logging) matches what already happens for the analogous stream-window case.

Deliberately left out, per the report's own "consider" framing: capping total queued bytes/entries per connection. That's a reasonable follow-up hardening step but is a separate, non-blocking concern from the two gaps that make the primitive unbounded today.

## Test plan
- [x] New tests adapted from the report's PoC: RST_STREAM deterministically releases a stream blocked on the connection window (~1s); the same block is now released even under PING-only keepalive that outlives the transport read timeout (`:slow`, ~16s)
- [x] `mix test --exclude slow` (809 tests) and `mix test --include slow` (814 tests) — only pre-existing, unrelated failures (a flaky WINDOW_UPDATE test that fails identically on unmodified `main`, and the Autobahn suite which needs Docker)
- [x] `mix credo --strict` clean
- [x] `mix dialyzer` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)