### PR TITLE
RFC Conformance: Fix HTTP/1.0 streaming response framing

### DIFF
--- a/lib/bandit/http1/socket.ex
+++ b/lib/bandit/http1/socket.ex
@@ -455,6 +455,7 @@ defmodule Bandit.HTTP1.Socket do
       resp_line = "#{socket.version} #{status} #{Plug.Conn.Status.reason_phrase(status)}\r\n"
 
       {headers, socket} = handle_keepalive(status, headers, socket)
+      headers = remove_http_1_0_transfer_encoding(headers, socket)
 
       has_content_length = Bandit.Headers.get_header(headers, "content-length") != nil
 
@@ -464,6 +465,15 @@ defmodule Bandit.HTTP1.Socket do
           # and coalesces the header and body send calls into a single ThousandIsland.Socket.send/2
           # call. This makes a _substantial_ difference in practice
           %{socket | write_state: :writing, send_buffer: [resp_line | encode_headers(headers)]}
+
+        :chunk_encoded when not has_content_length and socket.version == :"HTTP/1.0" ->
+          # HTTP/1.0 has no chunked transfer coding. Delimit the response body by closing the
+          # connection, even if the client requested a persistent connection.
+          headers =
+            [{"connection", "close"} | Enum.reject(headers, &(elem(&1, 0) == "connection"))]
+
+          send!(socket.socket, [resp_line | encode_headers(headers)])
+          %{socket | write_state: :chunk_streaming, keepalive: false}
 
         :chunk_encoded when not has_content_length ->
           headers = [{"transfer-encoding", "chunked"} | headers]
@@ -483,6 +493,14 @@ defmodule Bandit.HTTP1.Socket do
           %{socket | write_state: :unsent}
       end
     end
+
+    # RFC9112§6.1 prohibits Transfer-Encoding in every response to an HTTP/1.0 request,
+    # including a field supplied explicitly by the application.
+    defp remove_http_1_0_transfer_encoding(headers, %@for{version: :"HTTP/1.0"}) do
+      Enum.reject(headers, &(elem(&1, 0) == "transfer-encoding"))
+    end
+
+    defp remove_http_1_0_transfer_encoding(headers, _socket), do: headers
 
     defp handle_keepalive(status, headers, socket) do
       response_connection_header = safe_downcase(Bandit.Headers.get_header(headers, "connection"))

--- a/test/bandit/http1/protocol_test.exs
+++ b/test/bandit/http1/protocol_test.exs
@@ -1551,6 +1551,57 @@ defmodule HTTP1ProtocolTest do
       conn
     end
 
+    test "uses close-delimited streaming for an HTTP/1.0 response", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(
+        client,
+        "GET",
+        "/send_chunked_200",
+        ["host: localhost", "connection: keep-alive"],
+        "1.0"
+      )
+
+      response = recv_until_closed(client)
+      assert {:ok, "200 OK", headers, "OK"} = SimpleHTTP1Client.parse_response(client, response)
+
+      refute Bandit.Headers.get_header(headers, :"transfer-encoding")
+      assert Bandit.Headers.get_header(headers, :connection) == "close"
+    end
+
+    defp recv_until_closed(client, response \\ "") do
+      case Transport.recv(client, 0) do
+        {:ok, data} -> recv_until_closed(client, response <> data)
+        {:error, :closed} -> response
+      end
+    end
+
+    test "removes an application-supplied transfer-encoding from HTTP/1.0", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(
+        client,
+        "GET",
+        "/send_chunked_200_with_transfer_encoding",
+        ["host: localhost"],
+        "1.0"
+      )
+
+      response = recv_until_closed(client)
+      assert {:ok, "200 OK", headers, "OK"} = SimpleHTTP1Client.parse_response(client, response)
+      refute Bandit.Headers.get_header(headers, :"transfer-encoding")
+    end
+
+    def send_chunked_200_with_transfer_encoding(conn) do
+      {:ok, conn} =
+        conn
+        |> put_resp_header("transfer-encoding", "chunked")
+        |> send_chunked(200)
+        |> chunk("OK")
+
+      conn
+    end
+
     test "streams a content-length delimited response if content-length is set before chunking",
          context do
       response = Req.get!(context.req, url: "/send_chunked_200_with_content_length")


### PR DESCRIPTION
Note: I asked Claude to specifically look for RFC non-conformance. It found below. Claude helped write the desc, test case and identification of the PR.

## Nonconformance

`Bandit.HTTP1.Socket.send_headers/4` added `Transfer-Encoding: chunked` for every streamed response without a `Content-Length`, including responses to HTTP/1.0 requests.

[RFC 9112 Section 6.1](https://www.rfc-editor.org/rfc/rfc9112.html#section-6.1) says that a server **MUST NOT** send a response containing `Transfer-Encoding` unless the corresponding request indicates HTTP/1.1 or later. [RFC 9112 Section 6.3, rule 8](https://www.rfc-editor.org/rfc/rfc9112.html#section-6.3-8) defines a response without `Transfer-Encoding` or `Content-Length` as close-delimited.

## Change

For an HTTP/1.0 streamed response whose length is not known in advance, Bandit now:

- sends the body bytes without HTTP/1.1 chunk framing;
- omits `Transfer-Encoding`, including a field supplied by the application;
- sends `Connection: close`; and
- disables connection reuse so that connection closure delimits the body.

HTTP/1.1 streaming and content-length-delimited streaming are unchanged.

## Regression test

The new protocol test sends an HTTP/1.0 request with `Connection: keep-alive` to a chunked Plug response. It reads through connection closure and verifies that:

- the decoded body is complete;
- no `Transfer-Encoding` field is present; and
- `Connection: close` is present.

A companion test verifies that Bandit removes an application-supplied `Transfer-Encoding` field from an HTTP/1.0 streamed response.

Run:

```console
mix test test/bandit/http1/protocol_test.exs
```

Verified against Bandit `main` at `b084b37` with Erlang/OTP 27.3 and Elixir 1.18.4:

- `mix format --check-formatted`
- `MIX_ENV=test mix compile --warnings-as-errors`
- Full non-slow suite: 816 tests pass (the suite's one IPv6 server binding test needs an IPv6-capable host)
- `mix credo --strict` and `mix dialyzer` pass on the combined tree of all nineteen prepared Bandit changes