### PR TITLE
Fix chunked read_body(length: 0) falsely completing the body

### DIFF
--- a/lib/bandit/http1/socket.ex
+++ b/lib/bandit/http1/socket.ex
@@ -280,16 +280,26 @@ defmodule Bandit.HTTP1.Socket do
     # do_read_chunked_data! reads up to the configured length, reading multiple
     # chunks to do so. It accumulates data in the 'body' list, adding to it
     # chunk by (possibly partial) chunk until either the end of the body is reached
-    # or the configured length is exceeded
-    @dialyzer {:no_improper_lists, do_read_chunked_data!: 5}
+    # or the configured length is exceeded. Note that an exhausted read budget must
+    # be checked before attempting to read a chunk, since a zero-byte chunk read is
+    # otherwise indistinguishable from the terminal chunk
     defp do_read_chunked_data!(socket, buffer, body, body_length, opts) do
       max_to_read = Keyword.get(opts, :length, 8_000_000) - body_length
 
+      if max_to_read <= 0 do
+        {:more, body, buffer}
+      else
+        do_read_next_chunk!(socket, buffer, body, body_length, max_to_read, opts)
+      end
+    end
+
+    @dialyzer {:no_improper_lists, do_read_next_chunk!: 6}
+    defp do_read_next_chunk!(socket, buffer, body, body_length, max_to_read, opts) do
       case do_read_chunk!(socket, buffer, max_to_read, opts) do
-        {<<>>, rest} ->
+        {:done, rest} ->
           {:ok, body, rest}
 
-        {chunk, rest} ->
+        {:chunk, chunk, rest} ->
           length = IO.iodata_length(chunk)
 
           if length < max_to_read do
@@ -319,7 +329,7 @@ defmodule Bandit.HTTP1.Socket do
           if trailers != [],
             do: Logger.warning("Encountered trailers in chunked request; ignoring")
 
-          {<<>>, fake_socket.buffer}
+          {:done, fake_socket.buffer}
 
         {chunk_size, rest} ->
           to_read = min(chunk_size, max_to_read)
@@ -335,11 +345,11 @@ defmodule Bandit.HTTP1.Socket do
               if IO.iodata_to_binary(newline) != "\r\n",
                 do: request_error!("Malformed chunked encoding request body")
 
-              {to_return, rest}
+              {:chunk, to_return, rest}
 
             remaining when remaining > 0 ->
               # Build a binary since we'll be passing it to read_chunk_size! which expects a binary
-              {to_return, Integer.to_string(remaining, 16) <> "\r\n" <> rest}
+              {:chunk, to_return, Integer.to_string(remaining, 16) <> "\r\n" <> rest}
           end
       end
     end

--- a/test/bandit/http1/protocol_test.exs
+++ b/test/bandit/http1/protocol_test.exs
@@ -1346,6 +1346,28 @@ defmodule HTTP1ProtocolTest do
       send_resp(conn, 200, "OK")
     end
 
+    test "handles a read_body call with length: 0 without falsely completing the body", context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "POST", "/zero_length_chunked_read", [
+        "Host: localhost",
+        "Transfer-encoding: chunked"
+      ])
+
+      Transport.send(client, "5\r\nhello\r\n0\r\n\r\n")
+      assert {:ok, "200 OK", _headers, "hello"} = SimpleHTTP1Client.recv_reply(client)
+
+      # Make sure the connection is still in sync by trying another request
+      SimpleHTTP1Client.send(client, "GET", "/echo_method", ["host: localhost"])
+      assert {:ok, "200 OK", _headers, "GET"} = SimpleHTTP1Client.recv_reply(client)
+    end
+
+    def zero_length_chunked_read(conn) do
+      {:more, "", conn} = Plug.Conn.read_body(conn, length: 0)
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      send_resp(conn, 200, body)
+    end
+
     test "reads a chunked body properly", context do
       stream =
         Stream.repeatedly(fn -> String.duplicate("0123456789", 100_000) end)


### PR DESCRIPTION
## The problem

A plug may legally call `Plug.Conn.read_body(conn, length: 0)` opts pass
straight through to the adapter. On a chunked request body this reports the
body as *complete* while none of it has been read, and desyncs the connection.
The trace, in `lib/bandit/http1/socket.ex`:

1. `do_read_chunked_data!` computes `max_to_read = 0`.
2. `do_read_chunk!` parses the real chunk size (say 5), so
   `to_read = min(5, 0) = 0` and `read_exactly!` returns a zero-byte binary.
   The chunk wasn't fully consumed, so a fake chunk header is pushed back onto
   the buffer and `{<<>>, "5\r\nhello\r\n0\r\n\r\n"}` is returned.
