### PR TITLE
RFC Conformance: Validate request transfer coding before Plug dispatch

### DIFF
--- a/lib/bandit/http1/socket.ex
+++ b/lib/bandit/http1/socket.ex
@@ -62,7 +62,7 @@ defmodule Bandit.HTTP1.Socket do
       {method, request_target, socket} = do_read_request_line!(socket)
       {headers, socket} = do_read_headers!(socket)
       content_length = get_content_length!(headers)
-      body_encoding = get_transfer_encoding!(headers)
+      body_encoding = headers |> get_transfer_encoding!() |> validate_transfer_encoding!()
       request_connection_header = safe_downcase(Bandit.Headers.get_header(headers, "connection"))
       socket = %{socket | request_connection_header: request_connection_header}
 
@@ -206,6 +206,31 @@ defmodule Bandit.HTTP1.Socket do
       case Bandit.Headers.get_transfer_encoding(headers) do
         {:ok, transfer_encoding} -> safe_downcase(transfer_encoding)
         {:error, reason} -> request_error!("Transfer encoding unknown error: #{inspect(reason)}")
+      end
+    end
+
+    # RFC9112§6.3 requires a 400 response when a request's final transfer coding
+    # is not chunked. Reject it while reading the headers so the request cannot be
+    # dispatched to Plug before its framing has been validated.
+    defp validate_transfer_encoding!(nil), do: nil
+
+    defp validate_transfer_encoding!(encoding) do
+      codings = Plug.Conn.Utils.list(encoding)
+
+      cond do
+        codings == ["chunked"] ->
+          "chunked"
+
+        Enum.count(codings, &(&1 == "chunked")) > 1 ->
+          request_error!("Transfer-encoding cannot apply chunked more than once (RFC9112§6.1)")
+
+        List.last(codings) != "chunked" ->
+          request_error!(
+            "Final transfer coding in a request must be chunked (RFC9112§6.3 rule 4)"
+          )
+
+        true ->
+          request_error!("Unsupported transfer-encoding", :not_implemented)
       end
     end
 

--- a/test/bandit/http1/protocol_test.exs
+++ b/test/bandit/http1/protocol_test.exs
@@ -1473,6 +1473,58 @@ defmodule HTTP1ProtocolTest do
   end
 
   describe "transfer-encoding edge cases (RFC9112§6.1, §7.1.1)" do
+    test "rejects a non-chunked final transfer coding before invoking Plug", context do
+      test_pid = self()
+
+      context =
+        context
+        |> http_server(
+          plug: fn conn, _opts ->
+            send(test_pid, :plug_called)
+            send_resp(conn, 200, "unexpected")
+          end
+        )
+        |> Enum.into(context)
+
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "POST", "/", [
+        "host: localhost",
+        "transfer-encoding: gzip"
+      ])
+
+      assert {:ok, "400 Bad Request", _headers, ""} = SimpleHTTP1Client.recv_reply(client)
+      refute_receive :plug_called, 100
+      assert SimpleHTTP1Client.connection_closed_for_reading?(client)
+    end
+
+    test "rejects an unsupported transfer coding before invoking Plug", context do
+      test_pid = self()
+
+      context =
+        context
+        |> http_server(
+          plug: fn conn, _opts ->
+            send(test_pid, :plug_called)
+            send_resp(conn, 200, "unexpected")
+          end
+        )
+        |> Enum.into(context)
+
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "POST", "/", [
+        "host: localhost",
+        "transfer-encoding: gzip, chunked"
+      ])
+
+      assert {:ok, "501 Not Implemented", _headers, ""} =
+               SimpleHTTP1Client.recv_reply(client)
+
+      refute_receive :plug_called, 100
+      assert SimpleHTTP1Client.connection_closed_for_reading?(client)
+    end
+
     @tag :capture_log
     test "rejects a request with transfer-encoding applied twice", context do
       client = SimpleHTTP1Client.tcp_client(context)
@@ -1498,7 +1550,7 @@ defmodule HTTP1ProtocolTest do
 
       Transport.send(client, "3\r\nabc\r\n0\r\n\r\n")
       assert {:ok, status, _headers, _body} = SimpleHTTP1Client.recv_reply(client)
-      assert status in ["400 Bad Request", "501 Not Implemented"]
+      assert status == "400 Bad Request"
     end
 
     test "ignores unrecognized chunk extensions", context do
@@ -1511,6 +1563,18 @@ defmodule HTTP1ProtocolTest do
 
       Transport.send(client, "3;ext=value\r\n123\r\n")
       Transport.send(client, "0\r\n\r\n")
+      assert SimpleHTTP1Client.recv_reply(client) ~> {:ok, "200 OK", list(), "OK"}
+    end
+
+    test "accepts optional whitespace after a single chunked transfer coding", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "POST", "/expect_case_insensitive_chunked_body", [
+        "host: localhost",
+        "transfer-encoding: chunked  \t"
+      ])
+
+      Transport.send(client, "3\r\n123\r\n0\r\n\r\n")
       assert SimpleHTTP1Client.recv_reply(client) ~> {:ok, "200 OK", list(), "OK"}
     end
 


### PR DESCRIPTION
Note: I asked Claude to specifically look for RFC non-conformance. It found below. Claude helped write the desc, test case and identification of the PR.

## Summary

Finish validating HTTP/1 request framing while reading the headers, before the request is passed to Plug.

## What was not conformant

Bandit recorded an unsupported `Transfer-Encoding` during header parsing but did not reject it until `read_data/2`. When a Plug returned a response without reading the request body, that response could be committed before Bandit discovered the invalid framing while draining the body.

[RFC 9112 section 6.3, rule 4](https://www.rfc-editor.org/rfc/rfc9112.html#section-6.3-4) requires a server to respond with 400 and close when a request's final transfer coding is not `chunked`. [RFC 9112 section 6.1](https://www.rfc-editor.org/rfc/rfc9112.html#section-6.1) also prohibits applying `chunked` more than once and recommends 501 when a transfer coding is unsupported.

The validity of the response therefore depended on whether application code happened to read the body.

## Implementation

- Accept no Transfer-Encoding or the single supported coding, `chunked`.
- Return 400 immediately when `chunked` appears more than once.
- Return 400 immediately when the final request transfer coding is not `chunked`.
- Return 501 immediately when the final coding is `chunked` but an earlier transfer coding is unsupported by Bandit.
- Normalize legal optional whitespace and list syntax before selecting the supported single `chunked` coding.
- Perform these checks before creating and invoking the Plug connection.

All rejection responses use `Connection: close`, preserving the framing boundary required by RFC 9112.

## Tests

The protocol tests use a Plug that reports if it is invoked and verify that:

- `Transfer-Encoding: gzip` receives 400, closes the connection, and never invokes Plug;
- `Transfer-Encoding: gzip, chunked` receives 501, closes the connection, and never invokes Plug;
- repeated `chunked` receives 400;
- an unrecognized nonfinal coding no longer has response behavior that depends on body consumption; and
- a single `chunked` coding followed by legal optional whitespace is accepted and decoded.

Run:

```console
mix test test/bandit/http1/protocol_test.exs
```

Verified against Bandit `main` at `b084b37` with Erlang/OTP 27.3 and Elixir 1.18.4:

- `mix format --check-formatted`
- `MIX_ENV=test mix compile --warnings-as-errors`
- Full non-slow suite: 817 tests pass (the suite's one IPv6 server binding test needs an IPv6-capable host)
- `mix credo --strict` and `mix dialyzer` pass on the combined tree of all nineteen prepared Bandit changes