### PR TITLE
Drain HTTP/2 pending sends without repeated List.delete/2

### DIFF
--- a/lib/bandit/http2/connection.ex
+++ b/lib/bandit/http2/connection.ex
@@ -356,8 +356,7 @@ defmodule Bandit.HTTP2.Connection do
   defp do_pending_sends(socket, connection) do
     connection.pending_sends
     |> Enum.reverse()
-    |> Enum.reduce(connection, fn pending_send, connection ->
-      connection = connection |> Map.update!(:pending_sends, &List.delete(&1, pending_send))
+    |> Enum.reduce(%{connection | pending_sends: []}, fn pending_send, connection ->
       {stream_id, rest, end_stream, on_unblock, _expires_at} = pending_send
       send_data(stream_id, [], rest, end_stream, on_unblock, socket, connection)
     end)


### PR DESCRIPTION
Note: Claude helped with the testing and PR desc.

Summary: Clear the HTTP/2 pending-send queue once before replaying it, instead of deleting each entry from the list immediately before retrying that entry.

This changes queue maintenance from quadratic to linear time while preserving the existing send order, flow-control behavior, callbacks, and timeout handling.

## Problem

`pending_sends` is stored in reverse insertion order. When the connection send window opens, `do_pending_sends/2` reverses the queue to process it in FIFO order.

The current reduction also calls `List.delete/2` for every pending send. Each deletion scans the remaining queue, so draining `n` entries performs `O(n^2)` list work. A connection with many flow-control-blocked streams can therefore spend substantial CPU on queue bookkeeping in addition to socket I/O.

## Change

Start the reduction with an otherwise unchanged connection whose `pending_sends` list is empty:

```diff
- |> Enum.reduce(connection, fn pending_send, connection ->
+ |> Enum.reduce(%{connection | pending_sends: []}, fn pending_send, connection ->
```

Each pending send is still retried through the existing `send_data/7` path. If it cannot be completed, that function puts the remainder back into `pending_sends` as it does today.

## Performance

An isolated benchmark of the drain's list handling, with a send stub that requeues a configurable fraction of entries, measured on Erlang/OTP 27.3.4.9 and Elixir 1.18.4 on a 2-CPU x86_64 Linux container:

| Pending sends | Requeued | Before | After | Speedup | | ---: | ---: | ---: | ---: | ---: |
| 100 | 0% | 90.5 us | 3.3 us | 27x |
| 100 | 30% | 113.8 us | 3.4 us | 33x |
| 1,000 | 0% | 9.88 ms | 35.2 us | 280x |
| 1,000 | 30% | 12.85 ms | 35.0 us | 367x |
| 5,000 | 0% | 404.6 ms | 258.4 us | 1,566x |
| 5,000 | 30% | 541.1 ms | 345.7 us | 1,565x |

Scheduler reductions show the same change in scaling:

| Pending sends | Before | After |
| ---: | ---: | ---: |
| 1,000 | 1,033,076 | 5,827 |
| 5,000 | 25,527,607 | 20,093 |

This benchmark deliberately isolates list maintenance. It does not include network I/O, so the result should be read as the CPU cost removed from a drain, not as an end-to-end request latency claim.

## Correctness

The observable behavior is unchanged:

- `Enum.reverse/1` still establishes FIFO retry order.
- The existing queue is cleared once before the retry loop, which is equivalent to removing every current item once.
- `send_data/7` still requeues any unsent remainder, including its stream ID, end-stream flag, callback, and expiry handling.
- Completed sends still invoke their existing unblock callback.
- Entries requeued during the reduction retain the same order for the next drain. Tracing both versions by hand and checking 15 size and requeue-fraction combinations programmatically produced identical residual queues, order included.
- Existing stream reset, expiry, and purge paths continue to operate on `pending_sends` without modification.
- No code on the drain path raises: requeued entries re-enter `send_data/7` with an empty header list, so no HPAX encoding runs, and socket write results are intentionally not matched here (failures surface on the next read, as today). The two versions therefore cannot diverge on exception-time state either.

## Tests

On Erlang/OTP 27.3.4.9 and Elixir 1.18.4, the default non-slow run reports 811 tests, 4 excluded by the `:slow` tag, 1 skipped, and 1 failure. The single failure is the pre-existing `:inet6` bind test, which fails identically on the unpatched baseline because the build container has no IPv6 stack.

The following checks also pass:

```text
mix format --check-formatted
MIX_ENV=test mix compile --warnings-as-errors --force
MIX_ENV=test mix credo --strict
```