### PR TITLE
Report only actually written bytes in resp_body_bytes

### DIFF
--- a/lib/bandit/adapter.ex
+++ b/lib/bandit/adapter.ex
@@ -298,12 +298,14 @@ defmodule Bandit.Adapter do
   end
 
   defp send_data(adapter, data, end_request) do
-    socket =
-      if send_resp_body?(adapter),
-        do: Bandit.HTTPTransport.send_data(adapter.transport, data, end_request),
-        else: adapter.transport
+    {socket, data_size} =
+      if send_resp_body?(adapter) do
+        {Bandit.HTTPTransport.send_data(adapter.transport, data, end_request),
+         IO.iodata_length(data)}
+      else
+        {adapter.transport, 0}
+      end
 
-    data_size = IO.iodata_length(data)
     metrics = Map.update(adapter.metrics, :resp_body_bytes, data_size, &(&1 + data_size))
 
     metrics =

--- a/test/bandit/http1/telemetry_test.exs
+++ b/test/bandit/http1/telemetry_test.exs
@@ -239,6 +239,28 @@ defmodule HTTP1TelemetryTest do
       |> send_file(200, Path.join([__DIR__, "../../support/sendfile"]), 0, :all)
     end
 
+    test "it should not count suppressed response bodies in `stop` events for HEAD requests",
+         context do
+      Req.head!(context.req, url: "/do_read_body")
+
+      assert_receive {:telemetry, [:bandit, :request, :stop], measurements, _metadata}, 500
+
+      # The response body is suppressed for HEAD requests, so no body bytes were
+      # actually written (mirroring what send_file responses already report)
+      assert measurements
+             ~> %{
+               monotonic_time: integer(roughly: System.monotonic_time()),
+               duration: integer(max: System.convert_time_unit(1, :second, :native)),
+               req_header_end_time: integer(roughly: System.monotonic_time()),
+               req_body_start_time: integer(roughly: System.monotonic_time()),
+               req_body_end_time: integer(roughly: System.monotonic_time()),
+               req_body_bytes: 0,
+               resp_body_bytes: 0,
+               resp_start_time: integer(roughly: System.monotonic_time()),
+               resp_end_time: integer(roughly: System.monotonic_time())
+             }
+    end
+
     @tag :capture_log
     test "it should send `stop` events for malformed requests", context do
       client = SimpleHTTP1Client.tcp_client(context)


### PR DESCRIPTION
## The problem

`Bandit.Adapter.send_data/3` updates the `resp_body_bytes` telemetry
measurement *outside* the `send_resp_body?/1` guard, so responses whose bodies
are suppressed (HEAD requests, 204/304 statuses) report the full, never
transmitted body size. `send_file/6` in the same module does the opposite:
its `bytes_actually_written` is 0 when the body is suppressed. Telemetry
consumers computing egress get inconsistent numbers depending on which send
API the plug used.

## The fix

Move the byte accounting inside the `send_resp_body?/1` branch (recording 0
otherwise), matching `send_file`'s semantics: `resp_body_bytes` means bytes
actually written to the transport.

## Tests

New telemetry test "it should not count suppressed response bodies in `stop`
events for HEAD requests": a HEAD against `/do_read_body` asserts
`resp_body_bytes: 0`.

Against unfixed code (test applied, `adapter.ex` reverted):

```
1) test telemetry it should not count suppressed response bodies in `stop`
   events for HEAD requests (HTTP1TelemetryTest)
   Assertion with ~> failed

   Mismatches:

     1) .resp_body_bytes: 2 is not equal to 0
```

The reported `2` is the same figure the neighboring
"it should add req metrics to `stop` events" test asserts for a POST to the
same endpoint, except that response actually put two bytes on the wire, and
this one wrote none.