### PR TITLE
Count each received WebSocket wire frame exactly once in telemetry

### DIFF
--- a/lib/bandit/websocket/connection.ex
+++ b/lib/bandit/websocket/connection.ex
@@ -53,9 +53,13 @@ defmodule Bandit.WebSocket.Connection do
     websock.init(websock_state) |> handle_continuation(socket, instance)
   end
 
-  def handle_frame(frame, socket, %{fragment_frame: nil} = connection) do
-    connection = do_recv_metrics(frame, connection)
+  # Recv metrics are recorded here and only here: dispatch_frame/3 re-enters itself with
+  # synthesized frames (inflated payloads, reassembled fragmented messages) which never
+  # arrived on the wire and so must not be counted a second time
+  def handle_frame(frame, socket, connection),
+    do: dispatch_frame(frame, socket, do_recv_metrics(frame, connection))
 
+  defp dispatch_frame(frame, socket, %{fragment_frame: nil} = connection) do
     case frame do
       %Frame.Continuation{} ->
         do_error(1002, "Received unexpected continuation frame (RFC6455§5.4)", socket, connection)
@@ -91,10 +95,8 @@ defmodule Bandit.WebSocket.Connection do
     end
   end
 
-  def handle_frame(frame, socket, %{fragment_frame: fragment_frame} = connection)
-      when not is_nil(fragment_frame) do
-    connection = do_recv_metrics(frame, connection)
-
+  defp dispatch_frame(frame, socket, %{fragment_frame: fragment_frame} = connection)
+       when not is_nil(fragment_frame) do
     case frame do
       %Frame.Continuation{fin: true} = frame ->
         fragment_size = connection.fragment_size + IO.iodata_length(frame.data)
@@ -104,7 +106,7 @@ defmodule Bandit.WebSocket.Connection do
         else
           data = IO.iodata_to_binary([connection.fragment_frame.data | frame.data])
           frame = %{connection.fragment_frame | fin: true, data: data}
-          handle_frame(frame, socket, %{connection | fragment_frame: nil, fragment_size: 0})
+          dispatch_frame(frame, socket, %{connection | fragment_frame: nil, fragment_size: 0})
         end
 
       %Frame.Continuation{fin: false} = frame ->
@@ -342,7 +344,7 @@ defmodule Bandit.WebSocket.Connection do
       {:ok, data, compress} ->
         frame = %{frame | data: data, compressed: false}
         connection = %{connection | compress: compress}
-        handle_frame(frame, socket, connection)
+        dispatch_frame(frame, socket, connection)
 
       {:error, :no_compress} ->
         do_error(1002, "Received unexpected compressed frame (RFC6455§5.2)", socket, connection)

--- a/test/bandit/websocket/sock_test.exs
+++ b/test/bandit/websocket/sock_test.exs
@@ -10,7 +10,8 @@ defmodule WebSocketWebSockTest do
   def call(conn, _opts) do
     conn = Plug.Conn.fetch_query_params(conn)
     websock = conn.query_params["websock"] |> String.to_atom()
-    Plug.Conn.upgrade_adapter(conn, :websocket, {websock, [], []})
+    compress = conn.query_params["compress"]
+    Plug.Conn.upgrade_adapter(conn, :websocket, {websock, [], compress: compress})
   end
 
   describe "init" do
@@ -1418,6 +1419,66 @@ defmodule WebSocketWebSockTest do
                websock: TelemetrySock,
                connection_telemetry_span_context: reference(),
                telemetry_span_context: reference()
