### PR TITLE
Close instead of draining when a plug never honors Expect: 100-continue

### DIFF
--- a/lib/bandit/adapter.ex
+++ b/lib/bandit/adapter.ex
@@ -273,6 +273,8 @@ defmodule Bandit.Adapter do
     if get_http_protocol(adapter) == :"HTTP/1.0" do
       {:error, :not_supported}
     else
+      adapter = if status == 100, do: %{adapter | expect_continue: false}, else: adapter
+
       # inform/3 is unique in that headers comes in as a keyword list
       headers = Enum.map(headers, fn {header, value} -> {to_string(header), value} end)
       {:ok, adapter |> send_headers(status, headers, :inform) |> advance_usage_counter()}
@@ -286,6 +288,8 @@ defmodule Bandit.Adapter do
       else
         headers
       end
+
+    headers = maybe_close_for_unhonored_expect(headers, adapter, status)
 
     adapter = %{adapter | status: status}
 
@@ -314,6 +318,20 @@ defmodule Bandit.Adapter do
         else: metrics
 
     %{adapter | transport: socket, metrics: metrics}
+  end
+
+  # Per RFC9110§10.1.1, a client that asked for a 100 Continue and never got one may never
+  # send the request body, so close rather than trying to drain a body that may never arrive.
+  # HTTP/1.1 only: an HTTP/2 stream's ensure_completed already handles an unread body without
+  # draining
+  defp maybe_close_for_unhonored_expect(headers, adapter, status) do
+    if adapter.expect_continue and status not in 100..199 and
+         get_http_protocol(adapter) == :"HTTP/1.1" and
+         is_nil(Bandit.Headers.get_header(headers, "connection")) do
+      [{"connection", "close"} | headers]
+    else
+      headers
+    end
   end
 
   defp send_resp_body?(%{method: "HEAD"}), do: false

--- a/test/bandit/http1/protocol_test.exs
+++ b/test/bandit/http1/protocol_test.exs
@@ -3138,5 +3138,28 @@ defmodule HTTP1ProtocolTest do
     def echo_method(conn) do
       send_resp(conn, 200, conn.method)
     end
+
+    test "closes without draining when a plug responds to expect: 100-continue without reading the body",
+         context do
+      client = SimpleHTTP1Client.tcp_client(context)
+
+      SimpleHTTP1Client.send(client, "POST", "/expect_continue_reject", [
+        "host: localhost",
+        "expect: 100-continue",
+        "content-length: 5"
+      ])
+
+      assert {:ok, "401 Unauthorized", headers, "denied"} = SimpleHTTP1Client.recv_reply(client)
+      assert Keyword.get_values(headers, :connection) == ["close"]
+      assert SimpleHTTP1Client.connection_closed_for_reading?(client)
+
+      # The request completed cleanly rather than erroring out in a drain timeout
+      assert_receive {:telemetry, [:bandit, :request, :stop], _, metadata}, 500
+      refute Map.has_key?(metadata, :error)
+    end
+
+    def expect_continue_reject(conn) do
+      send_resp(conn, 401, "denied")
+    end
   end
 end


### PR DESCRIPTION
## What happens today

A client sends `Expect: 100-continue` and waits for the 100 before sending the
body. If the plug responds without ever reading the body (a 401, say), Bandit
never sends the 100, but after the response it still tries to drain the
request body to keep the connection alive. So the client is waiting on a 100
that will never come, and Bandit is waiting on a body that may never arrive.
The connection hangs until `read_timeout`, and a request whose response was
already delivered ends in a read-timeout error and an error log.

[RFC9110§10.1.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.1) addresses exactly this case:

> A server that responds with a final status code before reading the entire
> request content SHOULD indicate whether it intends to close the connection
> (e.g., see Section 9.6 of [HTTP/1.1]) or continue reading the request
> content.

## The change

When a final response is sent on HTTP/1.1 with the 100-continue expectation
still pending (and the plug didn't set its own `connection` header), add
`connection: close`. The existing keepalive handling does the rest: it signals
the close on the wire and skips the body drain.

An explicit `inform(conn, 100, ...)` now also clears the pending expectation,
since it unblocks the client the same way the implicit 100 does.

HTTP/2 needs no change: its `ensure_completed` already handles an unread body
without draining (RST_STREAM with NO_ERROR).

## Test

POST with `expect: 100-continue` and a `content-length` but no body; the plug
401s without reading. Asserts the response carries `connection: close`, the
connection closes, and the request's telemetry stop event has no error.
Before the fix:

```
Assertion with == failed
code:  assert Keyword.get_values(headers, :connection) == ["close"]
left:  []
right: ["close"]
```