### PR TITLE
Don't compress 206 Partial Content responses

### DIFF
--- a/lib/bandit/compression.ex
+++ b/lib/bandit/compression.ex
@@ -77,7 +77,10 @@ defmodule Bandit.Compression do
 
     headers = maybe_add_vary_header(adapter, status, headers)
 
-    if status not in [204, 304] && not is_nil(adapter.content_encoding) &&
+    # 206 responses are excluded since compressing them would change the bytes relative to the
+    # content-range the response advertises against the identity representation, corrupting
+    # range reassembly at the client
+    if status not in [204, 206, 304] && not is_nil(adapter.content_encoding) &&
          is_nil(response_content_encoding_header) &&
          !response_has_strong_etag(headers) && !response_indicates_no_transform(headers) &&
          !empty_body? do

--- a/test/bandit/http1/protocol_test.exs
+++ b/test/bandit/http1/protocol_test.exs
@@ -1992,6 +1992,21 @@ defmodule HTTP1ProtocolTest do
       assert response.body == String.duplicate("a", 10_000)
     end
 
+    test "does no encoding for 206 responses", context do
+      response =
+        Req.get!(context.req,
+          url: "/send_206_response",
+          headers: [{"accept-encoding", "deflate"}]
+        )
+
+      # Assert that we did not try to compress the body, since doing so would
+      # invalidate the range the response advertises via content-range
+      assert response.status == 206
+      assert response.headers["content-length"] == ["10000"]
+      assert response.headers["content-encoding"] == nil
+      assert response.body == String.duplicate("a", 10_000)
+    end
+
     test "does no encoding if a malformed etag starting with W but not W/ is present", context do
       response =
         Req.get!(context.req,
@@ -2214,6 +2229,12 @@ defmodule HTTP1ProtocolTest do
       conn
       |> put_resp_header("etag", "\"1234\"")
       |> send_resp(200, String.duplicate("a", 10_000))
+    end
+
+    def send_206_response(conn) do
+      conn
+      |> put_resp_header("content-range", "bytes 0-9999/20000")
+      |> send_resp(206, String.duplicate("a", 10_000))
     end
 
     def send_weak_etag(conn) do


### PR DESCRIPTION
## The problem

`Bandit.Compression.new/5` suppresses response compression for status 204/304,
an existing `content-encoding`, a strong etag, `cache-control: no-transform`,
and empty bodies, but not for 206 Partial Content.

A plug that implements Range requests itself (custom static file serving, say)
sends a 206 whose `Content-Range: bytes 0-99/1000` refers to byte positions in
the identity representation. Bandit then gzip/deflate/zstd encodes the
100 byte slice and rewrites `content-length`, so the bytes on the wire no
longer correspond to the advertised range. A client that resumes a download by
stitching ranges together reassembles a corrupted file; intermediaries caching
ranges get poisoned entries.

[RFC 9110 §14.1.2](https://www.rfc-editor.org/rfc/rfc9110.html#name-byte-ranges) pins ranges to the representation as encoded:

> If the representation data has a content coding applied, each byte range is
> calculated with respect to the encoded sequence of bytes, not the sequence
> of underlying bytes that would be obtained after decoding.

Compressing an already-sliced identity range inverts that: the response's
`content-range` describes offsets in a byte sequence that is not the one
transmitted. Per [§15.3.7](https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.7), `content-length` must be the transmitted partial
length while `content-range` carries the selected representation's totals
after on the fly compression the two describe different representations.

## Why it hasn't been noticed

`Plug.Static` (the most common source of 206s) sets a strong etag, which
already suppresses compression via the etag guard masking the problem for
the common case. Any plug serving ranges without a strong etag is exposed.
When Plug gained Range support (elixir-plug/plug#523/#526) it was a
deliberately minimal single-range implementation, and the compression
interplay wasn't part of that work. The server is the natural place to
guard it, consistent with the existing set of targeted "don't compress when X"
guards this code has accumulated (#605, #657, #658).

This also matches broader server practice:

- nginx's gzip filter compresses only an explicit status allowlist of
  200/403/404 (the status check at the top of `ngx_http_gzip_header_filter` in
  [`ngx_http_gzip_filter_module.c`](https://github.com/nginx/nginx/blob/master/src/http/modules/ngx_http_gzip_filter_module.c)),
  and when it does compress it also calls `ngx_http_clear_accept_ranges` 
  treating compression and byte ranges as mutually exclusive in both
  directions;
- [klauspost/gzhttp](https://github.com/klauspost/compress/tree/master/gzhttp)
  (which Traefik's compress middleware is built on, since
  [traefik#8245](https://github.com/traefik/traefik/pull/8245)) is blunter
  still, its docs read "Ranged requests are not well supported with
  compression. Therefore any request with a 'Content-Range' header is not
  compressed", and it strips `Accept-Ranges` from responses it does compress.

## The fix

Add `206` to the excluded statuses in the compression guard, with a comment
explaining why.

The exclusion costs essentially nothing: content typically served via ranges
(video, PDF, archives, images) is already internally compressed. And the one
*legitimate* compressed range pattern, serving byte ranges over a stable,
precompressed representation is unaffected, since a plug doing that sets
`content-encoding` on its response, which the existing
`response_content_encoding_header` guard already respects. This change closes
only the incorrect path.

## Tests

New test "does no encoding for 206 responses" alongside the existing
skip compression tests: a plug replies 206 + `content-range` to a request with
`accept-encoding: deflate`; asserts the body comes back identity-encoded at
its original length with no `content-encoding` header. Before this change the
test fails with the 10,000-byte body deflated down to 40 bytes and
`content-length` rewritten to `40` while `content-range` still advertises
`bytes 0-9999/20000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)