+             }
+    end
+
+    test "it should count each wire frame exactly once for fragmented messages", context do
+      TelemetryHelpers.attach_all_events(TelemetrySock) |> on_exit()
+
+      client = SimpleWebSocketClient.tcp_client(context)
+      SimpleWebSocketClient.http1_handshake(client, TelemetrySock)
+      SimpleWebSocketClient.send_text_frame(client, "AB", 0x0)
+      SimpleWebSocketClient.send_continuation_frame(client, "CD")
+      _ = SimpleWebSocketClient.recv_text_frame(client)
+      SimpleWebSocketClient.send_connection_close_frame(client, 1000)
+
+      assert_receive {:telemetry, [:bandit, :websocket, :stop], measurements, _metadata}, 500
+
+      # The wire carried one 2-byte text frame and one 2-byte continuation; the
+      # reassembled 4-byte message dispatched to the websock must not be counted
+      # as an additional received frame
+      assert measurements
+             ~> %{
+               monotonic_time: integer(roughly: System.monotonic_time()),
+               duration: integer(max: System.convert_time_unit(1, :second, :native)),
+               recv_text_frame_count: 1,
+               recv_text_frame_bytes: 2,
+               recv_continuation_frame_count: 1,
+               recv_continuation_frame_bytes: 2,
+               recv_connection_close_frame_count: 1,
+               recv_connection_close_frame_bytes: 0,
+               send_text_frame_count: 1,
+               send_text_frame_bytes: 4
+             }
+    end
+
+    test "it should count a compressed frame once, at its wire size", context do
+      TelemetryHelpers.attach_all_events(TelemetrySock) |> on_exit()
+
+      client = SimpleWebSocketClient.tcp_client(context)
+      SimpleWebSocketClient.http1_handshake(client, TelemetrySock, [], true)
+
+      # A pre-deflated payload, as used by the permessage-deflate protocol tests
+      deflated_payload = <<74, 76, 28, 5, 163, 96, 20, 12, 119, 0, 0>>
+      SimpleWebSocketClient.send_text_frame(client, deflated_payload, 0xC)
+      _ = SimpleWebSocketClient.recv_deflated_text_frame(client)
+      SimpleWebSocketClient.send_connection_close_frame(client, 1000)
+
+      assert_receive {:telemetry, [:bandit, :websocket, :stop], measurements, _metadata}, 500
+
+      # Recv metrics see the frame as it arrived on the wire; the inflated frame
+      # dispatched to the websock afterwards must not be counted a second time,
+      # nor may its (larger) inflated size be added to the byte total
+      assert measurements
+             ~> %{
+               monotonic_time: integer(roughly: System.monotonic_time()),
+               duration: integer(max: System.convert_time_unit(1, :second, :native)),
+               recv_text_frame_count: 1,
+               recv_text_frame_bytes: 11,
+               recv_connection_close_frame_count: 1,
+               recv_connection_close_frame_bytes: 0,
+               send_text_frame_count: 1,
+               send_text_frame_bytes: integer()
              }
     end
 


### PR DESCRIPTION
## The problem

`Bandit.WebSocket.Connection.handle_frame/3` records recv metrics as its first
step, but it is also used as an internal redispatch target for frames that
never arrived on the wire:

- `do_inflate/3` re-invokes it with the *decompressed* frame, so one
  compressed text message increments `recv_text_frame_count` twice and adds
  both the wire size and the inflated size to `recv_text_frame_bytes`;
- the fin continuation branch re-invokes it with the *reassembled* message, so
  a fragmented message counts a phantom extra frame with the stitched together
  byte size.

Anyone driving dashboards or accounting off the `[:bandit, :websocket, :stop]`
measurements gets inflated counts and byte totals for compressed and
fragmented traffic. The compression case can be dramatic: in the test added
here, an 11-byte deflated frame that inflates to 1000 bytes is reported as
`recv_text_frame_bytes: 1011`, 92× the bytes that actually arrived and as
two received frames rather than one.

## The fix

Split dispatch from metrics: `handle_frame/3` becomes
`dispatch_frame(frame, socket, do_recv_metrics(frame, connection))`, and both
internal re-entry points (`do_inflate/3` and fragment reassembly) call
`dispatch_frame/3` directly. Wire frames are counted at exactly one site;
synthesized frames are never counted.

## Tests

One test per re-entry path, since the two defects are reached through
different code:

- **"it should count each wire frame exactly once for fragmented messages"** —
  a 2-byte text fragment plus a 2-byte fin continuation, asserting
  `recv_text_frame_count: 1, recv_text_frame_bytes: 2`.
- **"it should count a compressed frame once, at its wire size"** — an 11-byte
  deflated text frame over a negotiated permessage-deflate connection,
  asserting `recv_text_frame_count: 1, recv_text_frame_bytes: 11`.

Both fail against unfixed code (tests applied, `connection.ex` reverted):

```
1) test telemetry it should count each wire frame exactly once for fragmented
   messages (WebSocketWebSockTest)
   Mismatches:
     1) .recv_text_frame_bytes: 6 is not equal to 2
     2) .recv_text_frame_count: 2 is not equal to 1

2) test telemetry it should count a compressed frame once, at its wire size
   (WebSocketWebSockTest)
   Mismatches:
     1) .recv_text_frame_bytes: 1011 is not equal to 11
     2) .recv_text_frame_count: 2 is not equal to 1
```

The fragmented case adds the 4-byte reassembly to the 2 wire bytes; the
compressed case adds the 1000-byte inflated payload to the 11 wire bytes.

The second test needs the websock upgrade to negotiate compression, so
`WebSocketWebSockTest.call/2` now forwards the `compress` query parameter the
same way `WebSocketProtocolTest.call/2` already does. Existing tests in the
file don't pass that parameter, and `compress: nil` is equivalent to omitting
it (`Handshake.do_handshake/3` guards on `Keyword.get(opts, :compress) &&`),
so their behavior is unchanged.