### PR TITLE
RFC Conformance: Validate HTTP/2 content length on initial END_STREAM

### DIFF
--- a/lib/bandit/http2/stream.ex
+++ b/lib/bandit/http2/stream.ex
@@ -140,6 +140,10 @@ defmodule Bandit.HTTP2.Stream do
           content_length = get_content_length!(headers, stream)
           headers = combine_cookie_crumbs(headers)
           stream = %{stream | bytes_remaining: content_length}
+
+          if stream.state in [:remote_closed, :closed] and content_length not in [nil, 0],
+            do: stream_error!("Received END_STREAM with byte still pending", stream)
+
           {:ok, method, request_target, headers, stream}
 
         :timeout ->

--- a/test/bandit/http2/protocol_test.exs
+++ b/test/bandit/http2/protocol_test.exs
@@ -1736,6 +1736,46 @@ defmodule HTTP2ProtocolTest do
     end
 
     @tag :capture_log
+    test "returns a stream error if HEADERS ends a request before its content-length", context do
+      socket = SimpleH2Client.setup_connection(context)
+
+      headers = [
+        {":method", "POST"},
+        {":path", "/echo"},
+        {":scheme", "https"},
+        {":authority", "localhost:#{context.port}"},
+        {"content-length", "3"}
+      ]
+
+      SimpleH2Client.send_headers(socket, 1, true, headers)
+
+      assert SimpleH2Client.recv_rst_stream(socket) == {:ok, 1, 1}
+      assert SimpleH2Client.connection_alive?(socket)
+
+      assert_receive {:log, %{level: :error, msg: {:string, msg}, meta: %{stream_id: 1}}}, 500
+
+      assert msg ==
+               "** (Bandit.HTTP2.Errors.StreamError) Received END_STREAM with byte still pending"
+    end
+
+    test "accepts a zero content-length when HEADERS ends the request", context do
+      socket = SimpleH2Client.setup_connection(context)
+
+      headers = [
+        {":method", "POST"},
+        {":path", "/echo"},
+        {":scheme", "https"},
+        {":authority", "localhost:#{context.port}"},
+        {"content-length", "0"}
+      ]
+
+      SimpleH2Client.send_headers(socket, 1, true, headers)
+
+      assert SimpleH2Client.successful_response?(socket, 1, false)
+      assert SimpleH2Client.recv_body(socket) == {:ok, 1, true, ""}
+    end
+
+    @tag :capture_log
     test "rejects DATA frames received on a zero stream id", context do
       socket = SimpleH2Client.setup_connection(context)
 


### PR DESCRIPTION
I had Claude check the code against various RFC conformance, and it flagged below. Claude helped with the desc.

## Problem

Bandit checks a request's remaining `Content-Length` whenever a DATA frame carries `END_STREAM`. The same check is ineffective when `END_STREAM` appears on the initial HEADERS frame.

The initial HEADERS frame changes the stream to `remote_closed` before Bandit parses `Content-Length`. At that point `bytes_remaining` is still `nil`, so a request declaring a nonzero body is accepted even though it sends no DATA:

```text
HEADERS END_STREAM
content-length: 3
```

The request can then reach the Plug as an empty body.

## RFC requirement

[RFC 9113 section 8.1.1](https://www.rfc-editor.org/rfc/rfc9113.html#section-8.1.1) defines a message as malformed when its `Content-Length` value does not equal the sum of its DATA frame payload lengths. A request ending in its initial HEADERS has a DATA payload length sum of zero.

[RFC 9113 section 8.1.1](https://www.rfc-editor.org/rfc/rfc9113.html#section-8.1.1) requires a server to reset the stream with `PROTOCOL_ERROR` when it receives a malformed request.

## Implementation

After parsing `Content-Length`, Bandit now checks whether the peer has already closed its side of the stream. If so, a nonzero remaining length raises the same stream error already used when a DATA frame ends a short body.

Requests with no `Content-Length` or `Content-Length: 0` remain valid when the initial HEADERS carries `END_STREAM`.

## Tests

The new protocol test sends an initial HEADERS frame with:

- `END_STREAM` set.
- `content-length: 3`.
- No DATA frames.

It verifies that Bandit sends `RST_STREAM` with `PROTOCOL_ERROR`, records the existing content-length mismatch diagnostic, and leaves the HTTP/2 connection usable.

A companion test verifies that `Content-Length: 0` remains valid when the initial HEADERS ends the stream.

Verified against Bandit `main` at `b084b37` with Erlang/OTP 27.3 and Elixir 1.18.4:

- `mix format --check-formatted`
- `MIX_ENV=test mix compile --warnings-as-errors`
- Full non-slow suite: 816 tests pass (the suite's one IPv6 server binding test needs an IPv6-capable host)
- `mix credo --strict` and `mix dialyzer` pass on the combined tree of all nineteen prepared Bandit changes
- h2spec 2.6.0 passes in full on the combined tree