### PR TITLE
Fix recent releases changelog headings in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,7 +121,7 @@ https://thousand-island.hexdocs.pm/changelog.html#1-5-0-1-jun-2026)
   which defines the maximum allowed WebSocket frame size (inclusive of
   continuation frames). Defaults to 8MB
 
-# Changes
+### Changes
 
 * The default value of the `max_frame_size` WebSocket option has changed from `:infinity` to 8MB
 * Zero length non-fin continuation frames are now disallowed (we now skip Autobahn 6.1.2 as a result)
@@ -650,18 +650,18 @@ sent in HTTP/2 (#483)
 
 ## 1.0.0-pre.12 (12 Aug 2023)
 
-## Fixes
+### Fixes
 
 * Bump ThousandIsland to 1.0.0-pre.7 to fix leaking file descriptors on
   `Plug.Conn.sendfile/5` calls (thanks @Hermanverschooten!)
 
 ## 1.0.0-pre.11 (11 Aug 2023)
 
-## Changes
+### Changes
 
 * **BREAKING CHANGE** Move `conn` value in telemetry events from measurements to metadata
 
-## Enhancements
+### Enhancements
 
 * Add `method`, `request_target` and `status` fields to telemetry metadata on HTTP stop events
 * Improve RFC compliance regarding cache-related headers on deflated responses (#207, thanks @tanguilp!)
@@ -671,20 +671,20 @@ sent in HTTP/2 (#483)
 
 ## 1.0.0-pre.10 (28 Jun 2023)
 
-## Enhancements
+### Enhancements
 
 * Add support for `Plug.Conn.inform/3` on HTTP/1 connections (#180)
 * Add support for h2c upgrades (#186, thanks @alisinabh!)
 * Internal refactoring of HTTP/1 content-length encoded body reads (#184, #190,
   thanks @asakura & @moogle19!)
 
-## Changes
+### Changes
 
 * Bump Thousand Island to 1.0.0-pre.6 (gaining support for suspend/resume API)
 * Drop Elixir 1.12 as a supported target (it should continue to work, but is no
   longer covered by CI)
 
-## Fixes
+### Fixes
 
 * Fix crash when Plug used `Plug.Conn.get_peer_data/1` function on HTTP/1
   connections (#170, thanks @moogle19!)
@@ -693,33 +693,33 @@ sent in HTTP/2 (#483)
 
 ## 1.0.0-pre.9 (16 Jun 2023)
 
-## Changes
+### Changes
 
 * Use new ThousandIsland APIs for socket info (#167, thanks @asakura!)
 
-## Fixes
+### Fixes
 
 * Handle nil connection close reason when closing a WebSocket
 
 ## 1.0.0-pre.8 (15 Jun 2023)
 
-## Fixes
+### Fixes
 
 * Further improve logging on WebSocket upgrade errors (#149)
 
 ## 1.0.0-pre.7 (14 Jun 2023)
 
-## Enhancements
+### Enhancements
 
 * Refactor HTTP/1 read routines (#158 & #166, thanks @asakura!)
 * Improve logging on WebSocket upgrade errors (#149)
 
-## Changes
+### Changes
 
 * Override any content-length headers that may have been set by Plug (#165)
 * Send content-length on HTTP/2 responses where appropriate (#165)
 
-## Fixes
+### Fixes
 
 * Send correct content-length header when sending deflated response (#151)
 * Do not attempt to deflate if Plug sends a content-encoding header (#165)
@@ -922,7 +922,7 @@ sent in HTTP/2 (#483)
 * Fix parsing of host / request headers which contain IPv6 addresses (#97).
   Thanks @derekkraan!
 
-# Changes
+### Changes
 
 * Use Plug's list of response code reason phrases (#96). Thanks @jclem!
 * Minor doc updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.12.5 (20 Aug 2026)
+## 1.12.5 (20 Aug 2026)
 
 ### Changes
 
@@ -29,7 +29,7 @@
 * Keep track of body_length to avoid list iterations (#645)
 * Avoid per-header length/1 and option lookups in do_read_headers! (#614) (#626)
 
-# 1.12.4 (27 July 2026)
+## 1.12.4 (27 July 2026)
 
 ### Fixes
 
@@ -46,13 +46,13 @@
 * Tolerate a leading newline on HTTP/1 requests (#622)
 * Send "100 Continue" interim response before reading body if client requests it (#624)
 
-# 1.12.3 (25 July 2026)
+## 1.12.3 (25 July 2026)
 
 ### Enhancements
 
 * Cache connection-level data between HTTP/1 keepalives (#603, thanks @preciz!)
 
-# 1.12.2 (25 July 2026)
+## 1.12.2 (25 July 2026)
 
 ### Enhancements
 
@@ -71,13 +71,13 @@
   (https://github.com/mtrudel/bandit/security/advisories/GHSA-9q5m-g6v3-6772,
   thanks @lukaszsamson!)
 
-# 1.12.1 (24 July 2026)
+## 1.12.1 (24 July 2026)
 
 ### Fixes
 
 * Fix DoS issue with fragmented WebSocket frames (CVE-2026-65623, thanks @PJUllrich!)
 
-# 1.12.0 (5 June 2026)
+## 1.12.0 (5 June 2026)
 
 ### Changes
 
@@ -93,7 +93,7 @@ https://thousand-island.hexdocs.pm/changelog.html#1-5-0-1-jun-2026)
 
 * Internal improvements to HTTP/1 body read functions (#588)
 
-# 1.11.1 (13 May 2026)
+## 1.11.1 (13 May 2026)
 
 ### Fixes
 
@@ -104,7 +104,7 @@ https://thousand-island.hexdocs.pm/changelog.html#1-5-0-1-jun-2026)
 
 * We no longer disallow `.` and `..` path components in HTTP/2 absolute paths (#581)
 
-# 1.11.0 (1 May 2026)
+## 1.11.0 (1 May 2026)
 
 ### Fixes
 


### PR DESCRIPTION
<img width="303" height="397" alt="Screenshot 2026-08-21 at 10 26 52" src="https://github.com/user-attachments/assets/bc72de99-7bea-4393-94fd-8eb42308a3da" />

It seems ex_doc / hexdocs doesn't link changelog headings in the sidebar if they are h1 instead of h2.

This change fixes it for recent changelog entries.