### PR TITLE
RFC Conformance: Keep inflate ratio out of extension negotiation

### DIFF
--- a/lib/bandit/websocket/permessage_deflate.ex
+++ b/lib/bandit/websocket/permessage_deflate.ex
@@ -21,7 +21,7 @@ defmodule Bandit.WebSocket.PerMessageDeflate do
             deflate_context: nil,
             max_inflate_ratio: nil
 
-  @valid_params ~w[server_no_context_takeover client_no_context_takeover server_max_window_bits client_max_window_bits max_inflate_ratio]
+  @valid_params ~w[server_no_context_takeover client_no_context_takeover server_max_window_bits client_max_window_bits]
 
   def negotiate(requested_extensions, opts) do
     :proplists.get_all_values("permessage-deflate", requested_extensions)

--- a/test/bandit/websocket/http1_handshake_test.exs
+++ b/test/bandit/websocket/http1_handshake_test.exs
@@ -274,6 +274,28 @@ defmodule WebSocketHTTP1HandshakeTest do
       refute Keyword.get(headers, :"sec-websocket-extensions")
     end
 
+    test "does not negotiate permessage-deflate when the client offers max_inflate_ratio",
+         context do
+      client = SimpleWebSocketClient.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "GET", "/compress", [
+        "Host: server.example.com",
+        "Upgrade: WeBsOcKeT",
+        "Connection: UpGrAdE",
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+        "Sec-WebSocket-Version: 13",
+        "Sec-WebSocket-Extensions: permessage-deflate;max_inflate_ratio=25"
+      ])
+
+      assert {:ok, "101 Switching Protocols", headers, <<>>} =
+               SimpleHTTP1Client.recv_reply(client)
+
+      assert Keyword.get(headers, :upgrade) == "websocket"
+      assert Keyword.get(headers, :connection) == "Upgrade"
+      assert Keyword.get(headers, :"sec-websocket-accept") == "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="
+      refute Keyword.get(headers, :"sec-websocket-extensions")
+    end
+
     test "does not negotiate permessage-deflate if the client sends repeat option values",
          context do
       client = SimpleWebSocketClient.tcp_client(context)


### PR DESCRIPTION
Note: I asked Claude to specifically look for RFC non-conformance. It found below. Claude helped write the desc, test case and identification of the PR.

## Summary

Treat `max_inflate_ratio` exclusively as a local Bandit configuration option. Decline any `permessage-deflate` offer that includes it as a wire extension parameter.

## RFC conformance

[RFC 7692 Section 7](https://www.rfc-editor.org/rfc/rfc7692.html#section-7) requires a server to decline a `permessage-deflate` offer containing an extension parameter that is not defined for use in an offer. [Section 7.1](https://www.rfc-editor.org/rfc/rfc7692.html#section-7.1) defines the negotiation parameters.

The defined parameters are:

- `server_no_context_takeover`
- `client_no_context_takeover`
- `server_max_window_bits`
- `client_max_window_bits`

Bandit currently includes its private `max_inflate_ratio` configuration setting in the wire parameter allow-list. A client can therefore offer `permessage-deflate;max_inflate_ratio=25`, and Bandit accepts and echoes the undefined parameter in `Sec-WebSocket-Extensions`.

## Implementation

Remove `max_inflate_ratio` from the list of RFC 7692 negotiation parameters. The existing validation path now declines an offer containing it, just as it declines any other unknown parameter.

The local `websocket_options: [max_inflate_ratio: ...]` option is unchanged. It is still read from Bandit's server configuration when an otherwise valid `permessage-deflate` offer is initialized, and it continues to bound decompression independently of anything sent by the client.

## Tests

Added an HTTP/1.1 handshake test proving that an offer containing `max_inflate_ratio` still receives a valid WebSocket upgrade but does not receive a negotiated `Sec-WebSocket-Extensions` response.

The existing `respects max_inflate_ratio for received frames` protocol test continues to cover the local configuration behavior.

Run:

```console
mix test test/bandit/websocket/http1_handshake_test.exs test/bandit/websocket/protocol_test.exs
```

Validation completed:

- Full test suite: 814 tests, 0 failures, 4 excluded, 1 skipped.
- `mix format --check-formatted`: passed.
- `mix credo --strict`: passed with no issues.

## Verification

Verified against Bandit `main` at `b084b37` with Erlang/OTP 27.3 and Elixir 1.18.4:

- `mix format --check-formatted`
- `MIX_ENV=test mix compile --warnings-as-errors`
- Full non-slow suite: 815 tests pass (the suite's one IPv6 server binding test needs an IPv6-capable host)
- `mix credo --strict` and `mix dialyzer` pass on the combined tree of all nineteen prepared Bandit changes