### PR TITLE
Observe RST_STREAM while blocked on the stream send window

### DIFF
--- a/lib/bandit/http2/stream.ex
+++ b/lib/bandit/http2/stream.ex
@@ -582,6 +582,12 @@ defmodule Bandit.HTTP2.Stream do
             stream
             |> do_recv_send_window_update(delta)
             |> send_data(rest, end_stream)
+
+          # Observe a client reset promptly rather than sitting blocked until read_timeout
+          # (after which we would send an RST_STREAM of our own, which RFC9113§6.4 forbids
+          # after receiving one). Mirrors the handling in do_recv/2
+          {:bandit, {:rst_stream, error_code}} ->
+            do_recv_rst_stream!(stream, error_code)
         after
           stream.read_timeout ->
             stream_error!(

--- a/test/bandit/http2/protocol_test.exs
+++ b/test/bandit/http2/protocol_test.exs
@@ -3500,6 +3500,34 @@ defmodule HTTP2ProtocolTest do
       assert SimpleH2Client.recv_body(socket) == {:ok, 1, true, "e"}
     end
 
+    test "promptly unblocks a stream blocked on the stream send window when the client resets it",
+         context do
+      socket = SimpleH2Client.setup_connection(context)
+
+      # Give ourselves lots of room on the connection
+      SimpleH2Client.send_window_update(socket, 0, 1_000_000)
+
+      # Set our initial stream window size to something small
+      SimpleH2Client.exchange_client_settings(socket, <<4::16, 100::32>>)
+
+      SimpleH2Client.send_simple_headers(socket, 1, :post, "/echo", context.port)
+      SimpleH2Client.send_body(socket, 1, true, String.duplicate("a", 16_384))
+
+      assert {:ok, 0, _} = SimpleH2Client.recv_window_update(socket)
+      assert SimpleH2Client.successful_response?(socket, 1, false)
+
+      # Expect 100 bytes as that is our initial stream window; the stream is now
+      # blocked waiting for stream window space
+      assert SimpleH2Client.recv_body(socket) == {:ok, 1, false, String.duplicate("a", 100)}
+
+      # Reset the stream and expect the blocked stream to unwind promptly (well before
+      # its read_timeout) without sending an RST_STREAM of its own (RFC9113§6.4)
+      SimpleH2Client.send_rst_stream(socket, 1, 8)
+
+      assert_receive {:telemetry, [:bandit, :request, :stop], _, %{error: _}}, 1_000
+      assert SimpleH2Client.connection_alive?(socket)
+    end
+
     test "respects both stream and connection windows in complex scenarios", context do
       socket = SimpleH2Client.setup_connection(context)
 


### PR DESCRIPTION
## The problem

When a response is larger than the stream-level send window, `send_data/3` in
`lib/bandit/http2/stream.ex` parks the stream process in a selective `receive`
that matches only `{:bandit, {:send_window_update, delta}}`:

```elixir
receive do
  {:bandit, {:send_window_update, delta}} -> ...
after
  stream.read_timeout -> stream_error!(..., flow_control_error())
end
```

If the client sends RST_STREAM while the stream is parked here, the
`{:bandit, {:rst_stream, error_code}}` message the connection process delivers
sits unmatched in the mailbox until `read_timeout` (15s) fires. Two
consequences:

1. The stream process — and whatever resources the plug holds — stays pinned
   for up to 15s after the client has already walked away.
2. When the timeout fires, the stream raises a `flow_control_error`
   StreamError, and `send_on_error/2` answers with an RST_STREAM of its own —
   after the client already reset the stream.

That second consequence is a rule the file already implements. The
`Bandit.TransportError` clause of `send_on_error/2` exists precisely to avoid
it, and says so:

```elixir
# A TransportError means the client reset the stream (do_recv_rst_stream!). RFC9113§6.4 forbids
# sending any further frame except PRIORITY after receiving RST_STREAM, so send no response at
# all -- not even an error one, unlike the generic clause below. Mirrors HTTP/1's handling.
def send_on_error(%@for{} = stream, %Bandit.TransportError{}), do: %{stream | state: :closed}
```

A stream blocked on the send window never reaches that clause, because the
reset is never observed as a reset — it expires as a flow-control timeout
instead, and takes the generic StreamError path.

## Context

This appears to be the last spot where a stream can be blocked and blind to a
reset: `do_recv/2` (both clauses) already matches `{:bandit, {:rst_stream, _}}`,
`ensure_completed/1` and `maybe_send_error/2` use `after 0` rather than
blocking, and the connection-window analogue was
fixed by GHSA-xj8g-532w-jv94 / #671 (`purge_pending_send` releases sends
blocked on the connection window when RST_STREAM arrives). That advisory noted
the stream-window block was already time-bounded — which it is, and this PR
doesn't dispute that bound. What it adds is reset-*observability* within the
bound: a reset stream should release its resources when the reset arrives, not
up to 15s later, and should not answer a reset with an RST_STREAM of its own.

## The fix

Add the same clause the read path already has to the blocking `receive`:

```elixir
{:bandit, {:rst_stream, error_code}} ->
  do_recv_rst_stream!(stream, error_code)
```

`do_recv_rst_stream!` raises `Bandit.TransportError`, which unwinds through
the existing pipeline path: the telemetry span stops with the error, and the
`TransportError` clause of `send_on_error/2` quoted above sends nothing. No new
mechanism is introduced — the reset simply reaches the handling that already
exists for it.

## Tests

New protocol test "promptly unblocks a stream blocked on the stream send
window when the client resets it": constrains the stream window to 100 bytes
via SETTINGS, requests a 16KB echo so the stream blocks after 100 bytes, sends
RST_STREAM(CANCEL), and asserts the request's telemetry stop event arrives
within 1s and that the connection remains healthy with no RST_STREAM echoed
back.

Run against unfixed code (test applied, `stream.ex` change reverted), the
stream stays parked for its full 15s `read_timeout` and the assertion gives up
after 1s with only the start event delivered:

```
1) test WINDOW_UPDATE frames (download direction) promptly unblocks a stream
   blocked on the stream send window when the client resets it (HTTP2ProtocolTest)
   Assertion failed, no matching message after 1000ms
   Showing 1 of 1 message in the mailbox
   code: assert_receive {:telemetry, [:bandit, :request, :stop], _, %{error: _}}
   mailbox:
     pattern: {:telemetry, [:bandit, :request, :stop], _, %{error: _}}
     value:   {:telemetry, [:bandit, :request, :start], ...}
```

With the fix applied, the stop event arrives promptly and the suite is green.

### Sidenote
It looks like I got Wally Pipped for a few other fixes. (which is great btw, I'm glad there are other people out there auditing things) I didn't want to overwhelm you with a tsunami of PRs but I do have some more queued. Let me know what your preference is for reporting, as I don't want to overwhelm maintainers of open source projects.