### PR TITLE
Close idle zero byte connections silently instead of answering 408

### DIFF
--- a/lib/bandit/initial_handler.ex
+++ b/lib/bandit/initial_handler.ex
@@ -41,6 +41,13 @@ defmodule Bandit.InitialHandler do
       {true, _, :no_match, {:no_match, data}} ->
         {:switch, Bandit.HTTP1.Handler, data, state}
 
+      {_, _, _, :idle_timeout} ->
+        # The connection sent no bytes at all within the read timeout (an idle probe, port
+        # scan or similar). Close silently rather than handing an empty buffer to the HTTP/1
+        # handler, which would block for a second read timeout and then answer with an
+        # unsolicited 408
+        {:close, state}
+
       _other ->
         {:close, state}
     end
@@ -63,6 +70,7 @@ defmodule Bandit.InitialHandler do
   @spec sniff_wire(ThousandIsland.Socket.t()) ::
           Bandit.HTTP2.Handler
           | :likely_tls
+          | :idle_timeout
           | {:no_match, binary()}
           | {:error, :closed | :timeout | :inet.posix()}
   defp sniff_wire(socket) do
@@ -70,7 +78,7 @@ defmodule Bandit.InitialHandler do
       {:ok, "PRI" = buffer} -> sniff_wire_for_http2(socket, buffer)
       {:ok, <<22::8, 3::8, minor::8>>} when minor in [1, 3] -> :likely_tls
       {:ok, data} -> {:no_match, data}
-      {:error, :timeout} -> {:no_match, <<>>}
+      {:error, :timeout} -> :idle_timeout
       {:error, error} -> {:error, error}
     end
   end

--- a/test/bandit/initial_handler_test.exs
+++ b/test/bandit/initial_handler_test.exs
@@ -88,6 +88,19 @@ defmodule InitialHandlerTest do
     end
   end
 
+  describe "idle connections" do
+    setup :http_server
+
+    test "closes silently when no data is sent before the read timeout", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      # Expect a silent close after the server's read timeout: no unsolicited 408
+      # response bytes and no error logged
+      assert Transport.recv(client, 0) == {:error, :closed}
+      refute_receive {:log, %{level: :error}}
+    end
+  end
+
   describe "unknown protocols" do
     setup :http_server
     setup :req_http1_client


### PR DESCRIPTION
## The problem

A connection that sends no bytes at all takes this path: the protocol sniff in
`Bandit.InitialHandler` blocks for a full read timeout, converts the timeout
into `{:no_match, <<>>}`, and hands an *empty buffer* to the HTTP/1 handler,
which blocks for a second full read timeout, then raises a request-timeout
error. This writes an unsolicited `HTTP/1.0 408 Request Timeout` to the socket and
(by default) logs an error. Every idle probe, port scan, and TCP
health-check thus holds a socket for 2× the configured timeout and generates
log noise plus a response nobody asked for.

## Precedent

Cowboy distinguishes the two cases explicitly, in `cowboy_http.erl`:

```erlang
timeout(State=#state{in_state=#ps_request_line{}}, request_timeout) ->
    terminate(State, {connection_error, timeout,
        'No request-line received before timeout.'});
timeout(State=#state{in_state=#ps_header{}}, request_timeout) ->
    error_terminate(408, State, {connection_error, timeout,
        'Request headers not received before timeout.'});
timeout(State, idle_timeout) ->
    terminate(State, {connection_error, timeout,
        'Connection idle longer than configuration allows.'});
```

Only the `#ps_header{}` clause answers, a request-line arrived and the headers
didn't. A connection that sent nothing (or less than a full request-line) is in
`#ps_request_line{}` and takes `terminate/2`, which writes nothing to the
socket. Keep-alive idle lands there too, since `next_request/1` resets
`in_state` to `#ps_request_line{}`.

Lining the cases up:

| | zero bytes / no request-line | request-line, headers incomplete | keep-alive idle |
|---|---|---|---|
| Cowboy | silent close | 408 | silent close |
| Bandit today | **408** | 408 | silent close |
| Bandit after this PR | silent close | 408 | silent close |

Bandit differs in one cell, and this patch closes that cell. It doesn't touch
the partial-request path: with three or more bytes the sniff succeeds, the
HTTP/1 handler reads headers, and a timeout there still yields a 408, the same
place Cowboy answers.

## Context

Bandit already treats this situation the other way in the keepalive case. An
idle connection that has served a request returns `{:continue, state}` from
`maybe_keepalive/2`, and since `Bandit.HTTP1.Handler` implements no
`handle_timeout/2`, the eventual read timeout falls through to
`ThousandIsland.Handler`'s default `{:close, state}` silent, no response, no
log.

So the same socket, idle for the same reason and for the same duration, is
handled two different ways depending only on whether a request happened to
precede the idle period. This PR makes the never spoke case match the
already spoke one.

## The fix

A sniff timeout in the first-stage `recv(socket, 3)` now returns a distinct
`:idle_timeout`, which `handle_connection` closes silently.

Scope, precisely: `{:no_match, <<>>}` was reachable only from that timeout
`recv(socket, 3)` yields either exactly three bytes or an error, and the
second stage sniff returns `{:no_match, "PRI"}` so no other path changes.
A client that sends one or two bytes and then stalls does take the new path,
since it is indistinguishable from silence at the three-byte read; a client
that got as far as `"PRI"` is unaffected and still passes through.

This applies to any connection that sends nothing, including one that
completed a TLS handshake and negotiated `http/1.1` via ALPN not only
plaintext probes.

Two observable consequences worth naming: these connections no longer emit
`[:bandit, :request, :start]` / `:stop` telemetry (no request is ever read),
and they no longer produce an error log. The latter is the point, but it does
remove a signal that an operator could have been using to spot scanning.

## Tests

New test "closes silently when no data is sent before the read timeout":
opens a socket, sends nothing, and asserts the socket closes with zero bytes
received and no error logged. It deliberately carries no `@tag :capture_log`,
since the absence of an error log is part of what it pins.

Against unfixed code (test applied, `initial_handler.ex` change reverted), the
client that sent nothing receives a complete response:

```
1) test idle connections closes silently when no data is sent before the read timeout
   Assertion with == failed
   code:  assert Transport.recv(client, 0) == {:error, :closed}
   left:  {:ok, "HTTP/1.0 408 Request Timeout\r\nconnection: close\r\n\r\n"}
   right: {:error, :closed}
```

With the fix, the socket closes after a single read timeout with nothing
written to it.