### PR TITLE
Don't treat max_inflate_ratio as a permessage deflate wire parameter

### DIFF
--- a/lib/bandit/websocket/permessage_deflate.ex
+++ b/lib/bandit/websocket/permessage_deflate.ex
@@ -21,7 +21,12 @@ defmodule Bandit.WebSocket.PerMessageDeflate do
             deflate_context: nil,
             max_inflate_ratio: nil
 
-  @valid_params ~w[server_no_context_takeover client_no_context_takeover server_max_window_bits client_max_window_bits max_inflate_ratio]
+  # The four extension parameters defined by RFC7692§7. Note that max_inflate_ratio is a
+  # Bandit-internal option (sourced from server config in init/2), NOT a wire parameter:
+  # including it here would both accept it in client offers and echo it back in the
+  # handshake response, and RFC7692§7 forbids a server from including parameters not
+  # defined for the extension
+  @valid_params ~w[server_no_context_takeover client_no_context_takeover server_max_window_bits client_max_window_bits]
 
   def negotiate(requested_extensions, opts) do
     :proplists.get_all_values("permessage-deflate", requested_extensions)

--- a/test/bandit/websocket/http1_handshake_test.exs
+++ b/test/bandit/websocket/http1_handshake_test.exs
@@ -274,6 +274,31 @@ defmodule WebSocketHTTP1HandshakeTest do
       refute Keyword.get(headers, :"sec-websocket-extensions")
     end
 
+    test "declines permessage-deflate offers containing the internal max_inflate_ratio option",
+         context do
+      client = SimpleWebSocketClient.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "GET", "/compress", [
+        "Host: server.example.com",
+        "Upgrade: WeBsOcKeT",
+        "Connection: UpGrAdE",
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+        "Sec-WebSocket-Version: 13",
+        "Sec-WebSocket-Extensions: permessage-deflate;max_inflate_ratio=5"
+      ])
+
+      assert {:ok, "101 Switching Protocols", headers, <<>>} =
+               SimpleHTTP1Client.recv_reply(client)
+
+      assert Keyword.get(headers, :upgrade) == "websocket"
+      assert Keyword.get(headers, :connection) == "Upgrade"
+      assert Keyword.get(headers, :"sec-websocket-accept") == "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="
+
+      # max_inflate_ratio is a Bandit config option, not an RFC7692 extension parameter;
+      # an offer containing it is declined (and it must never be echoed in the response)
+      refute Keyword.get(headers, :"sec-websocket-extensions")
+    end
+
     test "does not negotiate permessage-deflate if the client sends repeat option values",
          context do
       client = SimpleWebSocketClient.tcp_client(context)


### PR DESCRIPTION
## The problem

`max_inflate_ratio` is a Bandit-internal configuration option (added in 1.11.0
to bound inflate bombing), but it sits in `@valid_params` in
`Bandit.WebSocket.PerMessageDeflate` alongside the four real [RFC 7692](https://www.rfc-editor.org/info/rfc7692)
negotiation parameters. Two consequences:

1. A client offer of `permessage-deflate; max_inflate_ratio=5` passes
   validation and negotiates, and `resolve_params/1` carries the parameter
   into the response, so the handshake echoes
   `Sec-WebSocket-Extensions: permessage-deflate;max_inflate_ratio=5`.
   [RFC 7692 §7](https://www.rfc-editor.org/info/rfc7692/#section-7) forbids a server from including extension parameters not
   defined for the extension; a compliant client MUST fail the connection on
   seeing it.
2. Per [RFC 7692 §5](https://www.rfc-editor.org/info/rfc7692/#section-5), an offer containing a parameter not defined for use in an
   offer must cause the server to *decline* that offer, which is the opposite
   of what happens today.

The actual inflate protection is not bypassed: `init/2` always overrides the
struct field from server opts. The defect is purely in the negotiation wire
behavior.

## The fix

Remove `max_inflate_ratio` from `@valid_params`, leaving the four RFC-defined
parameters. Offers containing it now decline the extension (per §5) via the
existing invalid param path, and it can never be echoed. `init/2` continues to
source the option from server config, unchanged.

## Tests

New handshake test "declines permessage-deflate offers containing the internal
max_inflate_ratio option": offers `permessage-deflate;max_inflate_ratio=5`,
asserts the upgrade succeeds with no `sec-websocket-extensions` response
header. Before the fix, the response echoes the parameter back.