### PR TITLE
Unroll WebSocket masking over 32-byte blocks

### DIFF
--- a/lib/bandit/primitive_ops/websocket.ex
+++ b/lib/bandit/primitive_ops/websocket.ex
@@ -17,6 +17,29 @@ defmodule Bandit.PrimitiveOps.WebSocket do
     ws_mask(<<>>, payload, mask)
   end
 
+  defp ws_mask(
+         acc,
+         <<a::32, b::32, c::32, d::32, e::32, f::32, g::32, h::32, rest::binary>>,
+         mask
+       ) do
+    ws_mask(
+      <<acc::binary, Bitwise.bxor(a, mask)::32, Bitwise.bxor(b, mask)::32,
+        Bitwise.bxor(c, mask)::32, Bitwise.bxor(d, mask)::32, Bitwise.bxor(e, mask)::32,
+        Bitwise.bxor(f, mask)::32, Bitwise.bxor(g, mask)::32, Bitwise.bxor(h, mask)::32>>,
+      rest,
+      mask
+    )
+  end
+
+  defp ws_mask(acc, <<a::32, b::32, c::32, d::32, rest::binary>>, mask) do
+    ws_mask(
+      <<acc::binary, Bitwise.bxor(a, mask)::32, Bitwise.bxor(b, mask)::32,
+        Bitwise.bxor(c, mask)::32, Bitwise.bxor(d, mask)::32>>,
+      rest,
+      mask
+    )
+  end
+
   defp ws_mask(acc, <<h::32, rest::binary>>, mask) do
     ws_mask(<<acc::binary, (<<Bitwise.bxor(h, mask)::32>>)>>, rest, mask)
   end

--- a/test/bandit/primitive_ops/websocket_test.exs
+++ b/test/bandit/primitive_ops/websocket_test.exs
@@ -1,0 +1,26 @@
+defmodule Bandit.PrimitiveOps.WebSocketTest do
+  use ExUnit.Case, async: true
+
+  alias Bandit.PrimitiveOps.WebSocket
+
+  test "matches the RFC 6455 masking example" do
+    assert WebSocket.ws_mask("Hello", 0x37FA213D) == <<0x7F, 0x9F, 0x4D, 0x51, 0x58>>
+  end
+
+  test "masks payloads across optimized chunk boundaries" do
+    for mask_integer <- [0, 1, 0x01020304, 0x80000000, 0xFFFFFFFF], size <- 0..65 do
+      mask = <<mask_integer::32>>
+      payload = :binary.copy(<<0x01>>, size)
+
+      expected =
+        payload
+        |> :binary.bin_to_list()
+        |> Enum.with_index()
+        |> Enum.map(fn {byte, index} -> Bitwise.bxor(byte, :binary.at(mask, rem(index, 4))) end)
+        |> :binary.list_to_bin()
+
+      assert WebSocket.ws_mask(payload, mask_integer) == expected
+      assert WebSocket.ws_mask(expected, mask_integer) == payload
+    end
+  end
+end


### PR DESCRIPTION
This might need better documentation in the code to explain what's going on, and if you'd like that (or anything else changed) - please let me know.

Summary: Process WebSocket masking in 32-byte blocks, with a 16-byte fallback before the existing 4-byte and trailing-byte clauses. This reduces recursive calls and binary append operations in a hot path while preserving the existing API and byte-for-byte output.

## Problem

RFC 6455 requires every client-to-server WebSocket payload to be unmasked. The current implementation handles 4 bytes per recursive call, so a 1 MiB frame takes more than 262,000 iterations through the main masking clause. This creates substantial function call, pattern matching, binary construction, and scheduler reduction overhead for larger frames.

## Change

Add two clauses to `Bandit.PrimitiveOps.WebSocket.ws_mask/3`:

* A 32-byte clause that XORs eight 32-bit words per iteration.
* A 16-byte clause that XORs four 32-bit words before falling back to the existing logic.

The implementation deliberately keeps each XOR at 32 bits. Using 64-bit unsigned words can create boxed integers on the BEAM and give back part of the gain this change is intended to capture.

An alternative worth recording: `:crypto.exor/2` against a repeated mask binary would likely be faster still for large frames, but it runs as a single uninterruptible NIF call, so a multi-megabyte frame would occupy a scheduler for its full duration. The pure Elixir loop stays reduction-counted and preemptible, which is the safer default for a general-purpose server.

## Performance

Measured on Bandit 1.12.5 at commit `9571499`, Erlang/OTP 27.3.4.9, Elixir 1.18.4, on a 2-CPU x86_64 Linux container. Medians of 5 interleaved samples of 200,000 iterations each for small sizes, and proportionally fewer iterations for large sizes:

| Payload | Baseline | Patch | Change |
| ---: | ---: | ---: | ---: |
| 8 B | 156 ns | 152 ns | within noise |
| 32 B | 236 ns | 185 ns | -21% |
| 125 B | 472 ns | 259 ns | -45% |
| 512 B | 1.48 us | 0.56 us | -62% |
| 16 KiB | 43.7 us | 12.6 us | -71% |
| 64 KiB | 190.5 us | 50.7 us | -73% |
| 1 MiB | 3,023.7 us | 980.5 us | -68% |

Payloads at or below 20 bytes are unchanged within measurement noise, which is expected: the two new clauses fail their size checks once each and the original clauses do the work.

Scheduler reductions for a 1 MiB payload fell from 262,977 to 34,045, which is 7.72 times fewer. The operation remains reduction-accounted and preemptible by the scheduler.

## Correctness

The masking operation and public primitive API are unchanged. New tests verify the published [RFC 6455 masking example](https://www.rfc-editor.org/rfc/rfc6455.html#section-5.3), payload sizes from 0 through 65 bytes across every optimized boundary, masks including `0x00000000` and `0xFFFFFFFF`, and the masking involution property.

Beyond the shipped tests, this change was validated with a differential fuzz of 1,463 cases comparing the new implementation against both the previous implementation and an independent byte-at-a-time reference written directly from RFC 6455 section 5.3: payload sizes 0 through 200 plus larger sizes up to 1 MiB plus one byte, across 7 masks including both edge masks, with the involution property asserted for every case. Zero mismatches.

Custom primitive implementations are unaffected.

## Tests

The new unit tests live at `test/bandit/primitive_ops/websocket_test.exs`, mirroring the module's path under `lib/`.

On Erlang/OTP 27.3.4.9 and Elixir 1.18.4, the default non-slow run reports 813 tests (the repository's 811 plus these 2), 4 excluded by the `:slow` tag, 1 skipped, and 1 failure. The single failure is the pre-existing `:inet6` bind test, which fails identically on the unpatched baseline because the build container has no IPv6 stack.

The following checks also pass:

```text
mix format --check-formatted
MIX_ENV=test mix compile --warnings-as-errors --force
MIX_ENV=test mix credo --strict