3. Back in `do_read_chunked_data!`, `{<<>>, rest}` matches — but that clause is
   reserved for the *terminal* zero-length chunk, so it returns
   `{:ok, body, rest}`.

The socket is then marked `read_state: :read` with the whole body still
buffered. `ensure_completed/1` skips draining, and on keepalive those raw chunk
bytes are fed to the parser as the next *request*, producing a spurious 400 and
a desynced connection.

The content-length path returns `{:more, "", socket}` for the same input, so
the chunked path is the outlier rather than this being deliberate.

## How you'd reach it

Worth bounding, since `length: 0` looks contrived written down. The realistic
route is a plug with a decrementing read budget "read at most N bytes":

```elixir
defp read_capped(conn, remaining, acc) do
  case Plug.Conn.read_body(conn, length: remaining) do
    {:ok, body, conn} -> {:ok, acc <> body, conn}
    {:more, body, conn} -> read_capped(conn, remaining - byte_size(body), acc <> body)
  end
end
```

The chunked path never returns more than `length` bytes per call, so a caller
subtracting what it received lands on exactly zero, never negative, on the
call after its budget is spent. A 5-byte body with a 3-byte cap returns
`{:more, "hel"}`; the next call goes in with `length: 0`.

That needs an application which both caps its reads and keeps going until
`{:ok, ...}` rather than stopping at the first `{:more, ...}`. A plug that
rejects on `{:more, ...}` never reaches it, so this isn't client-reachable on
its own and I'd expect it to be rare.

What makes it worth fixing anyway is the shape of the failure rather than its
frequency: not an error or a wrong status, but a silent desync where one
request's unread body becomes the parser's next request on a keepalive
connection. Behind a proxy that pools upstream connections, those bytes land on
whatever request the proxy sends next.

## Context

This read path was last reworked in #585 ("Improve handling of large chunked
request bodies", 1.11.1, CVE-2026-39803), which is where the `:length` budget
came to interact with chunk reading. That work was scoped to large bodies; this
is the opposite end, a budget of zero, where the "zero bytes returned"
sentinel collides with the terminal-chunk signal.

## The fix

Two changes that remove the ambiguity outright:

- `do_read_chunk!` returns tagged tuples `{:done, rest}` for the terminal
  chunk, `{:chunk, data, rest}` for data chunks, so a zero-byte read can never
  be mistaken for end of body.
- `do_read_chunked_data!` checks for an exhausted budget (`max_to_read <= 0`)
  *before* reading a chunk, returning `{:more, body, buffer}` to match the
  content-length path.

The `<= 0` guard also closes a negative `:length` passed directly. This file
already documents that route, in the note above `parse_chunk_size!/1`:

> A negative size reaches `read_exactly!/5`, which is guarded on a non-negative
> length and so raises FunctionClauseError rather than returning a 400.

That note concerns a negative chunk size on the wire, now rejected at parse
time. A negative `:length` from the plug reaches the same place via
`to_read = min(chunk_size, max_to_read)`.

## Tests

New test "handles a read_body call with length: 0 without falsely completing
the body": a chunked POST whose plug calls `read_body(conn, length: 0)`, reads
the rest, and echoes it, then a second request on the same connection to
confirm it stayed in sync.

Against unfixed code (test applied, `socket.ex` reverted), the first read
reports the body complete having read none of it:

```
** (MatchError) no match of right hand side value:

    {:ok, "",
     %Plug.Conn{... path_info: ["zero_length_chunked_read"],
       req_headers: [{"host", "localhost"}, {"transfer-encoding", "chunked"}], ...}}

1) test chunked request bodies (RFC9112§7.1) handles a read_body call with
   length: 0 without falsely completing the body (HTTP1ProtocolTest)
   code:  assert {:ok, "200 OK", _headers, "hello"} = SimpleHTTP1Client.recv_reply(client)
   left:  {:ok, "200 OK", _headers, "hello"}
   right: {:ok, "500 Internal Server Error", [connection: "close"], ""}
```

That `{:ok, ""}` is the defect directly: `:ok` means the body is complete, and
`""` is all that was read of a five-byte body.

On scope because the plug destructures strictly (matching neighbouring
`expect_chunked_body/1`), the pre-fix run raises there and returns 500 with
`connection: close`, tearing the connection down before the desync can show. So
the test pins the violation, not its downstream consequence; the desync above rests 
on the code trace.

With the fix the first read returns `{:more, ""}`, the body reads back in full,
and the follow-up request on the same connection succeeds.